### PR TITLE
Add conditionals for ethnicity and disabilities

### DIFF
--- a/app/views/_includes/forms/ethnic-background.html
+++ b/app/views/_includes/forms/ethnic-background.html
@@ -1,50 +1,50 @@
 
 {% set ethnicGroup = record.diversity.ethnicGroup %}
 
-{# {% set asianOtherHtml %}
+{% set asianOtherHtml %}
   {{ govukInput({
     classes: "govuk-!-width-two-thirds",
     label: {
-      text: "Your Asian background (optional)"
+      text: "Describe their Asian background (optional)"
     }
-  } | decorateApplicationAttributes(["equality-monitoring", "ethnic-background-other"])) }}
+  } | decorateAttributes(record, "record.diversity.ethnicBackgroundOther"))}}
 {% endset -%}
 
 {% set blackOtherHtml %}
   {{ govukInput({
     classes: "govuk-!-width-two-thirds",
     label: {
-      text: "Your Black background (optional)"
+      text: "Describe their Black background (optional)"
     }
-  } | decorateApplicationAttributes(["equality-monitoring", "ethnic-background-other"])) }}
+  } | decorateAttributes(record, "record.diversity.ethnicBackgroundOther"))}}
 {% endset -%}
 
 {% set mixedOtherHtml %}
   {{ govukInput({
     classes: "govuk-!-width-two-thirds",
     label: {
-      text: "Your Mixed background (optional)"
+      text: "Describe their Mixed background (optional)"
     }
-  } | decorateApplicationAttributes(["equality-monitoring", "ethnic-background-other"])) }}
+  } | decorateAttributes(record, "record.diversity.ethnicBackgroundOther"))}}
 {% endset -%}
 
 {% set whiteOtherHtml %}
   {{ govukInput({
     classes: "govuk-!-width-two-thirds",
     label: {
-      text: "Your White background (optional)"
+      text: "Describe their White background (optional)"
     }
-  } | decorateApplicationAttributes(["equality-monitoring", "ethnic-background-other"])) }}
+  } | decorateAttributes(record, "record.diversity.ethnicBackgroundOther"))}}
 {% endset -%}
 
 {% set otherOtherHtml %}
   {{ govukInput({
     classes: "govuk-!-width-two-thirds",
     label: {
-      text: "Describe your ethnic background (optional)"
+      text: "Describe their ethnic background (optional)"
     }
-  } | decorateApplicationAttributes(["equality-monitoring", "ethnic-background-other"])) }}
-{% endset -%} #}
+  } | decorateAttributes(record, "record.diversity.ethnicBackgroundOther"))}}
+{% endset -%}
 
 {% if ethnicGroup == "Asian or Asian British" %}
 

