### PR TITLE
QTS recommended page

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -499,7 +499,7 @@ router.get('/record/:uuid/timeline', (req, res) => {
 })
 
 // Copy qts data back to real record
-router.post('/record/:uuid/qts/qts-recommended', (req, res) => {
+router.post('/record/:uuid/qts/update', (req, res) => {
   const data = req.session.data
   const newRecord = data.record
   // Update failed or no data
@@ -511,8 +511,8 @@ router.post('/record/:uuid/qts/qts-recommended', (req, res) => {
     newRecord.qtsRecommendedDate = new Date()
     deleteTempData(data)
     updateRecord(data, newRecord, "Trainee recommended for QTS")
-    req.flash('success', 'Trainee recommended for QTS')
-    res.redirect('/record/' + req.params.uuid)
+    // req.flash('success', 'Trainee recommended for QTS')
+    res.redirect(`/record/${req.params.uuid}/qts/recommended`)
   }
 })
 

--- a/app/views/record/qts/confirm.html
+++ b/app/views/record/qts/confirm.html
@@ -2,11 +2,11 @@
 {% set pageHeadingTraineeName = data.record.personalDetails.shortName %}
 {% set pageHeading = "Check assessment details" %}
 
-{% set formAction = "./qts-recommended" %}
+{% set formAction = "./update" %}
 
 {% block formContent %}
   <h1 class="govuk-heading-l">
-    <span class="govuk-caption-xl">{{pageHeadingTraineeName}}</span>
+    <span class="govuk-caption-l">{{pageHeadingTraineeName}}</span>
     {{pageHeading}}
   </h1>
   {% include "_includes/summary-cards/qts-assessment-details.html" %}

--- a/app/views/record/qts/recommended.html
+++ b/app/views/record/qts/recommended.html
@@ -17,23 +17,19 @@
   classes: "govuk-!-margin-bottom-6"
 }) }}
 
-<p class="govuk-body">It usually takes 2 to 3 working days to issue a TRN and update the trainee record in Register trainee teachers.</p>
+<p class="govuk-body">QTS is usually awarded overnight. It could take 2 to 3 working days in some cases.</p>
 
 <p class="govuk-body">
-  We do not notify the trainee when we issue a TRN. If you think there is a problem with the TRN, contact <a href="mailto:itt.datamanagement@education.gov.uk">itt.datamanagement@education.gov.uk</a>.
+  If you think there is a problem with the QTS award, contact <a href="mailto:itt.datamanagement@education.gov.uk">itt.datamanagement@education.gov.uk</a>.
 </p>
 
 <h2 class="govuk-heading-m">Next steps:</h2>
-<p class="govuk-body">You can recommend the trainee for QTS once their record is marked ‘TRN received’ and they have met the requirements.</p>
 <ul class="govuk-list govuk-list--bullet">
   <li>
     <a href="{{ recordPath }}" class="govuk-link">View this trainee’s record</a>
   </li>
   <li>
     <a href="/records" class="govuk-link">View your trainee records list</a>
-  </li>
-  <li>
-    <a href="/new-record/new" class="govuk-link">Add another trainee</a>
   </li>
 </ul>
 
@@ -49,4 +45,3 @@
  #}
 
 {% endblock %}
-

--- a/app/views/record/qts/recommended.html
+++ b/app/views/record/qts/recommended.html
@@ -1,0 +1,52 @@
+{% extends "_templates/_record-form.html" %}
+
+{% set pageHeading = "Trainee recommended for QTS" %}
+
+{# {% set formAction = "./save" %} #}
+
+{# {% set hideReturnLink = true %} #}
+{% set backLink = "/record/" + data.record.id %}
+{% set backText = 'Back to trainee' %}
+
+
+{% block formContent %}
+
+{{ govukPanel({
+  titleText: pageHeading,
+  html: "Your reference number<br><strong>HDJ2123F</strong>" if false,
+  classes: "govuk-!-margin-bottom-6"
+}) }}
+
+<p class="govuk-body">It usually takes 2 to 3 working days to issue a TRN and update the trainee record in Register trainee teachers.</p>
+
+<p class="govuk-body">
+  We do not notify the trainee when we issue a TRN. If you think there is a problem with the TRN, contact <a href="mailto:itt.datamanagement@education.gov.uk">itt.datamanagement@education.gov.uk</a>.
+</p>
+
+<h2 class="govuk-heading-m">Next steps:</h2>
+<p class="govuk-body">You can recommend the trainee for QTS once their record is marked ‘TRN received’ and they have met the requirements.</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    <a href="{{ recordPath }}" class="govuk-link">View this trainee’s record</a>
+  </li>
+  <li>
+    <a href="/records" class="govuk-link">View your trainee records list</a>
+  </li>
+  <li>
+    <a href="/new-record/new" class="govuk-link">Add another trainee</a>
+  </li>
+</ul>
+
+{# {{ govukButton({
+  text: "View record",
+  href: "/record/" + data.recordId
+}) }}
+
+{{ govukButton({
+  text: "Add another record",
+  href: "/new-record/new"
+}) }}
+ #}
+
+{% endblock %}
+

--- a/app/views/record/qts/recommended.html
+++ b/app/views/record/qts/recommended.html
@@ -4,9 +4,9 @@
 
 {# {% set formAction = "./save" %} #}
 
-{# {% set hideReturnLink = true %} #}
+{% set hideReturnLink = true %}
 {% set backLink = "/record/" + data.record.id %}
-{% set backText = 'Back to trainee' %}
+{% set backText = 'Return to trainee' %}
 
 
 {% block formContent %}


### PR DESCRIPTION
Create the content for the QTS recommended page:

- Set timescales for the QTS recommendation

- contact details for problems

- Next steps links - view this trainee record, view all trainee records