### PR TITLE
Clean up headings

### DIFF
--- a/app/views/_includes/record-sub-nav.njk
+++ b/app/views/_includes/record-sub-nav.njk
@@ -3,7 +3,7 @@
   label: 'Sub navigation',
   classes: 'govuk-!-margin-bottom-4',
   items: [{
-    text: 'Trainee details',
+    text: 'Training record',
     href: recordPath,
     active: (activeTab == "trainee-details")
   },

--- a/app/views/_includes/summary-cards/programme-details/assessment-only.html
+++ b/app/views/_includes/summary-cards/programme-details/assessment-only.html
@@ -128,7 +128,7 @@
 
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
-    titleText: record.route + " programme details",
+    titleText: "Programme details",
     html: programmeDetailsHtml
   }) }}
   

--- a/app/views/_includes/summary-cards/programme-details/provider-led.html
+++ b/app/views/_includes/summary-cards/programme-details/provider-led.html
@@ -144,7 +144,7 @@
 
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
-    titleText: record.route + " programme details",
+    titleText: "Programme details",
     html: programmeDetailsHtml
   }) }}
   

--- a/app/views/_includes/summary-cards/programme-details/publish-course.html
+++ b/app/views/_includes/summary-cards/programme-details/publish-course.html
@@ -201,7 +201,7 @@
 {% else %}
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
-    titleText: programmeDetails.route + " programme details",
+    titleText: "Progamme details",
     html: programmeDetailsHtml
   }) }}
   

--- a/app/views/_includes/summary-cards/student-record.html
+++ b/app/views/_includes/summary-cards/student-record.html
@@ -172,8 +172,6 @@
 {% endset %}
 
 {% set traineeStarted = record.trainingDetails.traineeStarted | falsify %}
-{{traineeStarted | log}}
-{{record | log}}
 
 {% set commencementDateLabel %}
   {% if traineeStarted %}

--- a/app/views/new-record/check-record.html
+++ b/app/views/new-record/check-record.html
@@ -54,12 +54,10 @@
   </div>
 </div>
 
-<h2 class="govuk-heading-m">Training details</h2>
-{% include "_includes/summary-cards/record-setup.html" %}
-{% include "_includes/summary-cards/training-details.html" %}
-{% include "_includes/summary-cards/programme-details.html" %}
 
-<h2 class="govuk-heading-m">About the trainee</h2>
+
+
+<h2 class="govuk-heading-m">Personal details and education</h2>
 
 
 {% include "_includes/summary-cards/personal-details.html" %}
@@ -72,6 +70,10 @@
 
 {% include "_includes/summary-cards/degree-details.html" %}
 
+<h2 class="govuk-heading-m">Training details</h2>
+{% include "_includes/summary-cards/record-setup.html" %}
+{% include "_includes/summary-cards/programme-details.html" %}
+{% include "_includes/summary-cards/training-details.html" %}
 
 
 

--- a/app/views/new-record/overview.html
+++ b/app/views/new-record/overview.html
@@ -20,41 +20,8 @@
 <h1 class="govuk-heading-l govuk-!-margin-bottom-8">{{pageHeading}}</h1>
 
 
-<h2 class="govuk-heading-m">Training details</h2>
 
