### PR TITLE
Bump node to use latest es6 features

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "9.8.0",
   "private": true,
   "engines": {
-    "node": "^12.0.0"
+    "node": "^14.15.0"
   },
   "scripts": {
     "start": "node start.js",


### PR DESCRIPTION
Pr #99 introduced a bug - it uses optional chaining (`foo?.bar`) which only works in Node 14 and later. This bumps the node version that we use.