### PR TITLE
Content changes to post submission pages

### DIFF
--- a/app/views/new-record/submitted.html
+++ b/app/views/new-record/submitted.html
@@ -5,10 +5,16 @@
 {# {% set formAction = "./save" %} #}
 
 {% set hideReturnLink = true %}
-{% set backLink = 'false' %}
+{% set backLink = '/records' %}
+{% set backText = 'All records' %}
+
 
 
 {% block formContent %}
+
+{# For this one page, we no longer have record in session data, so have to look it up #}
+{% set recordArray = data.records | where("route", data.recordId) %}
+{% set record = recordArray[0] %}
 
 {{ govukPanel({
   titleText: "Trainee submitted for TRN",
@@ -20,14 +26,11 @@
 
 <p class="govuk-body">When the TRN is received, the trainee record status will be automatically updated. You can <a href="/records" class="govuk-link">check trainee statuses from your list of records</a>.</p>
 
-<p class="govuk-body">You can recommend the trainee for QTS once their TRN is received and they’ve met the requirements.</p>
+{% if record.route == "Assessment Only" %}
+  <p class="govuk-body">You can recommend the trainee for QTS once their TRN is received and they’ve met the requirements.</p>
+{% endif %}
 
 <p class="govuk-body">Would you like to <a href="/new-record/new" class="govuk-link">add another trainee</a>?</p>
-
-
-
-  </li>
-</ul>
 
 {# {{ govukButton({
   text: "View record",

--- a/app/views/new-record/submitted.html
+++ b/app/views/new-record/submitted.html
@@ -16,25 +16,16 @@
   classes: "govuk-!-margin-bottom-6"
 }) }}
 
-<p class="govuk-body">It usually takes 2 to 3 working days to issue a TRN and update the trainee record in Register trainee teachers.</p>
+<p class="govuk-body">The Department for Education will issue the TRN within 3 working days.</p>
 
-<p class="govuk-body">
-  We do not notify the trainee when we issue a TRN. If you think there is a problem with the TRN, contact <a href="mailto:itt.datamanagement@education.gov.uk">itt.datamanagement@education.gov.uk</a>.
-</p>
+<p class="govuk-body">When the TRN is received, the trainee record status will be automatically updated. You can <a href="/records" class="govuk-link">check trainee statuses from your list of records</a>.</p>
+
+<p class="govuk-body">You can recommend the trainee for QTS once their TRN is received and they’ve met the requirements.</p>
+
+<p class="govuk-body">Would you like to <a href="/new-record/new" class="govuk-link">add another trainee</a>?</p>
 
 
 
-<h2 class="govuk-heading-m">Next steps:</h2>
-<p class="govuk-body">You can recommend the trainee for QTS once their record is marked ‘TRN received’ and they have met the requirements.</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>
-    <a href="{{ '/record/' + data.recordId }}" class="govuk-link">View this trainee’s record</a>
-  </li>
-  <li>
-    <a href="/records" class="govuk-link">View your trainee records list</a>
-  </li>
-  <li>
-    <a href="/new-record/new" class="govuk-link">Add another trainee</a>
   </li>
 </ul>
 
@@ -50,4 +41,3 @@
  #}
 
 {% endblock %}
-

--- a/app/views/record/qts/recommended.html
+++ b/app/views/record/qts/recommended.html
@@ -17,21 +17,9 @@
   classes: "govuk-!-margin-bottom-6"
 }) }}
 
-<p class="govuk-body">QTS is usually awarded overnight. It could take 2 to 3 working days in some cases.</p>
+<p class="govuk-body">The Department for Education will award QTS where appropriate within 3 working days.</p>
 
-<p class="govuk-body">
-  If you think there is a problem with the QTS award, contact <a href="mailto:itt.datamanagement@education.gov.uk">itt.datamanagement@education.gov.uk</a>.
-</p>
-
-<h2 class="govuk-heading-m">Next steps:</h2>
-<ul class="govuk-list govuk-list--bullet">
-  <li>
-    <a href="{{ recordPath }}" class="govuk-link">View this trainee’s record</a>
-  </li>
-  <li>
-    <a href="/records" class="govuk-link">View your trainee records list</a>
-  </li>
-</ul>
+<p class="govuk-body">When the QTS is awarded, the trainee record status will be automatically updated. You can <a href="/records" class="govuk-link">check trainee statuses from your list of records</a>.</p>
 
 {# {{ govukButton({
   text: "View record",


### PR DESCRIPTION
be clearer on what happens next, who does what, what the user can do, and use active language

(in user research, a couple of providers used the word 'assume' regarding what they should do next)

remove messages about what to do if something goes wrong

(it's a negative message too early in a journey, on an page that's not easy to access once you've left it)

remove some of the links 

(we don't know which ones are really valuable yet, and everything can be accessed via the records list)

remove caps from bullets and colon after heading 

(gov style)

new content: 

![Screenshot 2020-10-21 at 18 05 39](https://user-images.githubusercontent.com/56349171/96753616-0993cc00-13c8-11eb-9719-fdcff6815366.png)

![Screenshot 2020-10-21 at 18 06 25](https://user-images.githubusercontent.com/56349171/96753704-24664080-13c8-11eb-854c-ea56cdb92a53.png)



