### PR TITLE
Update degree page

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -42,9 +42,11 @@ $govuk-assets-path: '/govuk/assets/';
 @import "overrides/moj-pagination";
 @import "overrides/tabs";
 @import "overrides/dash-list";
+@import "overrides/summary-card";
 
 // Misc
 @import "helpers";
+@import "helpers/field-widths";
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
 

--- a/app/assets/sass/helpers/_field-widths.scss
+++ b/app/assets/sass/helpers/_field-widths.scss
@@ -1,0 +1,90 @@
+// Custom width overrides so inputs can be fixed width regardless of display width.
+
+// Widths are constant rather than being % of column so that
+// they relate to the size of the content they contain. Applies from tablet
+// breakpoint only so they go full width on mobile to match other GOV.UK
+// services.
+@include govuk-media-query($from: tablet) {
+
+  // Widths chosen by eye to correspond to govuk widths at desktop 960px.
+  // Using ex to match govuk fixed width inputs, so they will scale acording
+  // to font size.
+  .app-\!-max-width-three-quarters {
+    max-width: 50ex !important;
+  }
+
+  .app-\!-max-width-two-thirds {
+    max-width: 44ex !important;
+  }
+
+  .app-\!-max-width-one-half {
+    max-width: 33ex !important;
+  }
+
+  .app-\!-max-width-one-third {
+    max-width: 22ex !important;
+  }
+
+  .app-\!-max-width-one-quarter {
+    max-width: 17ex !important;
+  }
+
+}
+
+
+
+// Set autocomplete widths
+
+// TODO: It would be better to add a wrapper to autocompletes instead.
+// Autocompletes need a wrapper width to be set rather than on
+// input directly because of our 'clear' button
+@mixin autocomplete-set-width($max-width) {
+
+  // Explicitly set font size on container so ex units work
+  // Assumes all autocompletes are default size.
+  // This matches govuk fixed width inputs which scale with
+  // font size.
+  @include govuk-font(19);
+
+  // Set on govuk-selects and autocompletes (clear and non-clear)
+  // There is no one selector currently we can target, so we target
+  // both, then unset where we don't need.
+  .govuk-select,
+  .autocomplete__wrapper,
+  .autocomplete-select-with-clear {
+    max-width: $max-width !important;
+  }
+
+  // Unset on autocompletes clear button is used
+  // Easier to unset than to have more complex selector above
+  .autocomplete-select-with-clear .autocomplete__wrapper {
+    max-width: inherit !important;
+  }
+
+}
+
+// Custom width overrides so inputs can be fixed width regardless of resolution.
+@include govuk-media-query($from: tablet) {
+
+  // These widths should match those set in helpers/field-widths.scss
+  .app-\!-autocomplete--max-width-three-quarters {
+    @include autocomplete-set-width(50ex);
+  }
+
+  .app-\!-autocomplete--max-width-two-thirds {
+    @include autocomplete-set-width(44ex);
+  }
+
+  .app-\!-autocomplete--max-width-one-half {
+    @include autocomplete-set-width(33ex);
+  }
+
+  .app-\!-autocomplete--max-width-one-third {
+    @include autocomplete-set-width(22ex);
+  }
+
+  .app-\!-autocomplete--max-width-one-quarter {
+    @include autocomplete-set-width(17ex);
+  }
+
+}

--- a/app/assets/sass/overrides/_summary-card.scss
+++ b/app/assets/sass/overrides/_summary-card.scss
@@ -1,0 +1,5 @@
+
+// Needed for when action links wrap
+.app-summary-card__actions {
+  text-align: right;
+}

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -5,7 +5,7 @@ let nationalities           = require('./nationalities')
 // Degree stuff
 let awards                  = require('./awards') // Types of degree
 let degreeData              = require('./degree')()
-let degreeTypes             = degreeData.types.undergraduate.map(type => type.text)
+let degreeTypes             = degreeData.types.undergraduate.map(type => type.text).sort()
 let subjects                = degreeData.subjects
 let ukComparableDegrees     = degreeData.ukComparableDegrees
 let degreeOrganisations     = degreeData.orgs