-{{ appTaskList({
-  classes: "govuk-!-margin-bottom-8",
-  items: [{
-    text: "Type of training",
-    href: "record-setup",
-    id: "record-type",
-    tag: {
-      classes: 'Completed' | getStatusClass,
-      text: 'Completed'
-    }
-  } if record | requiresSection("recordSetup"),
-  {
-    text: "Training details",
-    href: "training-details" | reviewIfInProgress(record.trainingDetails),
-    id: "training-details",
-    tag: {
-      classes: record.trainingDetails | getStatusText | getStatusClass,
-      text: record.trainingDetails | getStatusText
-    }
-  } if record | requiresSection("trainingDetails"),
-  {
-    text: "Programme details",
-    href: "programme-details" | reviewIfInProgress(record.programmeDetails),
-    id: "programme-details",
-    tag: {
-      classes: record.programmeDetails | getStatusText | getStatusClass,
-      text: record.programmeDetails | getStatusText
-    }
-  } if record | requiresSection("programmeDetails")
-  ]
-}) if not closed }}
-
-<h2 class="govuk-heading-m">About the trainee</h2>
+<h2 class="govuk-heading-m">Personal details and education</h2>
 {{ appTaskList({
   classes: "govuk-!-margin-bottom-8",
   items: [{
@@ -102,6 +69,41 @@
       text: record.degree | getStatusText
     }
   } if record | requiresSection("degree")
+  ]
+}) if not closed }}
+
+
+<h2 class="govuk-heading-m">Training record</h2>
+
+{{ appTaskList({
+  classes: "govuk-!-margin-bottom-8",
+  items: [{
+    text: "Type of training",
+    href: "record-setup",
+    id: "record-type",
+    tag: {
+      classes: 'Completed' | getStatusClass,
+      text: 'Completed'
+    }
+  } if record | requiresSection("recordSetup"),
+  {
+    text: "Programme details",
+    href: "programme-details" | reviewIfInProgress(record.programmeDetails),
+    id: "programme-details",
+    tag: {
+      classes: record.programmeDetails | getStatusText | getStatusClass,
+      text: record.programmeDetails | getStatusText
+    }
+  } if record | requiresSection("programmeDetails"),
+  {
+    text: "Training details",
+    href: "training-details" | reviewIfInProgress(record.trainingDetails),
+    id: "training-details",
+    tag: {
+      classes: record.trainingDetails | getStatusText | getStatusClass,
+      text: record.trainingDetails | getStatusText
+    }
+  } if record | requiresSection("trainingDetails")
   ]
 }) if not closed }}
 

--- a/app/views/record.html
+++ b/app/views/record.html
@@ -59,9 +59,9 @@
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     {% endif %}
 
-    <h2 class="govuk-heading-m">Trainee record</h2>
+    {# <h2 class="govuk-heading-m">Trainee record</h2> #}
     {% include "_includes/summary-cards/student-record.html" %}
-    <h2 class="govuk-heading-m">Programme details</h2>
+    {# <h2 class="govuk-heading-m">Programme details</h2> #}
     {% include "_includes/summary-cards/programme-details.html" %}
 
   </div>

--- a/app/views/record/details-and-education.html
+++ b/app/views/record/details-and-education.html
@@ -9,28 +9,19 @@
 
   {% set referrer = recordPath + "/details-and-education" %}
 
-  <h2 class="govuk-heading-m">Trainee details</h2>
-
   {% include "_includes/summary-cards/personal-details.html" %}
 
   {% include "_includes/summary-cards/contact-details.html" %}
 
   {% include "_includes/summary-cards/diversity.html" %}
 
-  <h2 class="govuk-heading-m">Education</h2>
-
   {% include "_includes/summary-cards/gcse-details.html" %}
 
-  <h3 class="govuk-heading-s">{{ "Degree" | pluralise(record.qualifications.degree | length)}}</h3>
-  {# {% for degree in record.qualifications.degree %} #}
   {% include "_includes/summary-cards/degree-details.html" %}
-  {# {% endfor %} #}
-  {{record | log}}
 
-  {# {{record | log}} #}
   {% set degreeCount = record.qualifications.degree | length %}
 
-   <div class="govuk-form-group">
+  <div class="govuk-form-group">
     {{ govukButton({
       "text": "Add another degree" if degreeCount > 0 else "Add a degree",
       href: recordPath + "/degree/add",


### PR DESCRIPTION
Clean up headings on records with @EmmaFrith 

* Swap personal details and training record sections in task list (helps to have name collected first)
* Make section titles match tabs on completed records.
* Remove some of the headings from existing records - which seemed a bit repetitive.