### PR TITLE
Make status cards link to filtered list

### DIFF
--- a/app/assets/sass/components/_status-card.scss
+++ b/app/assets/sass/components/_status-card.scss
@@ -1,53 +1,83 @@
-.status-card {
+
+.status-card, {
   background-color: govuk-colour("light-grey");
   display: block;
   padding: govuk-spacing(2);
   text-decoration: none;
+
   @include govuk-font($size: 19);
 
   @include govuk-media-query($from: desktop) {
     padding: govuk-spacing(4);
   }
+
+  &:focus, &:link:focus, &:visited:focus {
+    color:  $govuk-text-colour;
+    background:  $govuk-focus-colour;
+  }
+
+}
+
+
+
+.status-card, .status-card:visited {
+  color: inherit;
 }
 
 // Colours sourced from here: https://github.com/alphagov/govuk-frontend/blob/61aabca3d440edee6bdecdd20ea54a241c7bbdd5/src/govuk/components/tag/_index.scss#L42
 
 .status-card--draft {
-  color: govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);
-  background: govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90);
+  &, &:link, &:visited {
+    color: govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);
+    background: govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90);
+  }
 }
 
 .status-card--qts-recommended {
-  color: govuk-shade(govuk-colour("purple"), 20);
-  background: govuk-tint(govuk-colour("purple"), 80);
+  &, &:link, &:visited {
+    color: govuk-shade(govuk-colour("purple"), 20);
+    background: govuk-tint(govuk-colour("purple"), 80);
+  }
 }
 
 .status-card--qts-awarded {
-  color:  #fff;
-  background: $govuk-brand-colour;
+  &, &:link, &:visited {
+    color:  #fff;
+    background: $govuk-brand-colour;
+  }
 }
 
 .status-card--pending-trn {
-  color: govuk-shade(govuk-colour("turquoise"), 60);
-  background: govuk-tint(govuk-colour("turquoise"), 70);
+  &, &:link, &:visited {
+    color: govuk-shade(govuk-colour("turquoise"), 60);
+    background: govuk-tint(govuk-colour("turquoise"), 70);
+  }
 }
 
 .status-card--trn-received {
-  color: govuk-shade(govuk-colour("blue"), 30);
-  background: govuk-tint(govuk-colour("blue"), 80);
+  &, &:link, &:visited {
+    color: govuk-shade(govuk-colour("blue"), 30);
+    background: govuk-tint(govuk-colour("blue"), 80);
+  }
 }
 
 .status-card--deferred {
-  color: govuk-shade(govuk-colour("yellow"), 65);
-  background: govuk-tint(govuk-colour("yellow"), 75);
+  &, &:link, &:visited {
+    color: govuk-shade(govuk-colour("yellow"), 65);
+    background: govuk-tint(govuk-colour("yellow"), 75);
+  }
 }
 
 .status-card--withdrawn {
-  color: govuk-shade(govuk-colour("red"), 30);
-  background: govuk-tint(govuk-colour("red"), 80);
+  &, &:link, &:visited {
+    color: govuk-shade(govuk-colour("red"), 30);
+    background: govuk-tint(govuk-colour("red"), 80);
+  }
 }
 
 .status-card__count {
-  @include govuk-font($size: 36, $weight: bold, $tabular: true);
-  display: block;
+  &, &:link, &:visited {
+    @include govuk-font($size: 36, $weight: bold, $tabular: true);
+    display: block;
+  }
 }

--- a/app/assets/sass/components/_status-card.scss
+++ b/app/assets/sass/components/_status-card.scss
@@ -18,21 +18,11 @@
 
 }
 
-
 .status-card, .status-card:visited {
   color: inherit;
 }
 
 // Colours sourced from here: https://github.com/alphagov/govuk-frontend/blob/61aabca3d440edee6bdecdd20ea54a241c7bbdd5/src/govuk/components/tag/_index.scss#L42
