### PR TITLE
Typo on confirm contact details

### DIFF
--- a/app/views/new-record/contact-details/confirm.html
+++ b/app/views/new-record/contact-details/confirm.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_new-record.html" %}
 
-{% set pageHeading = "Confirm personal details" %}
+{% set pageHeading = "Confirm contact details" %}
 {% set backLink = './../overview' %}
 {% set backText = "Back to overview" %}
 
@@ -27,4 +27,3 @@
   }) }}
 
 {% endblock %}
-

--- a/app/views/record/contact-details/confirm.html
+++ b/app/views/record/contact-details/confirm.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_record-form.html" %}
 
-{% set pageHeading = "Confirm personal details" %}
+{% set pageHeading = "Confirm contact details" %}
 
 {% set formAction = "./update" %}
 
@@ -25,4 +25,3 @@
   }) }}
 
 {% endblock %}
-


### PR DESCRIPTION
Change 'personal' to 'contact' on both 'new trainee' and 'edit trainee' confirm contact details pages