--- a/app/views/_includes/forms/trainee-disabilities.html
+++ b/app/views/_includes/forms/trainee-disabilities.html
@@ -1,3 +1,12 @@
+{% set otherDisabilityHtml %}
+  {{ govukInput({
+    classes: "govuk-!-width-two-thirds",
+    label: {
+      text: "Describe their disability (optional)"
+    }
+  } | decorateAttributes(record, "record.diversity.disabilitiesOther"))}}
+{% endset -%}
+
 {{ govukCheckboxes({
     idPrefix: "disabilities",
     name: "record[diversity][disabilities]",

--- a/app/views/_includes/summary-cards/diversity.html
+++ b/app/views/_includes/summary-cards/diversity.html
@@ -27,15 +27,15 @@
 {% set ethnicBackgroundOther = record.diversity.ethnicBackgroundOther %}
 
 {# Use freetext ethnic background if provided #}
-{% if "Another" in ethnicBackground %}
+{% if ethnicBackground and "Another" in ethnicBackground %}
   {% set ethnicBackground = ethnicBackgroundOther or ethnicBackground %}
 {% endif %}
 
 {# Combine ethnic group and ethnic background #}
 {% set ethnicity %}
   {{ethnicGroup}}
-  {% if ethnicBackground != 'Not provided' %}
-    ({{ethnicBackground}})
+  {% if ethnicBackground and ethnicBackground != 'Not provided' %}
+    ({{ethnicBackground | replace('Another', 'another')}})
   {% endif %}
 {% endset %}
 
@@ -85,7 +85,7 @@
 
 {% set disabilities = record.diversity.disabilities | joinify | lower | sentenceCase %}
 
-{% if 'other' in disabilities and record.diversity.disabilitiesOther%}
+{% if disabilities and 'other' in (disabilities | lower) and record.diversity.disabilitiesOther%}
   {% set disabilities %}
     {{disabilities}} ({{record.diversity.disabilitiesOther}})
   {% endset %}

--- a/app/views/_includes/summary-cards/diversity.html
+++ b/app/views/_includes/summary-cards/diversity.html
@@ -24,20 +24,27 @@
 
 {% set ethnicGroup = record.diversity.ethnicGroup %}
 {% set ethnicBackground = record.diversity.ethnicBackground %}
+{% set ethnicBackgroundOther = record.diversity.ethnicBackgroundOther %}
 
-{% if ethnicBackground and ethnicGroup != 'Not provided' and ethnicBackground != 'Not provided' %}
-  {% set ethnicGroup %}
-  {{ethnicGroup}}
-  ({{ethnicBackground}})
-  {% endset %}
+{# Use freetext ethnic background if provided #}
+{% if "Another" in ethnicBackground %}
+  {% set ethnicBackground = ethnicBackgroundOther or ethnicBackground %}
 {% endif %}
+
+{# Combine ethnic group and ethnic background #}
+{% set ethnicity %}
+  {{ethnicGroup}}
+  {% if ethnicBackground != 'Not provided' %}
+    ({{ethnicBackground}})
+  {% endif %}
+{% endset %}
 
 {% set ethnicGroupRow = {
   key: {
-    text: "Ethnic group"
+    text: "Ethnicity"
   },
   value: {
-    text: ethnicGroup
+    text: ethnicity or 'Not provided'
   },
   actions: {
     items: [
@@ -53,30 +60,6 @@
 {% if diversityInformationDisclosed and ethnicGroup %}
   {% set diversityRows = diversityRows | push(ethnicGroupRow) %}
 {% endif %}
-
-
-
-{# {% set ethnicBackgroundRow = {
-  key: {
-    text: "Ethnic group background"
-  },
-  value: {
-    text: ethnicBackground
-  },
-  actions: {
-    items: [
-      {
-        href: recordPath + "/ethnic-background" | addReferrer(referrer),
-        text: "Change",
-        visuallyHiddenText: "ethnic group background"
-      }
-    ]
-  }
-} %}
-
-{% if diversityInformationDisclosed and ethnicBackground %}
-  {% set diversityRows = diversityRows | push(ethnicBackgroundRow) %}
-{% endif %} #}
 
 {% set disabilitiesAnswerRow = {
     key: {
@@ -100,12 +83,20 @@
   {% set diversityRows = diversityRows | push(disabilitiesAnswerRow) %}
 {% endif %}
 
+{% set disabilities = record.diversity.disabilities | joinify | lower | sentenceCase %}
+
+{% if 'other' in disabilities and record.diversity.disabilitiesOther%}
+  {% set disabilities %}
+    {{disabilities}} ({{record.diversity.disabilitiesOther}})
+  {% endset %}
+{% endif %}
+
 {% set disabilitiesRow = {
     key: {
       text: "Disabilities"
     },
     value: {
-      text: record.diversity.disabilities | joinify | lower | sentenceCase or "Not provided"
+      text: disabilities or "Not provided"
     },
     actions: {
       items: [


### PR DESCRIPTION
The two diversity sections should both support users being able to answer 'other' and provide a freetext response. I didn't have time to build this originally, so adding now. These mostly follow the patterns from Apply but with some text tweaks to refer to `their` rather than `your`.

## Ethnic background

Optionally collecting another ethnic background:
<img width="872" alt="Screenshot 2020-10-16 at 11 44 35" src="https://user-images.githubusercontent.com/2204224/96249373-01412880-0fa5-11eb-9e75-1ff5257472d9.png">

Optionally displaying the ethnic background:
<img width="756" alt="Screenshot 2020-10-16 at 11 44 42" src="https://user-images.githubusercontent.com/2204224/96249416-1027db00-0fa5-11eb-991f-d45ee03e95b3.png">

## Disabilities

Optionally collecting a different disability:
<img width="823" alt="Screenshot 2020-10-16 at 11 46 16" src="https://user-images.githubusercontent.com/2204224/96249644-6a28a080-0fa5-11eb-811c-96cfcf7bf9f6.png">

Optionally displaying the disability:
<img width="704" alt="Screenshot 2020-10-16 at 11 47 08" src="https://user-images.githubusercontent.com/2204224/96249653-6f85eb00-0fa5-11eb-936f-2cc6f2a3eba6.png">
