### PR TITLE
Records page bug fix and some layout updates for smaller viewports

### DIFF
--- a/app/assets/sass/components/_application-card.scss
+++ b/app/assets/sass/components/_application-card.scss
@@ -22,6 +22,10 @@
 }
 
 .app-application-card_col:nth-child(2) {
+  @include govuk-media-query($until: tablet) {
+    margin-top: govuk-spacing(2);
+    margin-bottom: govuk-spacing(2);
+  }
   @include govuk-media-query($from: tablet) {
     width: 25%;
   }

--- a/app/assets/sass/overrides/_moj-filter.scss
+++ b/app/assets/sass/overrides/_moj-filter.scss
@@ -1,8 +1,22 @@
 // Moj Filter panel overrides
 
+.moj-filter-layout__filter-wrapper {
+  max-width: 300px;
+  margin-right: 40px;
+  min-width: 260px;
+  width: 100%;
+  
+  @include govuk-media-query($from: desktop) {
+    float: left;
+  }
+}
+
 .moj-filter-layout__filter {
   box-shadow: none;
-  max-width: 300px;
+  
+  @include govuk-media-query($from: desktop) {
+    margin-bottom: govuk-spacing(3);
+  }
 }
 
 .moj-filter__header {
@@ -30,7 +44,7 @@
 .moj-action-bar {
   overflow: hidden;
 
-  @include govuk-media-query($from: tablet) {
+  @include govuk-media-query($from: desktop) {
     display: none;
   }
 }

--- a/app/views/_includes/trainee-record-card.njk
+++ b/app/views/_includes/trainee-record-card.njk
@@ -18,8 +18,8 @@
     {% endif %}
   </div>
   <div class="app-application-card_col">
-    <p class="govuk-body govuk-!-margin-bottom-0">{{record.programmeDetails.subject}}</p>
-    <p class="govuk-body govuk-hint govuk-!-margin-bottom-0">{{record.route}}</p>
+    <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-0">{{record.programmeDetails.subject}}</p>
+    <p class="govuk-body govuk-!-font-size-16 govuk-hint govuk-!-margin-bottom-0">{{record.route}}</p>
   </div>
   <div class="app-application-card_col">
     {{govukTag({

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -1,5 +1,5 @@
 {% extends "_templates/_page.html" %}
-{% set pageHeading = "Trainee teachers" %}
+{% set pageHeading = "Trainee records" %}
 
 {% set backLink = 'false' %}
 

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -29,9 +29,14 @@
       
       <form method="get" action="">
       
-        <div class="moj-filter-layout__filter">
-          {% include "_includes/filter-panel.njk" %}
-          <p class="govuk-body govuk-!-margin-top-5"><a href="#" class="govuk-link">Export these records</a></p>
+        <div class="moj-filter-layout__filter-wrapper">
+          
+          <div class="moj-filter-layout__filter">
+            {% include "_includes/filter-panel.njk" %}
+          </div>
+
+          <p class="govuk-body"><a href="#" class="govuk-link">Export these records</a></p>
+
         </div>
 
         <div class="moj-filter-layout__content">

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -16,8 +16,6 @@
         href: "./new-record/new",
         isStartButton: true
       }) }}
-
-      
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR includes:

## Reducing text size of route and subject to reduce wrapping

**Before**

![Screenshot 2020-11-11 at 09 29 57](https://user-images.githubusercontent.com/1108991/98795412-18d3cb80-2402-11eb-87c9-754062b38428.png)

**After**

![Screenshot 2020-11-11 at 09 30 07](https://user-images.githubusercontent.com/1108991/98795439-20937000-2402-11eb-891b-4d9b4bd9fb2a.png)

## Improved layout for records at smaller viewports

**Before**

![Screenshot 2020-11-11 at 09 31 11](https://user-images.githubusercontent.com/1108991/98795266-ec1fb400-2401-11eb-8026-0594d9aabf47.png)

**After**

![Screenshot 2020-11-11 at 09 30 44](https://user-images.githubusercontent.com/1108991/98795297-f5108580-2401-11eb-9d2b-43561bf723fb.png)

## An initial fix for the Export link breaking the layout at smaller viewports.

I imagine this will be refactored again as we iterate on this screen and think more about the Export link. In the meantime this solves the broken layout issue.

**Before**

![Screenshot 2020-11-11 at 09 36 04](https://user-images.githubusercontent.com/1108991/98795719-6fd9a080-2402-11eb-8959-19d9c2d498ec.png)

**After**

![Screenshot 2020-11-11 at 09 36 19](https://user-images.githubusercontent.com/1108991/98795750-7700ae80-2402-11eb-9714-585707927acc.png)