-
-// Colours
-// $status-card-draft-colour: govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);
-// $status-card-draft-background-colour: govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90);
-// $status-card-draft-hover-colour: govuk-shade($status-card-draft-background-colour, 10%);
-
-// $status-card-qts-recommended-colour: govuk-shade(govuk-colour("purple"), 20);
-// $status-card-qts-recommended-background-colour: govuk-tint(govuk-colour("purple"), 80);
-// $status-card-qts-recommended-hover-colour: govuk-tint(govuk-colour("purple"), 70);
 
 $statuses: (
   "draft": (
@@ -72,11 +62,6 @@ $statuses: (
   )
 );
 
-
-// $status-card-qts-recommended-colour: 
-// $status-card-qts-recommended-background-colour: 
-// $status-card-qts-recommended-hover-colour: 
-
 @each $status, $data in $statuses
 {
   .status-card--#{$status} {
@@ -89,61 +74,6 @@ $statuses: (
     }
   }
 }
-
-// .status-card--draft {
-//   &, &:link, &:visited {
-//     color: $status-card-draft-colour;
-//     background: $status-card-draft-background-colour;
-//   }
-//   &:hover {
-//     background: $status-card-draft-hover-colour;
-//   }
-// }
-
-// .status-card--qts-recommended {
-//   &, &:link, &:visited {
-//     color: $status-card-qts-recommended-colour;
-//     background: $status-card-qts-recommended-background-colour;
-//   }
-//   &:hover {
-//     background: $status-card-qts-recommended-hover-colour;
-//   }
-// }
-
-// .status-card--qts-awarded {
-//   &, &:link, &:visited {
-//     color:  #fff;
-//     background: $govuk-brand-colour;
-//   }
-// }
-
-// .status-card--pending-trn {
-//   &, &:link, &:visited {
-//     color: govuk-shade(govuk-colour("turquoise"), 60);
-//     background: govuk-tint(govuk-colour("turquoise"), 70);
-//   }
-// }
-
-// .status-card--trn-received {
-//   &, &:link, &:visited {
-//     color: govuk-shade(govuk-colour("blue"), 30);
-//     background: govuk-tint(govuk-colour("blue"), 80);
-//   }
-// }
-
-// .status-card--deferred {
-//   &, &:link, &:visited {
-//     color: govuk-shade(govuk-colour("yellow"), 65);
-//     background: govuk-tint(govuk-colour("yellow"), 75);
-//   }
-// }
-
-// .status-card--withdrawn {
-//   &, &:link, &:visited {
-//     color: govuk-shade(govuk-colour("red"), 30);
-//     background: govuk-tint(govuk-colour("red"), 80);
-//   }
-// }
 
 .status-card__count {
   &, &:link, &:visited {

--- a/app/assets/sass/components/_status-card.scss
+++ b/app/assets/sass/components/_status-card.scss
@@ -19,61 +19,131 @@
 }
 
 
-
 .status-card, .status-card:visited {
   color: inherit;
 }
 
 // Colours sourced from here: https://github.com/alphagov/govuk-frontend/blob/61aabca3d440edee6bdecdd20ea54a241c7bbdd5/src/govuk/components/tag/_index.scss#L42
 
-.status-card--draft {
-  &, &:link, &:visited {
-    color: govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);
-    background: govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90);
+// Colours
+// $status-card-draft-colour: govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);
+// $status-card-draft-background-colour: govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90);
+// $status-card-draft-hover-colour: govuk-shade($status-card-draft-background-colour, 10%);
+
+// $status-card-qts-recommended-colour: govuk-shade(govuk-colour("purple"), 20);
+// $status-card-qts-recommended-background-colour: govuk-tint(govuk-colour("purple"), 80);
+// $status-card-qts-recommended-hover-colour: govuk-tint(govuk-colour("purple"), 70);
+
+$statuses: (
+  "draft": (
+    "colour":            govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30),
+    "background-colour": govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90),
+    "hover":             govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 80)
+  ),
+  "pending-trn": (
+    "colour":            govuk-shade(govuk-colour("turquoise"), 60),
+    "background-colour": govuk-tint(govuk-colour("turquoise"), 70),
+    "hover":             govuk-tint(govuk-colour("turquoise"), 57),
+  ),
+  "trn-received": (
+    "colour":            govuk-shade(govuk-colour("blue"), 30),
+    "background-colour": govuk-tint(govuk-colour("blue"), 80),
+    "hover":             govuk-tint(govuk-colour("blue"), 70)
+  ),
+  "qts-recommended": (
+    "colour":            govuk-shade(govuk-colour("purple"), 20),
+    "background-colour": govuk-tint(govuk-colour("purple"), 80),
+    "hover":             govuk-tint(govuk-colour("purple"), 70)
+  ),
+  "qts-awarded": (
+    "colour":            #fff,
+    "background-colour": $govuk-brand-colour,
+    "hover":             govuk-shade($govuk-brand-colour, 15%)
+  ),
+  "deferred": (
+    "colour":            govuk-shade(govuk-colour("yellow"), 65),
+    "background-colour": govuk-tint(govuk-colour("yellow"), 75),
+    "hover":             govuk-tint(govuk-colour("yellow"), 60)
+  ),
+  "withdrawn": (
+    "colour":            govuk-shade(govuk-colour("red"), 30),
+    "background-colour": govuk-tint(govuk-colour("red"), 80),
+    "hover":             govuk-tint(govuk-colour("red"), 70)
+  )
+);
+
+
+// $status-card-qts-recommended-colour: 
+// $status-card-qts-recommended-background-colour: 
+// $status-card-qts-recommended-hover-colour: 
+
+@each $status, $data in $statuses
+{
+  .status-card--#{$status} {
+    &, &:link, &:visited {
+      color: map-get($data, "colour");
+      background: map-get($data, "background-colour");
+    }
+    &:hover {
+      background: map-get($data, "hover");
+    }
   }
 }
 
