### PR TITLE
Fix bug with multiple autocompletes

### DIFF
--- a/app/views/_components/autocomplete/template.njk
+++ b/app/views/_components/autocomplete/template.njk
@@ -74,12 +74,12 @@
 
   var values = [{% for value in params.items %}"{{value}}",{% endfor %}];
 
-  element = document.querySelector('#{{params.id}}');
+  var element = document.querySelector('#{{params.id}}');
   // id = '{{params.id}}--autocomplete';
-  defaultValue = '{{params.value}}';
-  showAllValues = ('{{params.showAllValues}}' == 'false') ? false : true;
-  autoSelect = ('{{params.autoSelect}}' == 'false') ? false : true;
-  minLength = ('{{params.minLength}}' == false) ? 0 : parseInt('{{params.minLength}}');
+  var defaultValue = '{{params.value}}';
+  var showAllValues = ('{{params.showAllValues}}' == 'false') ? false : true;
+  var autoSelect = ('{{params.autoSelect}}' == 'false') ? false : true;
+  var minLength = ('{{params.minLength}}' == false) ? 0 : parseInt('{{params.minLength}}');
 
   // Conditional not used
   // confirmFunction = function(val) {
@@ -96,8 +96,7 @@
   //   {% endif %}
   // }
 
-  let template =  {
-    inputValue: function (result) {
+  var inputValue = (result) => {
       if (result) {
         const name = result.split(' | ')
         if (name[1]) {
@@ -106,8 +105,9 @@
         return result && result
       }
       return result && result
-    },
-    suggestion: function (result) {
+    }
+
+  var suggestion = (result) => {
       const name = result.split(' | ')
       if (name[1]) {
         return name[0] && name[0] + '<span class="autocomplete__option-hint">' + name[1] + '</span>'
@@ -117,7 +117,7 @@
       }
       
     }
-  }
+
 
   accessibleAutocomplete.enhanceSelectElement({
     selectElement: element,
@@ -126,7 +126,9 @@
     minLength: minLength,
     // source: values,
     defaultValue: defaultValue,
-    templates: template
+    templates: {
+      inputValue,
+      suggestion}
 
   });
     // onConfirm: confirmFunction


### PR DESCRIPTION
My previous autocomplete PR (#118) accidentally broke it when there were more than one autocomplete on a page as it was redefining consts. This changes them to vars so they just get overwritten. It's a bit wasteful but fine for a prototype.