### PR TITLE
Add initial support for hints inside autocompletes

### DIFF
--- a/app/assets/sass/components/_autocomplete.scss
+++ b/app/assets/sass/components/_autocomplete.scss
@@ -142,3 +142,19 @@
 .autocomplete__dropdown-arrow-down {
   pointer-events: none;
 }
+
+
+.autocomplete__option-hint {
+  display: block;
+  @include govuk-font(16);
+  color: $govuk-secondary-text-colour;
+}
+
+.autocomplete__option--focused,
+.autocomplete__option:hover {
+  color: govuk-colour("white");
+
+  .autocomplete__option-hint {
+    color: govuk-colour("white");
+  }
+}

--- a/app/views/_components/autocomplete/template.njk
+++ b/app/views/_components/autocomplete/template.njk
@@ -96,13 +96,37 @@
   //   {% endif %}
   // }
 
+  let template =  {
+    inputValue: function (result) {
+      if (result) {
+        const name = result.split(' | ')
+        if (name[1]) {
+          return name[0] && name[0]
+        }
+        return result && result
+      }
+      return result && result
+    },
+    suggestion: function (result) {
+      const name = result.split(' | ')
+      if (name[1]) {
+        return name[0] && name[0] + '<span class="autocomplete__option-hint">' + name[1] + '</span>'
+      }
+      else {
+        return result && result
+      }
+      
+    }
+  }
+
   accessibleAutocomplete.enhanceSelectElement({
     selectElement: element,
     showAllValues: showAllValues,
     autoselect: autoSelect,
     minLength: minLength,
     // source: values,
-    defaultValue: defaultValue
+    defaultValue: defaultValue,
+    templates: template
 
   });
     // onConfirm: confirmFunction


### PR DESCRIPTION
Adds some hacky support for a hint inside the results of the autocomplete.

To use, pass a name in the form `Text | hint` - the hint will be split off and shown in grey.

<img width="587" alt="Screenshot 2020-11-13 at 13 46 51" src="https://user-images.githubusercontent.com/2204224/99091828-4ec2ac80-25c8-11eb-9b04-85f2be84deaa.png">
