### PR TITLE
add trainee name to post submission page

### DIFF
--- a/app/views/new-record/submitted.html
+++ b/app/views/new-record/submitted.html
@@ -16,8 +16,14 @@
 {% set recordArray = data.records | where("route", data.recordId) %}
 {% set record = recordArray[0] %}
 
+{% set panelTitleText %}
+
+  {{ record.personalDetails.shortName or "Trainee" }}’s record submitted for TRN
+
+{% endset %}
+
 {{ govukPanel({
-  titleText: "Trainee submitted for TRN",
+  titleText: panelTitleText,
   html: "Your reference number<br><strong>HDJ2123F</strong>" if false,
   classes: "govuk-!-margin-bottom-6"
 }) }}


### PR DESCRIPTION
this may help a user remember who they just submitted a record for 

<img width="718" alt="Screenshot 2020-10-26 at 15 08 04" src="https://user-images.githubusercontent.com/56349171/97189933-0ec49280-179d-11eb-8dc7-4ece15d40ac2.png">
