### PR TITLE
Remove option to still be studying for a degree

### DIFF
--- a/app/views/_includes/forms/degree-details.html
+++ b/app/views/_includes/forms/degree-details.html
@@ -245,18 +245,21 @@
         conditional: {
           html: degreeGradeOtherHtml
         }
-      },
-      {
-        divider: "or"
-      },
-      {
-        text: "The trainee is still studying for their degree"
       }
     ]
   } | decorateAttributes(degreeTemp, "degreeTemp.grade")) }}
 
 {% endif %}
 
+{# 
+,
+      {
+        divider: "or"
+      },
+      {
+        text: "The trainee is still studying for their degree"
+      }
+ #}
 
 {{ govukButton({
   text: "Continue"


### PR DESCRIPTION
Removes the option to say the trainee is still studying for their course.

This was originally copied from apply, where applicants may still be studying. But by the time they come to be registered, they're expected to have their degrees.

Before:
<img width="682" alt="Screenshot 2020-10-22 at 13 22 24" src="https://user-images.githubusercontent.com/2204224/96871050-a35f8580-1469-11eb-857a-213163aac7f4.png">

After:
<img width="1149" alt="Screenshot 2020-10-22 at 13 21 59" src="https://user-images.githubusercontent.com/2204224/96871021-9b074a80-1469-11eb-9d2c-3c0cd80c6bf8.png">
