### PR TITLE
Don't filter records that don't have a route

### DIFF
--- a/app/routes/records-list.js
+++ b/app/routes/records-list.js
@@ -38,7 +38,7 @@ module.exports = router => {
 
     // Only show records for training routes that are enabled
     let enabledTrainingRoutes = data.settings.enabledTrainingRoutes
-    filteredRecords = filteredRecords.filter(record => enabledTrainingRoutes.includes(record.route))
+    filteredRecords = filteredRecords.filter(record => enabledTrainingRoutes.includes(record.route) || (record.route == undefined))
 
     // Search traineeId and full name
     if (searchQuery){


### PR DESCRIPTION
The records list filters out routes that aren't enabled - as a byproduct drafts with no route yet set were getting filtered. This lets things through where the route is `undefined`.