### PR TITLE
remove content about hesa and registering trainees

### DIFF
--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -62,15 +62,9 @@
       <li>recommend your trainees for qualified teacher status (QTS) or early years teacher status (EYTS)</li>
     </ul>
 
-    <h2 class="govuk-heading-s">If you’re a higher education institution (HEI)</h2>
-
-    <p class="govuk-body">Use this service, instead of the Higher Education Statistics Agency (HESA), to register your trainees.</p>
-
     <h2 class="govuk-heading-s">When to register your trainees</h2>
 
     <p class="govuk-body">Register your trainees when they start their programme.</p>
-
-    <p class="govuk-body">If you need to register a trainee who started in a previous academic year, get in touch with the data management team at the Department for Education at <a class="govuk-link" href="mailto:itt.datamanagement@education.gov.uk">itt.datamanagement@education.gov.uk</a>.</p>
 
   </div>
 </div>


### PR DESCRIPTION
Why the change?

- we can't promote using Register instead of using HESA (at least for now)

- some of the content about registering trainees from a previous year was not clear and contradicted with the sentence above about registering trainees when they start a programme 

**Before:**

![Screenshot 2020-10-22 at 16 05 24](https://user-images.githubusercontent.com/56349171/96891275-6a7edb00-1480-11eb-93d8-10f68e1d29dc.png)
 
**After:**

![Screenshot 2020-10-22 at 16 02 35](https://user-images.githubusercontent.com/56349171/96890879-01976300-1480-11eb-98ad-c4400b1ce04e.png)