--- a/app/views/_components/autocomplete/template.njk
+++ b/app/views/_components/autocomplete/template.njk
@@ -31,6 +31,9 @@
   
 {% endfor %}
 
+{# This needs margin manually applied because the design system removes
+ bottom margin from the last govuk-form-group in a div - which happens
+  for *each* autocomplete #}
 <div class="{{params.classes}} govuk-!-margin-bottom-6">
   {{ govukSelect({
     label: params.label,

--- a/app/views/_components/autocomplete/template.njk
+++ b/app/views/_components/autocomplete/template.njk
@@ -31,14 +31,18 @@
   
 {% endfor %}
 
-{{ govukSelect({
-  label: params.label,
-  hint: params.hint,
-  id: params.id,
-  classes: params.classes,
-  name: params.name,
-  items: selectItems
-}) }}
+<div class="{{params.classes}} govuk-!-margin-bottom-6">
+  {{ govukSelect({
+    label: params.label,
+    hint: params.hint,
+    id: params.id,
+    classes: params.classes,
+    name: params.name,
+    items: selectItems
+  }) }}
+  {# <div class="govuk-form-group"></div> #}
+</div>
+
 
 {# {% if data.class %}
   {% set class = data.class %}

--- a/app/views/_includes/forms/degree-details.html
+++ b/app/views/_includes/forms/degree-details.html
@@ -6,6 +6,15 @@
 {% set degreeTemp = degree | mergeObjects(data.degreeTemp) %}
 {% set isInternational = degreeTemp.isInternational | falsify %}
 
+{% set degreeCount = record.degree.items | length %}
+{% if degreeCount < 1 %}
+{# {% if degreeCount < 1 and action == "add" %} #}
+  {# {% set ukHintText = "For example, BA, BSc or other (please specify)" %} #}
+  {% set ukHintText = "For example, BA or BSc" %}
+{% else %}
+  {% set ukHintText = "For example, BA, BSc, Masters or PhD" %}
+{% endif %}
+
 {{ appAutocomplete({
   label: {
     text: "Degree subject",
@@ -19,27 +28,33 @@
   minLength: 2,
   name: "degreeTemp[subject]",
   items: data.subjects,
-  classes: "govuk-!-width-two-thirds",
+  classes: "app-!-autocomplete--max-width-two-thirds",
   value: degreeTemp.subject
   }
 ) }}
 
-
-{% if isInternational %}
-
-  {# {{ govukInput({
+{% if not isInternational %}
+  {{ appAutocomplete({
     label: {
-      text: "Institution",
+      text: "Enter degree type",
       classes: "govuk-label--s"
     },
     hint: {
-      text: "Or given names"
-    } if false,
-    id: "degree-institution",
-    name: "degreeTemp[org]",
-    value: degreeTemp.org,
-    classes: "govuk-!-width-two-thirds"
-  }) }} #}
+      text: ukHintText
+    },
+    id: 'degree-type',
+    name: "degreeTemp[typeUK]",
+    items: data.degreeTypes,
+    classes: "app-!-autocomplete--max-width-two-thirds",
+    value: (degreeTemp.type or degreeTemp.typeUK) if not isInternational
+    }
+  ) }}
+{% endif %}
+
+
+
+
+{% if isInternational %}
 
   {{ appAutocomplete({
     label: {
@@ -49,7 +64,7 @@
     id: 'degree-country',
     name: "degreeTemp[country]",
     items: data.countries,
-    classes: "govuk-!-width-two-thirds",
+    classes: "app-!-autocomplete--max-width-two-thirds",
     value: degreeTemp.country
     }
   ) }}
@@ -64,7 +79,7 @@
   id: 'degree-organisations',
   name: "degreeTemp[org]",
   items: data.degreeOrganisations,
-  classes: "govuk-!-width-two-thirds",
+  classes: "app-!-autocomplete--max-width-two-thirds",
   value: degreeTemp.org
   }
 ) }}
@@ -78,12 +93,12 @@
   id: "degree-start-date",
   name: "degreeTemp[endDate]",
   value: degreeTemp.endDate,
-  classes: "govuk-!-width-one-quarter"
+  classes: "app-!-max-width-one-quarter"
 }) }}
 
 {% if isInternational %}
 
