### PR TITLE
Collect programme end date at start

### DIFF
--- a/app/views/_includes/forms/programme-details/assessment-only.html
+++ b/app/views/_includes/forms/programme-details/assessment-only.html
@@ -114,43 +114,38 @@
     ]
 }) }}
 
-{# We only want to collect this once they go to submit for QTS #}
-{# Likely it can never be seen on this page, as we don't currently
-allow editing after you submit for QTS #}
-{% if record | requiresField("programmeEndDate") or record.status == "QTS recommended" or record.status == "QTS Awarded" %}
-  {% set programmeEndDateArray = record.programmeDetails.endDate | toDateArray %}
-  {{ govukDateInput({
-    id: "programme-end-date",
-    namePrefix: "record[programmeDetails][endDate]",
-    fieldset: {
-      legend: {
-        text: "Programme end date",
-        classes: "govuk-fieldset__legend--s"
+{% set programmeEndDateArray = record.programmeDetails.endDate | toDateArray %}
+{{ govukDateInput({
+  id: "programme-end-date",
+  namePrefix: "record[programmeDetails][endDate]",
+  fieldset: {
+    legend: {
+      text: "Programme end date",
+      classes: "govuk-fieldset__legend--s"
+    }
+  },
+  hint: {
+    text: "For example, " + "" | today | moment('add', 1, 'years') | toDateArray | spaceSeparate
+  },
+  items: [
+      {
+        name: "day",
+        classes: "govuk-input--width-2",
+        value: programmeEndDateArray["0"]
+      },
+      {
+        name: "month",
+        classes: "govuk-input--width-2",
+        value: programmeEndDateArray["1"]
+      },
+      {
+        name: "year",
+        classes: "govuk-input--width-4",
+        value: programmeEndDateArray["2"]
       }
-    },
-    hint: {
-      text: "For example, " + "" | today | moment('add', 1, 'years') | toDateArray | spaceSeparate
-    },
-    items: [
-        {
-          name: "day",
-          classes: "govuk-input--width-2",
-          value: programmeEndDateArray["0"]
-        },
-        {
-          name: "month",
-          classes: "govuk-input--width-2",
-          value: programmeEndDateArray["1"]
-        },
-        {
-          name: "year",
-          classes: "govuk-input--width-4",
-          value: programmeEndDateArray["2"]
-        }
-      ]
-  }) }}
+    ]
+}) }}
 
-{% endif %}
 
 {{ govukButton({
   text: "Continue"

--- a/app/views/_includes/summary-cards/programme-details/assessment-only.html
+++ b/app/views/_includes/summary-cards/programme-details/assessment-only.html
@@ -78,9 +78,9 @@
 }  %}
 
 {# End date only collected when submitting for QTS #}
-{% if record.status == "QTS recommended" or record.status == "QTS awarded" %}
+{# {% if record.status == "QTS recommended" or record.status == "QTS awarded" %} #}
   {% set programmeDetailsRows = programmeDetailsRows | push(endDateRow) %}  
-{% endif %}
+{# {% endif %} #}
 
 {% set programmeDetailsHtml %}
   {{ govukSummaryList({


### PR DESCRIPTION
We originally didn't collect end date on the assumption it could be the same as the qts assessment date - this may not be correct.

Probably easier for now to just collect it at the start and work out later if we can simplify.