### PR TITLE
Make guidance links configurable, default to off

### DIFF
--- a/app/views/admin.html
+++ b/app/views/admin.html
@@ -21,6 +21,15 @@
         ]
       } | decorateAttributes(data, "data.settings.includeTimeline")) }}
 
+      {{ govukCheckboxes({
+        items: [
+          {
+            value: 'true',
+            text: "Show links to guidance"
+          }
+        ]
+      } | decorateAttributes(data, "data.settings.includeGuidance")) }}
+
       {% set allTrainingRoutes = [] %}
       {% for route in data.allTrainingRoutes %}
         {% set allTrainingRoutes = allTrainingRoutes | push({

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -18,10 +18,12 @@
         <h2 class="govuk-heading-m"><a href="/records" class="govuk-link govuk-link--no-visited-state">Trainee records</a></h2>
         <p class="govuk-body">All the trainee teachers in your organisation.</p>
       </div>
-      <div class="govuk-grid-column-one-third">
-        <h2 class="govuk-heading-m"><a href="/guidance" class="govuk-link govuk-link--no-visited-state">Guidance</a></h2>
-        <p class="govuk-body">Service guidance for each route.</p>
-      </div>
+      {% if data.settings.includeGuidance %}
+        <div class="govuk-grid-column-one-third">
+          <h2 class="govuk-heading-m"><a href="/guidance" class="govuk-link govuk-link--no-visited-state">Guidance</a></h2>
+          <p class="govuk-body">Service guidance for each route.</p>
+        </div>
+      {% endif %}
       <div class="govuk-grid-column-one-third">
         <h2 class="govuk-heading-m"><a href="/data-requirements" class="govuk-link govuk-link--no-visited-state">Data requirements</a></h2>
         <p class="govuk-body">Route specific data requirements.</p>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -102,7 +102,8 @@
     <li>Email: <a class="govuk-link govuk-footer__link" href="mailto:registerateacher@digital.education.gov.uk">registerateacher<wbr>@digital.education.gov.uk</a></li>
     <li>We aim to respond within 5 working days, or one working day for more urgent&nbsp;queries</li>
   </ul>
-  <p class="govuk-body govuk-!-font-size-16"><a href="/guidance" class="govuk-link govuk-footer__link">How to use Register trainee teachers</a></p>
+  {% set guidanceLink = '/guidance' if data.settings.includeGuidance else '#' %}
+  <p class="govuk-body govuk-!-font-size-16"><a href="{{guidanceLink}}" class="govuk-link govuk-footer__link">How to use Register trainee teachers</a></p>
 {% endset %}
 
 {% if useAutoStoreData %}


### PR DESCRIPTION
This removes the links to the guidance page (effectively hiding it) so that we can test how the service does without it. It can be reenabled temporarily by going to settings.