-  {% set storedGrade = degreeTemp.grade %}
+{#   {% set storedGrade = degreeTemp.grade %}
   {{storedGrade | log('stored grade')}}
   {% set storedGradeOther = false %}
 
@@ -103,11 +118,11 @@
         text: "For example, ‘A’, ‘4.5’, ‘94%’, ‘Distinction’"
       },
       id: "degree-start-date",
-      classes: "govuk-!-width-two-thirds",
+      classes: "app-!-max-width-one-quarter",
       name: "degreeTemp[otherGrade]",
       value: degreeTemp.grade if storedGradeOther
     }| decorateAttributes(degreeTemp, "degreeTemp.grade"))}}
-  {% endset %}
+  {% endset %} #}
 
  {#  {{ govukRadios({
     fieldset: {
@@ -143,7 +158,7 @@
     ]
   } | decorateAttributes(degreeTemp, "degreeTemp.grade")) }} #}
 
-  {% set naricItems = [] %}
+  {# {% set naricItems = [] %}
   {% for naricItem in data.ukComparableDegrees %}
     {% set naricItems = naricItems | push({text: naricItem}) %}
   {% endfor %}
@@ -161,31 +176,28 @@
       },
       items: naricItems
     } | decorateAttributes(degreeTemp, "degreeTemp.comparableType")) }}
-  {% endset %}
+  {% endset %} #}
 
-  {# {{ govukRadios({
+  {% set naricItems = [] %}
+  {% for naricItem in data.ukComparableDegrees %}
+    {% set naricItems = naricItems | push({
+      text: naricItem,
+      checked: checked(degreeTemp.type, naricItem)
+    }) %}
+  {% endfor %}
+  {% set naricItems = naricItems | push({divider: 'or'}) %}
+  {% set naricItems = naricItems | push({text: 'NARIC not provided'}) %}
+
+  {{ govukRadios({
     fieldset: {
       legend: {
-        text: "Do you have the NARIC comparable degree?",
+        text: "Select the NARIC comparable UK degree",
         classes: "govuk-fieldset__legend--s"
       }
     },
-    hint: {
-      text: ""
-    },
-    items: [
-      {
-        text: "Yes",
-        conditional: {
-          html: naricComparableDegrees
-        }
-      },
-      {
-        text: "No"
-      }
-    ]
-  } | decorateAttributes(degreeTemp, "degreeTemp.hasNaric")) }} #}
-
+    items: naricItems
+  } | decorateAttributes(degreeTemp, "degreeTemp.typeInt")) }}
+  
 {% else %}
 
   {% set storedGrade = degreeTemp.grade %}
@@ -206,7 +218,7 @@
         text: "Enter the degree grade"
       },
       id: "degree-start-date",
-      classes: "govuk-!-width-two-thirds",
+      classes: "app-!-max-width-one-half",
       name: "degreeTemp[otherGrade]",
       value: degreeTemp.grade if storedGradeOther
     }| decorateAttributes(degreeTemp, "degreeTemp.grade"))}}
@@ -251,15 +263,6 @@
 
 {% endif %}
 