-.status-card--qts-recommended {
-  &, &:link, &:visited {
-    color: govuk-shade(govuk-colour("purple"), 20);
-    background: govuk-tint(govuk-colour("purple"), 80);
-  }
-}
+// .status-card--draft {
+//   &, &:link, &:visited {
+//     color: $status-card-draft-colour;
+//     background: $status-card-draft-background-colour;
+//   }
+//   &:hover {
+//     background: $status-card-draft-hover-colour;
+//   }
+// }
 
-.status-card--qts-awarded {
-  &, &:link, &:visited {
-    color:  #fff;
-    background: $govuk-brand-colour;
-  }
-}
+// .status-card--qts-recommended {
+//   &, &:link, &:visited {
+//     color: $status-card-qts-recommended-colour;
+//     background: $status-card-qts-recommended-background-colour;
+//   }
+//   &:hover {
+//     background: $status-card-qts-recommended-hover-colour;
+//   }
+// }
 
-.status-card--pending-trn {
-  &, &:link, &:visited {
-    color: govuk-shade(govuk-colour("turquoise"), 60);
-    background: govuk-tint(govuk-colour("turquoise"), 70);
-  }
-}
+// .status-card--qts-awarded {
+//   &, &:link, &:visited {
+//     color:  #fff;
+//     background: $govuk-brand-colour;
+//   }
+// }
 
-.status-card--trn-received {
-  &, &:link, &:visited {
-    color: govuk-shade(govuk-colour("blue"), 30);
-    background: govuk-tint(govuk-colour("blue"), 80);
-  }
-}
+// .status-card--pending-trn {
+//   &, &:link, &:visited {
+//     color: govuk-shade(govuk-colour("turquoise"), 60);
+//     background: govuk-tint(govuk-colour("turquoise"), 70);
+//   }
+// }
 
-.status-card--deferred {
-  &, &:link, &:visited {
-    color: govuk-shade(govuk-colour("yellow"), 65);
-    background: govuk-tint(govuk-colour("yellow"), 75);
-  }
-}
+// .status-card--trn-received {
+//   &, &:link, &:visited {
+//     color: govuk-shade(govuk-colour("blue"), 30);
+//     background: govuk-tint(govuk-colour("blue"), 80);
+//   }
+// }
 
