### PR TITLE
Adding the declaration page (WIP)

### DIFF
--- a/app/views/admin.html
+++ b/app/views/admin.html
@@ -38,6 +38,15 @@
           }
         ]
       } | decorateAttributes(data, "data.settings.useDarkHeader")) }}
+      
+      {{ govukCheckboxes({
+        items: [
+          {
+            value: 'true',
+            text: "Show declaration page"
+          }
+        ]
+      } | decorateAttributes(data, "data.settings.includeDeclaration")) }}
 
 
       {% set allTrainingRoutes = [] %}

--- a/app/views/declaration.html
+++ b/app/views/declaration.html
@@ -5,8 +5,6 @@
 
 {% block content %}
 
-{# todo: hide the grey navbar on this page #}
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">{{pageHeading}}</h1>

--- a/app/views/declaration.html
+++ b/app/views/declaration.html
@@ -1,0 +1,33 @@
+
+{% extends "_templates/_page.html" %}
+
+{% set pageHeading = 'Before you begin' %}
+
+{% block content %}
+
+{# todo: hide the grey navbar on this page #}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">{{pageHeading}}</h1>
+    <p class="govuk-body">By using this service, you agree to share accurate information about your trainees. You also agree to take responsibility for informing trainees that you share their data with DfE to register them as trainees.</p>
+    
+    <form action="/home" method="post">
+      {{ govukCheckboxes({
+        items: [
+          {
+            value: 'I agree',
+            text: "I agree"
+          }
+        ]
+      } | decorateAttributes(data, "data.declaration")) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </form>
+    
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/declaration.html
+++ b/app/views/declaration.html
@@ -1,7 +1,7 @@
 
 {% extends "_templates/_page.html" %}
-
 {% set pageHeading = 'Before you begin' %}
+{% set hidePrimaryNav = true %}
 
 {% block content %}
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -29,7 +29,7 @@
     <p class="govuk-body">Main pages</p>
     <ul class="govuk-list govuk-list--bullet">
       <li><a href="start-page" class="govuk-link">Start page</a></li>
-      <li><a href="declaration" class="govuk-link">Start page</a></li>
+      <li><a href="declaration" class="govuk-link">Declaration</a></li>
       <li><a href="home" class="govuk-link">Home / dashboard</a></li>
       <li><a href="records" class="govuk-link">Trainee records</a></li>
       <li><a href="new-record/new" class="govuk-link">Add a trainee</a></li>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -29,6 +29,7 @@
     <p class="govuk-body">Main pages</p>
     <ul class="govuk-list govuk-list--bullet">
       <li><a href="start-page" class="govuk-link">Start page</a></li>
+      <li><a href="declaration" class="govuk-link">Start page</a></li>
       <li><a href="home" class="govuk-link">Home / dashboard</a></li>
       <li><a href="records" class="govuk-link">Trainee records</a></li>
       <li><a href="new-record/new" class="govuk-link">Add a trainee</a></li>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -46,8 +46,6 @@
 {%- from "moj/components/pagination/macro.njk" import mojPagination -%}
 {%- from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation -%}
 
-
-
 {% block head %}
   {% include "_includes/head.html" %}
 {% endblock %}
@@ -101,19 +99,21 @@
     } if false
     ] %}
 
-  {% if data.settings.useDarkHeader %}
-    {{ appPrimaryNavigationDark({
+  {% if not hidePrimaryNav %}
+  
+    {% if data.settings.useDarkHeader %}
+      {{ appPrimaryNavigationDark({
+        label: 'Primary navigation',
+        items: navItems
+      }) }}
+    {% else %}
+      {{ mojPrimaryNavigation({
       label: 'Primary navigation',
       items: navItems
-    }) }}
-  {% else %}
-    {{ mojPrimaryNavigation({
-    label: 'Primary navigation',
-    items: navItems
-    }) }}
-  {% endif %}
-  
+      }) }}
+    {% endif %}
 
+  {% endif %}
   
 {% endblock %}
 

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %}
 {% set bodyClasses = "start-page" %}
 {% set hideNav = true %}
+{% set hidePrimaryNav = true %}
 
 {% block pageTitle %}
   {{ pageHeading }} - GOV.UK

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -31,12 +31,12 @@
           <div class="start-page-banner__actions">
             {{ govukButton({
               text: "Get started",
-              href: "/home",
+              href: "/declaration",
               classes: "start-page-banner__button",
               isStartButton: true
             }) }}
             <p class="govuk-body start-page-banner__text">or
-            <a class="govuk-link govuk-link--no-visited-state" href="/home">sign in</a>
+            <a class="govuk-link govuk-link--no-visited-state" href="/declaration">sign in</a>
             if you’ve used it before</p>
           </div>
 

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -41,7 +41,7 @@
               isStartButton: true
             }) }}
             <p class="govuk-body start-page-banner__text">or
-            <a class="govuk-link govuk-link--no-visited-state" href="/home">sign in</a>
+            <a class="govuk-link govuk-link--no-visited-state" href="{% if data.settings.includeDeclaration %}declaration{% else %}home{% endif %}">sign in</a>
             if you’ve used it before</p>
           </div>
 

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -32,7 +32,7 @@
           <div class="start-page-banner__actions">
             {{ govukButton({
               text: "Get started",
-              href: "/declaration",
+              href: "/home",
               classes: "start-page-banner__button",
               isStartButton: true
             }) }}


### PR DESCRIPTION
A placeholder for the Declaration page. It sounds like there is some question about it's necessity. Parking the page for now behind a feature flag.

This PR includes the `hidePrimaryNav` flag which is used in [#116](https://github.com/DFE-Digital/register-trainee-teachers-prototype/pull/116)
 
![Screenshot 2020-11-17 at 10 07 58](https://user-images.githubusercontent.com/1108991/99376624-14edf080-28bd-11eb-8671-b6c662e586cc.png)