-{# 
-,
-      {
-        divider: "or"
-      },
-      {
-        text: "The trainee is still studying for their degree"
-      }
- #}
 
 {{ govukButton({
   text: "Continue"

--- a/app/views/_includes/forms/degree-details.html
+++ b/app/views/_includes/forms/degree-details.html
@@ -36,7 +36,7 @@
 {% if not isInternational %}
   {{ appAutocomplete({
     label: {
-      text: "Enter degree type",
+      text: "Type of degree",
       classes: "govuk-label--s"
     },
     hint: {

--- a/app/views/_includes/forms/degree-type.html
+++ b/app/views/_includes/forms/degree-type.html
@@ -9,61 +9,7 @@
 {# Merge with temp store #}
 {% set degreeTemp = degree | mergeObjects(data.degreeTemp) %}
 
-{% set isInternational = degreeTemp.isInternational | falsify %}
-
-{% if degreeCount < 1 %}
-{# {% if degreeCount < 1 and action == "add" %} #}
-  {# {% set ukHintText = "For example, BA, BSc or other (please specify)" %} #}
-  {% set ukHintText = "For example, BA or BSc" %}
-{% else %}
-  {% set ukHintText = "For example, BA, BSc, Masters or PhD" %}
-{% endif %}
-
-{# <p class="govuk-body">If the trainee or candidate has further postgraduate degrees, you can add them next.</p> #}
 <p class="govuk-body">If the trainee has any other degrees, you can add them next.</p>
-
-
-{% set ukConditionalHtml %}
-  {# typeUK ultimately gets merged back in to type, hence value checking both #}
-  {# {{ appAutocomplete({
-    label: {
-      text: "Enter degree type"
-    },
-    hint: {
-      text: ukHintText
-    },
-    id: 'degree-type',
-    name: "degreeTemp[typeUK]",
-    items: data.degreeTypes,
-    classes: "govuk-!-width-two-thirds",
-    value: (degreeTemp.type or degreeTemp.typeUK) if not isInternational
-    }
-  ) }} #}
-{% endset %}
-
-
-{% set internationalConditionalHtml %}
-
-  {# {% set naricItems = [] %}
-  {% for naricItem in data.ukComparableDegrees %}
-    {% set naricItems = naricItems | push({
-      text: naricItem,
-      checked: checked(degreeTemp.type, naricItem)
-    }) %}
-  {% endfor %}
-  {% set naricItems = naricItems | push({divider: 'or'}) %}
-  {% set naricItems = naricItems | push({text: 'NARIC not provided'}) %}
-
-  {{ govukRadios({
-    fieldset: {
-      legend: {
-        text: "Select the NARIC comparable UK degree"
-      }
-    },
-    items: naricItems
-  } | decorateAttributes(degreeTemp, "degreeTemp.typeInt")) }}
-   #}
-{% endset %}
 
 {{ govukRadios({
   fieldset: {

--- a/app/views/_includes/forms/degree-type.html
+++ b/app/views/_includes/forms/degree-type.html
@@ -20,16 +20,10 @@
   },
   items: [{
     value: "false",
-    text: "UK degree",
-    _conditional: {
-      html: ukConditionalHtml
-    }
+    text: "UK degree"
   }, {
     value: "true",
-    text: "Non-UK degree",
-    _conditional: {
-      html: internationalConditionalHtml
-    }
+    text: "Non-UK degree"
   }]
 } | decorateAttributes(degreeTemp, "degreeTemp.isInternational")) }}
 

--- a/app/views/_includes/forms/degree-type.html
+++ b/app/views/_includes/forms/degree-type.html
@@ -25,7 +25,7 @@
 
 {% set ukConditionalHtml %}
   {# typeUK ultimately gets merged back in to type, hence value checking both #}
-  {{ appAutocomplete({
+  {# {{ appAutocomplete({
     label: {
       text: "Enter degree type"
     },
@@ -38,13 +38,13 @@
     classes: "govuk-!-width-two-thirds",
     value: (degreeTemp.type or degreeTemp.typeUK) if not isInternational
     }
-  ) }}
+  ) }} #}
 {% endset %}
 
 
 {% set internationalConditionalHtml %}
 
-  {% set naricItems = [] %}
+  {# {% set naricItems = [] %}
   {% for naricItem in data.ukComparableDegrees %}
     {% set naricItems = naricItems | push({
       text: naricItem,
@@ -62,7 +62,7 @@
     },
     items: naricItems
   } | decorateAttributes(degreeTemp, "degreeTemp.typeInt")) }}
-  
+   #}
 {% endset %}
 
 {{ govukRadios({
@@ -75,13 +75,13 @@
   items: [{
     value: "false",
     text: "UK degree",
-    conditional: {
+    _conditional: {
       html: ukConditionalHtml
     }
   }, {
     value: "true",
     text: "Non-UK degree",
-    conditional: {
+    _conditional: {
       html: internationalConditionalHtml
     }
   }]

--- a/app/views/_includes/forms/personal-details.html
+++ b/app/views/_includes/forms/personal-details.html
@@ -113,7 +113,7 @@
       id: 'nationality-other-' + nationalityIndex,
       name: "record[personalDetails][nationality][" + nationalityIndex + "]",
       items: nationalitiesWithoutBritishAndIrish,
-      classes: "govuk-!-width-two-thirds",
+      classes: "app-!-autocomplete--max-width-one-half",
       value: nationality
       }
     ) }}

--- a/app/views/_includes/summary-cards/single-degree-details.html
+++ b/app/views/_includes/summary-cards/single-degree-details.html
@@ -1,64 +1,60 @@
 {% set isInternational = degree.isInternational | falsify %}
 
-{% set degreeDetailsRows = [
-  {
-    key: {
-      text: "Degree type" if not isInternational else "Comparable UK degree"
-    },
-    value: {
-      text: degree.type or 'Not provided'
-    },
-    actions: {
-      items: [
-        {
-          href: recordPath + "/degree/" + loop.index0 + "/details" | addReferrer(referrer),
-          text: "Change",
-          visuallyHiddenText: "degree type"
-        }
-      ]
-    } if canAmend
+{% set subjectRow = {
+  key: {
+    text: "Subject"
   },
-  {
-    key: {
-      text: "Subject"
-    },
-    value: {
-      text: degree.subject or 'Not provided'
-    },
-    actions: {
-      items: [
-        {
-          href: recordPath + "/degree/" + loop.index0 + "/details" | addReferrer(referrer),
-          text: "Change",
-          visuallyHiddenText: "degree subject"
-        }
-      ]
-    } if canAmend
-  }] %}
+  value: {
+    text: degree.subject or 'Not provided'
+  },
+  actions: {
+    items: [
+      {
+        href: recordPath + "/degree/" + loop.index0 + "/details" | addReferrer(referrer),
+        text: "Change",
+        visuallyHiddenText: "degree subject"
+      }
+    ]
+  } if canAmend
+} %}
 
-{% set degreeInstitutionRow = {
-    key: {
-      text: "Institution"
-    },
-    value: {
-      text: degree.org or 'Not provided'
-    },
-    actions: {
-      items: [
-        {
-          href: recordPath + "/degree/" + loop.index0 + "/details" | addReferrer(referrer),
-          text: "Change",
-          visuallyHiddenText: "degree institution"
-        }
-      ]
-    } if canAmend
-  } %}
+{% set degreeTypeRow = {
+  key: {
+    text: "Degree type"
+  },
+  value: {
+    text: degree.type or 'Not provided'
+  },
+  actions: {
+    items: [
+      {
+        href: recordPath + "/degree/" + loop.index0 + "/details" | addReferrer(referrer),
+        text: "Change",
+        visuallyHiddenText: "degree type"
+      }
+    ]
+  } if canAmend
+} %}
 
-{% if degree.isInternational == 'false' %}
-  {% set degreeDetailsRows = degreeDetailsRows | push(degreeInstitutionRow) %}
-{% endif %}
+{% set institutionRow = {
+  key: {
+    text: "Institution"
+  },
+  value: {
+    text: degree.org or 'Not provided'
+  },
+  actions: {
+    items: [
+      {
+        href: recordPath + "/degree/" + loop.index0 + "/details" | addReferrer(referrer),
+        text: "Change",
+        visuallyHiddenText: "degree institution"
+      }
+    ]
+  } if canAmend
+} %}
 
-{% set degreeCountryRow = {
+{% set countryRow = {
   key: {
     text: "Country"
   },
@@ -76,29 +72,7 @@
   } if canAmend
 } %}
 
-{# Country only relevant for international #}
-{% if isInternational %}
-  {% set degreeDetailsRows = degreeDetailsRows | push(degreeCountryRow) %}
-{% endif %}
-
-{% set degreeYears = [{
-  key: {
-    text: "Start year"
-  },
-  value: {
-    text: degree.startDate or "Not provided"
-  },
-  actions: {
-    items: [
-      {
-        href: recordPath + "/degree/" + loop.index0 + "/details" | addReferrer(referrer),
-        text: "Change",
-        visuallyHiddenText: "degree start year"
-      }
-    ]
-  } if canAmend
-} if false,
-{
+{% set graduationRow = {
   key: {
     text: "Graduation year"
   },
@@ -114,9 +88,7 @@
       }
     ]
   } if canAmend
-}] %}
-
-{% set degreeDetailsRows = degreeDetailsRows | combineArrays(degreeYears) %}
+} %}
 
 {% set gradeRow = {
   key: {
@@ -136,9 +108,21 @@
   } if canAmend
 } %}
 
-{# Grade not relevant for international #}
-{% if not isInternational %}
-  {% set degreeDetailsRows = degreeDetailsRows | push(gradeRow) %}
+{% if isInternational %}
+  {% set degreeDetailsRows = [
+    subjectRow,
+    countryRow,
+    graduationRow,
+    degreeTypeRow
+  ] %}
+{% else %}
+  {% set degreeDetailsRows = [
+    subjectRow,
+    degreeTypeRow,
+    institutionRow,
+    graduationRow,
+    gradeRow
+  ] %}  
 {% endif %}
 
 

--- a/app/views/_includes/summary-cards/single-degree-details.html
+++ b/app/views/_includes/summary-cards/single-degree-details.html
@@ -11,7 +11,7 @@
     actions: {
       items: [
         {
-          href: recordPath + "/degree/" + loop.index0 + "/type" | addReferrer(referrer),
+          href: recordPath + "/degree/" + loop.index0 + "/details" | addReferrer(referrer),
           text: "Change",
           visuallyHiddenText: "degree type"
         }

--- a/app/views/_templates/_new-record.html
+++ b/app/views/_templates/_new-record.html
@@ -63,7 +63,7 @@
 
   <form {{formActionHtml}} method="post" novalidate>
     <div class="govuk-grid-row">
-      <div class="{{ gridColumn or 'govuk-grid-column-two-thirds'}}">
+      <div class="{{ gridColumn or 'govuk-grid-column-two-thirds-from-desktop'}}">
         {% block formContent %}
 
         {% endblock %}

--- a/app/views/new-record/degree/confirm.html
+++ b/app/views/new-record/degree/confirm.html
@@ -4,6 +4,8 @@
 {% set backLink = './../overview' %}
 {% set backText = "Back to draft record" %}
 
+{# {% set gridColumn = 'govuk-grid-column-full' %} #}
+
 
 {% set formAction = "./../overview" | orReferrer(referrer) %}
 

--- a/app/views/new-record/degree/type.html
+++ b/app/views/new-record/degree/type.html
@@ -1,6 +1,8 @@
 {% extends "_templates/_new-record.html" %}
 
-{% set pageHeading = "Add undergraduate degree" %}
+{% set degreeCount = data.record.degree.items | length %}
+
+{% set pageHeading = "Add undergraduate degree" if degreeCount == 0 else "Add a degree" %}
 
 {% set formAction = "./details" | addReferrer(referrer) %}
 

--- a/app/views/record/degree/type.html
+++ b/app/views/record/degree/type.html
@@ -1,6 +1,8 @@
 {% extends "_templates/_record-form.html" %}
 
-{% set pageHeading = "Add undergraduate degree" %}
+{% set degreeCount = data.record.degree.items | length %}
+
+{% set pageHeading = "Add undergraduate degree" if degreeCount == 0 else "Add a degree" %}
 
 {% set formAction = "./details" %}
 


### PR DESCRIPTION
Moves collecting the degree type from the initial page to the subsequent page.

This is easier for us to develop, but also might help with an issue where users attempt to include a subject with the degree type (BSC Biology, etc).

Also took a bit of time to add some helpers for setting the widths of inputs and autocompletes (copied from my [last project here](https://github.com/UKGovernmentBEIS/beis-opss-psd/blob/master/app/assets/stylesheets/helpers/field-widths.scss)). In a later PR I'll go back and adjust other inputs to match.

<img width="708" alt="Screenshot 2020-11-05 at 17 37 26" src="https://user-images.githubusercontent.com/2204224/98276345-bad05f80-1f8d-11eb-904d-37f61006b7ce.png">
<img width="704" alt="Screenshot 2020-11-05 at 17 37 34" src="https://user-images.githubusercontent.com/2204224/98276351-bd32b980-1f8d-11eb-88e3-640dfb7e9ec8.png">