-.status-card--withdrawn {
-  &, &:link, &:visited {
-    color: govuk-shade(govuk-colour("red"), 30);
-    background: govuk-tint(govuk-colour("red"), 80);
-  }
-}
+// .status-card--deferred {
+//   &, &:link, &:visited {
+//     color: govuk-shade(govuk-colour("yellow"), 65);
+//     background: govuk-tint(govuk-colour("yellow"), 75);
+//   }
+// }
+
+// .status-card--withdrawn {
+//   &, &:link, &:visited {
+//     color: govuk-shade(govuk-colour("red"), 30);
+//     background: govuk-tint(govuk-colour("red"), 80);
+//   }
+// }
 
 .status-card__count {
   &, &:link, &:visited {

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,6 +1,7 @@
 let countries               = require('./countries')
 let ethnicities             = require('./ethnicities')
 let nationalities           = require('./nationalities')
+let statuses                = require('./status')
 
 // Degree stuff
 let awards                  = require('./awards') // Types of degree
@@ -68,6 +69,7 @@ module.exports = {
   records,
   settings,
   subjects,
+  statuses,
   trainingRoutes,
   ukComparableDegrees,
   withdrawalReasons

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -40,69 +40,39 @@
 
     <h2 class="govuk-heading-m">Trainee status overview</h2>
 
+    {% set records = data.records | filterDisabledTrainingRoutes %}
+
+    {% macro statusCard(records, status) %}
+      <a href="/records?filterStatus={{status}}" class="status-card status-card--{{status | lower | kebabCase }}">
+        {% set recordCount = records | where("status", status) | length %}
+        <span class="status-card__count">{{recordCount}}</span>
+        {{status}}
+      </a>
+    {% endmacro %}
+
     <div class="govuk-grid-row govuk-!-margin-bottom-6">
-
-      {% set records = data.records | filterDisabledTrainingRoutes %}
-
-      <div class="govuk-grid-column-one-third">
-        <div class="status-card status-card--draft">
-          {% set draftRecordCount = records | where("status", "Draft") | length %}
-          <span class="status-card__count">{{draftRecordCount}}</span>
-          Draft
+      {% set statuses = ['Draft', 'Pending TRN', 'TRN received'] %}
+      {% for status in statuses %}
+        <div class="govuk-grid-column-one-third">
+          {{ statusCard(records, status) }}
         </div>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <div class="status-card status-card--pending-trn">
-          {% set pendingTrnRecordCount = records | where("status", "Pending TRN") | length %}
-          <span class="status-card__count">{{pendingTrnRecordCount}}</span>
-          Pending TRN
-        </div>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <div class="status-card status-card--trn-received">
-          {% set trnReceivedRecordCount = records | where("status", "TRN received") | length %}
-          <span class="status-card__count">{{trnReceivedRecordCount}}</span>
-          TRN received
-        </div>
-      </div>
-
+      {% endfor %}
     </div>
-
     <div class="govuk-grid-row govuk-!-margin-bottom-6">
-
-      <div class="govuk-grid-column-one-quarter">
-        <div class="status-card status-card--qts-recommended">
-          {% set qtsRecommendedRecordCount = records | where("status", "QTS recommended") | length %}
-          <span class="status-card__count">{{qtsRecommendedRecordCount}}</span>
-          QTS recommended
+      {% set statuses = ['QTS recommended', 'QTS awarded', 'Deferred', 'Withdrawn'] %}
+      {% for status in statuses %}
+        <div class="govuk-grid-column-one-quarter">
+          {{ statusCard(records, status) }}
         </div>
-      </div>
-      <div class="govuk-grid-column-one-quarter">
-        <div class="status-card status-card--qts-awarded">
-          {% set qtsAwardedRecordCount = records | where("status", "QTS awarded") | length %}
-          <span class="status-card__count">{{qtsAwardedRecordCount}}</span>
-          QTS awarded
-        </div>
-      </div>
-      <div class="govuk-grid-column-one-quarter">
-        <div class="status-card status-card--deferred">
-          {% set deferredRecordCount = records | where("status", "Deferred") | length %}
-          <span class="status-card__count">{{deferredRecordCount}}</span>
-          Deferred
-        </div>
-      </div>
-      <div class="govuk-grid-column-one-quarter">
-        <div class="status-card status-card--withdrawn">
-          {% set withdrawnRecordCount = records | where("status", "Withdrawn") | length %}
-          <span class="status-card__count">{{withdrawnRecordCount}}</span>
-          Withdrawn
-        </div>
-      </div>
-
+      {% endfor %}
     </div>
 
   </div>
 
 </div>
 
+
+
 {% endblock %}
+
+


### PR DESCRIPTION
Makes the status cards on the homepage link to the records list with the appropriate filter on.

No visual change normally:
<img width="888" alt="Screenshot 2020-11-06 at 13 05 59" src="https://user-images.githubusercontent.com/2204224/98369441-dfc9de80-2030-11eb-9aa7-607ea2244f77.png">

When focused:
<img width="880" alt="Screenshot 2020-11-06 at 13 06 05" src="https://user-images.githubusercontent.com/2204224/98369467-e9534680-2030-11eb-8024-7080431dafeb.png">
