### PR TITLE
403, 404, 500 error placeholders pages added

### DIFF
--- a/app/views/403.html
+++ b/app/views/403.html
@@ -6,13 +6,10 @@
 <div class="govuk-grid-row">
 
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">You are not permitted to see this page</h1>
+    <h1 class="govuk-heading-l">You do not have access to this page</h1>
 
     <p class="govuk-body">
-      This page is restricted to certain users only.
-    </p>
-    <p class="govuk-body">
-      Contact the Register trainee teachers team to request access: <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=Page%20not%20found">registerateacher@digital.education.gov.uk</a>
+      If you think you should have access, email the Register trainee teachers team at <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=Page%20not%20found">registerateacher@digital.education.gov.uk</a>.
     </p>
 
   </div>

--- a/app/views/403.html
+++ b/app/views/403.html
@@ -1,0 +1,22 @@
+
+{% extends "layout.html" %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">You are not permitted to see this page</h1>
+
+    <p class="govuk-body">
+      This page is restricted to certain users only.
+    </p>
+    <p class="govuk-body">
+      Contact the Register trainee teachers team to request access: <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=Page%20not%20found">registerateacher@digital.education.gov.uk</a>
+    </p>
+
+  </div>
+
+</div>
+
+{% endblock %}

--- a/app/views/403.html
+++ b/app/views/403.html
@@ -9,7 +9,7 @@
     <h1 class="govuk-heading-l">You do not have access to this page</h1>
 
     <p class="govuk-body">
-      If you think you should have access, email the Register trainee teachers team at <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=Page%20not%20found">registerateacher@digital.education.gov.uk</a>.
+      If you think you should have access, email the Register trainee teachers team at <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=You%20do%20not%20have%20access%20to%20this%20page">registerateacher@digital.education.gov.uk</a>.
     </p>
 
   </div>

--- a/app/views/404.html
+++ b/app/views/404.html
@@ -11,8 +11,9 @@
     <p class="govuk-body">
       Check the web address and try again.
     </p>
+
     <p class="govuk-body">
-      If that does not work and you need to speak to someone, email the Register trainee teachers team at <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=Page%20not%20found">registerateacher@digital.education.gov.uk</a>.
+      If you continue to get this message, email the Register trainee teachers team at <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=Page%20not%20found">registerateacher@digital.education.gov.uk</a>.
     </p>
 
   </div>

--- a/app/views/404.html
+++ b/app/views/404.html
@@ -9,13 +9,10 @@
     <h1 class="govuk-heading-l">Page not found</h1>
 
     <p class="govuk-body">
-      If you typed the web address, check it is correct.
+      Check the web address and try again.
     </p>
     <p class="govuk-body">
-      If you pasted the web address, check you copied the entire address.
-    </p>
-    <p class="govuk-body">
-      If the web address is correct or you selected a link or button and you need to speak to someone about this problem, contact the Register trainee teachers team: <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=Page%20not%20found">registerateacher@digital.education.gov.uk</a>
+      If that does not work and you need to speak to someone, email the Register trainee teachers team at <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=Page%20not%20found">registerateacher@digital.education.gov.uk</a>.
     </p>
 
   </div>

--- a/app/views/404.html
+++ b/app/views/404.html
@@ -1,0 +1,25 @@
+
+{% extends "layout.html" %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Page not found</h1>
+
+    <p class="govuk-body">
+      If you typed the web address, check it is correct.
+    </p>
+    <p class="govuk-body">
+      If you pasted the web address, check you copied the entire address.
+    </p>
+    <p class="govuk-body">
+      If the web address is correct or you selected a link or button and you need to speak to someone about this problem, contact the Register trainee teachers team: <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=Page%20not%20found">registerateacher@digital.education.gov.uk</a>
+    </p>
+
+  </div>
+
+</div>
+
+{% endblock %}

--- a/app/views/500.html
+++ b/app/views/500.html
@@ -1,0 +1,22 @@
+
+{% extends "layout.html" %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
+
+    <p class="govuk-body">
+      Try again later.
+    </p>
+    <p class="govuk-body">
+      If you continue to see this error contact the Register trainee teachers team: <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=Page%20not%20found">registerateacher@digital.education.gov.uk</a>
+    </p>
+
+  </div>
+
+</div>
+
+{% endblock %}

--- a/app/views/500.html
+++ b/app/views/500.html
@@ -13,7 +13,7 @@
     </p>
 
     <p class="govuk-body">
-      If you continue to get this message, email the Register trainee teachers team at <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=Page%20not%20found">registerateacher@digital.education.gov.uk</a>.
+      If you continue to get this message, email the Register trainee teachers team at <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=Sorry%2C%20somethig%20went%20wrong">registerateacher@digital.education.gov.uk</a>.
     </p>
 
   </div>

--- a/app/views/500.html
+++ b/app/views/500.html
@@ -6,13 +6,10 @@
 <div class="govuk-grid-row">
 
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
+    <h1 class="govuk-heading-l">Sorry, something went wrong</h1>
 
     <p class="govuk-body">
-      Try again later.
-    </p>
-    <p class="govuk-body">
-      If you continue to see this error contact the Register trainee teachers team: <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=Page%20not%20found">registerateacher@digital.education.gov.uk</a>
+      Try again later. If you continue to see this message, email the Register trainee teachers team at <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=Page%20not%20found">registerateacher@digital.education.gov.uk</a>.
     </p>
 
   </div>

--- a/app/views/500.html
+++ b/app/views/500.html
@@ -9,7 +9,11 @@
     <h1 class="govuk-heading-l">Sorry, something went wrong</h1>
 
     <p class="govuk-body">
-      Try again later. If you continue to see this message, email the Register trainee teachers team at <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=Page%20not%20found">registerateacher@digital.education.gov.uk</a>.
+      Try again later.
+    </p>
+
+    <p class="govuk-body">
+      If you continue to get this message, email the Register trainee teachers team at <a class="govuk-link" href="mailto:registerateacher@digital.education.gov.uk?subject=Page%20not%20found">registerateacher@digital.education.gov.uk</a>.
     </p>
 
   </div>


### PR DESCRIPTION
Placeholder error pages using Publish content (for now) added.

## 403

![Screenshot_2020-11-04 Register for teacher training - GOV UK(1)](https://user-images.githubusercontent.com/1108991/98134251-77ef8880-1eb6-11eb-8c0d-5783e316da4d.png)

## 404 

![Screenshot_2020-11-04 Register for teacher training - GOV UK(2)](https://user-images.githubusercontent.com/1108991/98134257-79b94c00-1eb6-11eb-8887-729f9a5fc58b.png)

## 500

![Screenshot_2020-11-04 Register for teacher training - GOV UK](https://user-images.githubusercontent.com/1108991/98134329-8d64b280-1eb6-11eb-97cd-0d8934394ba6.png)
