### PR TITLE
Update subjects used for assessment only with itt list from Dan

### DIFF
--- a/app/data/itt-subjects.js
+++ b/app/data/itt-subjects.js
@@ -1,0 +1,520 @@
+// From https://api2.publish-teacher-training-courses.service.gov.uk/api/v3/subjects?sort=subject_name
+
+module.exports = [
+{
+  id: "8",
+  type: "subjects",
+  attributes: {
+    subject_name: "Art and design",
+    subject_code: "W1",
+    bursary_amount: "9000",
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: false
+  }
+},
+{
+  id: "10",
+  type: "subjects",
+  attributes: {
+    subject_name: "Biology",
+    subject_code: "C1",
+    bursary_amount: "26000",
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "11",
+  type: "subjects",
+  attributes: {
+    subject_name: "Business studies",
+    subject_code: "08",
+    bursary_amount: "9000",
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: false
+  }
+},
+{
+  id: "12",
+  type: "subjects",
+  attributes: {
+    subject_name: "Chemistry",
+    subject_code: "F1",
+    bursary_amount: "26000",
+    early_career_payments: "2000",
+    scholarship: "28000",
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "13",
+  type: "subjects",
+  attributes: {
+    subject_name: "Citizenship",
+    subject_code: "09",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "14",
+  type: "subjects",
+  attributes: {
+    subject_name: "Classics",
+    subject_code: "Q8",
+    bursary_amount: "26000",
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: false
+  }
+},
+{
+  id: "15",
+  type: "subjects",
+  attributes: {
+    subject_name: "Communication and media studies",
+    subject_code: "P3",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "16",
+  type: "subjects",
+  attributes: {
+    subject_name: "Computing",
+    subject_code: "11",
+    bursary_amount: "26000",
+    early_career_payments: null,
+    scholarship: "28000",
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "17",
+  type: "subjects",
+  attributes: {
+    subject_name: "Dance",
+    subject_code: "12",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "18",
+  type: "subjects",
+  attributes: {
+    subject_name: "Design and technology",
+    subject_code: "DT",
+    bursary_amount: "15000",
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "19",
+  type: "subjects",
+  attributes: {
+    subject_name: "Drama",
+    subject_code: "13",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "20",
+  type: "subjects",
+  attributes: {
+    subject_name: "Economics",
+    subject_code: "L1",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "21",
+  type: "subjects",
+  attributes: {
+    subject_name: "English",
+    subject_code: "Q3",
+    bursary_amount: "12000",
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "35",
+  type: "subjects",
+  attributes: {
+    subject_name: "English as a second or other language",
+    subject_code: "16",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "34",
+  type: "subjects",
+  attributes: {
+    subject_name: "French",
+    subject_code: "15",
+    bursary_amount: "26000",
+    early_career_payments: "2000",
+    scholarship: "28000",
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "43",
+  type: "subjects",
+  attributes: {
+    subject_name: "Further education",
+    subject_code: "41",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "22",
+  type: "subjects",
+  attributes: {
+    subject_name: "Geography",
+    subject_code: "F8",
+    bursary_amount: "15000",
+    early_career_payments: null,
+    scholarship: "17000",
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "36",
+  type: "subjects",
+  attributes: {
+    subject_name: "German",
+    subject_code: "17",
+    bursary_amount: "26000",
+    early_career_payments: "2000",
+    scholarship: "28000",
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "23",
+  type: "subjects",
+  attributes: {
+    subject_name: "Health and social care",
+    subject_code: "L5",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "24",
+  type: "subjects",
+  attributes: {
+    subject_name: "History",
+    subject_code: "V1",
+    bursary_amount: "9000",
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: false
+  }
+},
+{
+  id: "37",
+  type: "subjects",
+  attributes: {
+    subject_name: "Italian",
+    subject_code: "18",
+    bursary_amount: "26000",
+    early_career_payments: "2000",
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "38",
+  type: "subjects",
+  attributes: {
+    subject_name: "Japanese",
+    subject_code: "19",
+    bursary_amount: "26000",
+    early_career_payments: "2000",
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "39",
+  type: "subjects",
+  attributes: {
+    subject_name: "Mandarin",
+    subject_code: "20",
+    bursary_amount: "26000",
+    early_career_payments: "2000",
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "25",
+  type: "subjects",
+  attributes: {
+    subject_name: "Mathematics",
+    subject_code: "G1",
+    bursary_amount: "26000",
+    early_career_payments: "2000",
+    scholarship: "28000",
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "33",
+  type: "subjects",
+  attributes: {
+    subject_name: "Modern Languages",
+    subject_code: null,
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "42",
+  type: "subjects",
+  attributes: {
+    subject_name: "Modern languages (other)",
+    subject_code: "24",
+    bursary_amount: "26000",
+    early_career_payments: "2000",
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "26",
+  type: "subjects",
+  attributes: {
+    subject_name: "Music",
+    subject_code: "W3",
+    bursary_amount: "9000",
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: false
+  }
+},
+{
+  id: "27",
+  type: "subjects",
+  attributes: {
+    subject_name: "Philosophy",
+    subject_code: "P1",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "28",
+  type: "subjects",
+  attributes: {
+    subject_name: "Physical education",
+    subject_code: "C6",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "29",
+  type: "subjects",
+  attributes: {
+    subject_name: "Physics",
+    subject_code: "F3",
+    bursary_amount: "26000",
+    early_career_payments: "2000",
+    scholarship: "28000",
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "1",
+  type: "subjects",
+  attributes: {
+    subject_name: "Primary",
+    subject_code: "00",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "2",
+  type: "subjects",
+  attributes: {
+    subject_name: "Primary with English",
+    subject_code: "01",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "3",
+  type: "subjects",
+  attributes: {
+    subject_name: "Primary with geography and history",
+    subject_code: "02",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "4",
+  type: "subjects",
+  attributes: {
+    subject_name: "Primary with mathematics",
+    subject_code: "03",
+    bursary_amount: "6000",
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "5",
+  type: "subjects",
+  attributes: {
+    subject_name: "Primary with modern languages",
+    subject_code: "04",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "6",
+  type: "subjects",
+  attributes: {
+    subject_name: "Primary with physical education",
+    subject_code: "06",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "7",
+  type: "subjects",
+  attributes: {
+    subject_name: "Primary with science",
+    subject_code: "07",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "30",
+  type: "subjects",
+  attributes: {
+    subject_name: "Psychology",
+    subject_code: "C8",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "31",
+  type: "subjects",
+  attributes: {
+    subject_name: "Religious education",
+    subject_code: "V6",
+    bursary_amount: "9000",
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "40",
+  type: "subjects",
+  attributes: {
+    subject_name: "Russian",
+    subject_code: "21",
+    bursary_amount: "26000",
+    early_career_payments: "2000",
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: true
+  }
+},
+{
+  id: "9",
+  type: "subjects",
+  attributes: {
+    subject_name: "Science",
+    subject_code: "F0",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "32",
+  type: "subjects",
+  attributes: {
+    subject_name: "Social sciences",
+    subject_code: "14",
+    bursary_amount: null,
+    early_career_payments: null,
+    scholarship: null,
+    subject_knowledge_enhancement_course_available: null
+  }
+},
+{
+  id: "41",
+  type: "subjects",
+  attributes: {
+    subject_name: "Spanish",
+    subject_code: "22",
+    bursary_amount: "26000",
+    early_career_payments: "2000",
+    scholarship: "28000",
+    subject_knowledge_enhancement_course_available: true
+  }
+}
+]

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -10,6 +10,8 @@ let degreeOrganisations = degreeData.orgs
 let countries = require('./countries')
 let awards = require('./awards')
 
+let ittSubjects = require('./itt-subjects').map( subject => subject.attributes.subject_name )
+
 
 module.exports = {
   assessmentOnlyAgeRanges,
@@ -20,7 +22,8 @@ module.exports = {
   degreeOrganisations,
   degreeTypes,
   countries,
-  awards
+  awards,
+  ittSubjects
   // Insert values here
 
 }

--- a/app/views/_includes/forms/assessment-details.html
+++ b/app/views/_includes/forms/assessment-details.html
@@ -1,5 +1,7 @@
 <h1 class="govuk-heading-l">{{pageHeading}}</h1>
 
+{{data.ittSubjects | log}}
+
 {{ appAutocomplete({
   label: {
     text: "Subject",
@@ -10,7 +12,7 @@
   },
   id: 'subject',
   name: "record[assessmentDetails][subject]",
-  items: data.subjects,
+  items: data.ittSubjects,
   value: record.assessmentDetails.subject
   }
 ) }}


### PR DESCRIPTION
We were previously using the same list for degree subjects as assessment only subjects. This updates with a list provided by @dankmitchell 