### PR TITLE
Move phase banner within blue bar, and make nav conditional

### DIFF
--- a/app/assets/sass/patterns/_start-page.scss
+++ b/app/assets/sass/patterns/_start-page.scss
@@ -1,6 +1,6 @@
 
 .start-page .govuk-phase-banner {
-  border: 0;
+  margin-bottom: govuk-spacing(6);
 }
 
 .start-page main {
@@ -8,10 +8,17 @@
 }
 
 .start-page-banner {
-  padding-top: govuk-spacing(7);
+  padding-top: govuk-spacing(1);
   padding-bottom: govuk-spacing(7);
   background-color: govuk-colour("blue");
   color: #fff;
+}
+
+.start-page-banner__tag {
+  background-color: govuk-colour("white");
+  color: govuk-colour("blue");
+
+  > :last-child { margin-bottom: 0 !important; margin-right: 0 !important; }
 }
 
 .start-page-banner__heading,

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -1,6 +1,7 @@
-{% extends "layout.html" %}
+ {% extends "layout.html" %}
 {% set bodyClasses = "start-page" %}
 {% set hideNav = true %}
+{% set hidePrimaryNav = true %}
 
 {% block pageTitle %}
   {{ pageHeading }} - GOV.UK
@@ -8,21 +9,25 @@
 
 {% set pageHeading = 'Register trainee teachers' %}
 
+{% block beforeContent %}
+{# beforeContent is reseting default phase banner #}
+{% endblock %}
+
 {% block main %}
-  <div class="govuk-width-container">
-    {{ govukPhaseBanner({
-      tag: {
-        text: "prototype"
-      },
-      html: 'This is a prototype of a new service. Some parts of this prototype do not work yet. '
-    }) }}
-    {# this overrides the default phase banner from layout.html #}
-    {% block beforeContent %}
-    {% endblock %}
-  </div>
   <div class="start-page-banner">
 
     <div class="govuk-width-container">
+      <div class="govuk-phase-banner">
+        <p class="govuk-phase-banner__content">
+          {{ govukTag({
+            text: "prototype",
+            classes: "govuk-phase-banner__content__tag start-page-banner__tag"
+          }) | indent(4) | trim }}
+          <span class="govuk-phase-banner__text start-page-banner__text">
+            This is a prototype of a new service. Some parts of this prototype do not work yet.
+          </span>
+        </p>
+      </div>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
 


### PR DESCRIPTION
Moves the phase banner within the blue bar.

The page also sets a variable to turn off the primary nav - but the condition to actually remove it is part of #115 

<img width="1234" alt="Screenshot 2020-11-13 at 11 33 47" src="https://user-images.githubusercontent.com/2204224/99068990-69375e80-25a5-11eb-881d-1ef3548ce733.png">
