### PR TITLE
Show route as row in summary lists

### DIFF
--- a/app/views/_includes/forms/programme-details/pick-course.html
+++ b/app/views/_includes/forms/programme-details/pick-course.html
@@ -5,11 +5,11 @@
 {% if record.programmeDetails.isPublishCourse | falsify %}
   {% set selectedCourse = record.programmeDetails.id %}
 {% elseif record.programmeDetails %}
-  {% set selectedCourse = record.programmeDetails.route %}
+  {# Todo: stop storing route in two places #}
+  {% set selectedCourse = record.programmeDetails.route or record.route %}
+{% else %}
+  {% set selectedCourse = record.route %}
 {% endif %}
-
-{% set test = {selectedCourse: selectedCourse} %}
-
 
 {% set courseItems = [] %}
 
@@ -31,13 +31,10 @@
   {% set courseItems = courseItems | push({
     value: route,
     text: route | lower | prependWithAOrAn | sentenceCase + " course",
-    checked: checked(selectedCourse, course.id)
+    checked: checked(selectedCourse, route)
   }) %}
 {% endfor %}
-{% set courseItems = courseItems | push({text: "Other"}) %}
-
-
-
+{% set courseItems = courseItems | push({text: "Other"}) %}s
 
 {{ govukRadios({
   fieldset: {

--- a/app/views/_includes/summary-cards/programme-details/assessment-only.html
+++ b/app/views/_includes/summary-cards/programme-details/assessment-only.html
@@ -7,6 +7,23 @@
 {% set programmeDetailsRows = [
   {
     key: {
+      text: "Training course"
+    },
+    value: {
+      text: record.route | safe or 'Not provided'
+    },
+    actions: {
+      items: [
+        {
+          href: recordPath + "/programme-details" | addReferrer(referrer),
+          text: "Change",
+          visuallyHiddenText: "training course"
+        }
+      ]
+    } if canAmend
+  },
+  {
+    key: {
       text: "Subject"
     },
     value: {

--- a/app/views/_includes/summary-cards/programme-details/provider-led.html
+++ b/app/views/_includes/summary-cards/programme-details/provider-led.html
@@ -7,6 +7,23 @@
 {% set programmeDetailsRows = [
   {
     key: {
+      text: "Training course"
+    },
+    value: {
+      text: record.route | safe or 'Not provided'
+    },
+    actions: {
+      items: [
+        {
+          href: recordPath + "/programme-details" | addReferrer(referrer),
+          text: "Change",
+          visuallyHiddenText: "training course"
+        }
+      ]
+    } if canAmend
+  },
+  {
+    key: {
       text: "Subject"
     },
     value: {


### PR DESCRIPTION
Adds a row to the programme details summary cards - this makes the route more obvious, but also means you can now change route on existing records.