### PR TITLE
Updates to page names and button text

### DIFF
--- a/app/views/applications.html
+++ b/app/views/applications.html
@@ -7,7 +7,7 @@
 <div class="applications-header">
   
   {{ govukButton({
-    text: "Add a record",
+    text: "Add a trainee",
     href: "./new-record/new"
   }) }}
   

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -12,8 +12,8 @@
 
     <div class="govuk-form-group">
       {{ govukButton({
-        text: "All records",
-        href: "/records.html",
+        text: "All applications",
+        href: "/applications.html",
         isStartButton: false
       }) }}
     </div>


### PR DESCRIPTION
We now refer to 'Records' as 'Applications' in url path and adding a 'record' becomes 'trainee' in public facing UI like buttons.