### PR TITLE
Minor UI updates to Home and Records list

### DIFF
--- a/app/assets/sass/components/_status-card.scss
+++ b/app/assets/sass/components/_status-card.scss
@@ -17,6 +17,11 @@
   background: govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90);
 }
 
+.status-card--qts-recommended {
+  color: govuk-shade(govuk-colour("purple"), 20);
+  background: govuk-tint(govuk-colour("purple"), 80);
+}
+
 .status-card--qts-awarded {
   color:  #fff;
   background: $govuk-brand-colour;

--- a/app/assets/sass/overrides/_moj-filter.scss
+++ b/app/assets/sass/overrides/_moj-filter.scss
@@ -1,6 +1,7 @@
 // Moj Filter panel overrides
 
 .moj-filter-layout__filter {
+  box-shadow: none;
   max-width: 300px;
 }
 

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -55,7 +55,7 @@
         <div class="status-card status-card--trn-received">
           {% set trnReceivedRecordCount = records | where("status", "TRN received") | length %}
           <span class="status-card__count">{{trnReceivedRecordCount}}</span>
-          TRN receieved
+          TRN received
         </div>
       </div>
 
@@ -63,21 +63,28 @@
 
     <div class="govuk-grid-row govuk-!-margin-bottom-6">
         
-      <div class="govuk-grid-column-one-third">
+      <div class="govuk-grid-column-one-quarter">
+        <div class="status-card status-card--qts-recommended">
+          {% set qtsRecommendedRecordCount = records | where("status", "QTS recommended") | length %}
+          <span class="status-card__count">{{qtsRecommendedRecordCount}}</span>
+          QTS recommended
+        </div>
+      </div>
+      <div class="govuk-grid-column-one-quarter">
         <div class="status-card status-card--qts-awarded">
-          {% set trnReceivedRecordCount = records | where("status", "QTS awarded") | length %}
-          <span class="status-card__count">{{trnReceivedRecordCount}}</span>
+          {% set qtsAwardedRecordCount = records | where("status", "QTS awarded") | length %}
+          <span class="status-card__count">{{qtsAwardedRecordCount}}</span>
           QTS awarded
         </div>
       </div>
-      <div class="govuk-grid-column-one-third">
+      <div class="govuk-grid-column-one-quarter">
         <div class="status-card status-card--deferred">
           {% set deferredRecordCount = records | where("status", "Deferred") | length %}
           <span class="status-card__count">{{deferredRecordCount}}</span>
           Deferred
         </div>
       </div>
-      <div class="govuk-grid-column-one-third">
+      <div class="govuk-grid-column-one-quarter">
         <div class="status-card status-card--withdrawn">
           {% set withdrawnRecordCount = records | where("status", "Withdrawn") | length %}
           <span class="status-card__count">{{withdrawnRecordCount}}</span>

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -47,6 +47,7 @@
       
         <div class="moj-filter-layout__filter">
           {% include "_includes/filter-panel.njk" %}
+          <p class="govuk-body govuk-!-margin-top-5"><a href="#" class="govuk-link">Export these records</a></p>
         </div>
 
         <div class="moj-filter-layout__content">
@@ -141,7 +142,7 @@
                 classes: 'govuk-!-margin-bottom-3'
               }) }}
             {% endif %}
-          <p class="govuk-body govuk-!-margin-top-5"><a href="#" class="govuk-link">Export these records</a></p>
+          
           {% else %}
             <h2 class="govuk-heading-m">No records found.</h2>
             <p class="govuk-body">Try <a href="/records">clearing your search and filters</a>.</p>


### PR DESCRIPTION
There are 7 statuses, not 6. 😳 I've updated the home page to reflect this and also fixed a spelling mistake.

![Screenshot_2020-10-23 Register for teacher training - GOV UK](https://user-images.githubusercontent.com/1108991/96992461-d82f1380-1521-11eb-8473-26b470b1475d.png)

I moved the export link higher on the records page as per findings fomr last UR and fixed a minor css/display box shadow bug.

![Screenshot_2020-10-23 Trainee teachers - Register trainee teachers - GOV UK](https://user-images.githubusercontent.com/1108991/96992690-26441700-1522-11eb-844f-e435e34c0603.png)