### PR TITLE
Use route rather than qualifications in hint

### DIFF
--- a/app/views/_includes/forms/programme-details/pick-course.html
+++ b/app/views/_includes/forms/programme-details/pick-course.html
@@ -20,7 +20,7 @@
     checked: checked(selectedCourse, course.id),
     hint: {
       _text: course.route + " — " + course.summary,
-      text: course.summary
+      text: course.route
     }
   }) %}
 {% endfor %}


### PR DESCRIPTION
Showing the qualifications with the publish data didn't seem to be much help for our participants - but they referred to the route quite a lot - this swaps to showing that instead.

<img width="593" alt="Screenshot 2020-11-26 at 18 01 36" src="https://user-images.githubusercontent.com/2204224/100381726-80e4fd00-3011-11eb-93ed-7ce59d32800a.png">
