### PR TITLE
Show banner when no degrees on a record

### DIFF
--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -240,8 +240,9 @@ module.exports = router => {
       _.pullAt(data.record.degree.items, [degreeIndex]) //delete item at index
       // Clear data if there are no more degrees - so the task list thinks the section is not started
       req.flash('success', 'Trainee degree deleted')
+      // Delete degree section if it’s empty
       if (data.record.degree.items.length == 0){
-        delete data.record.degree.items
+        delete data.record.degree
       }
     }
     if (referrer){

--- a/app/views/_includes/summary-cards/degree-details.html
+++ b/app/views/_includes/summary-cards/degree-details.html
@@ -24,6 +24,16 @@
 
 {% else %}
 
+  {# Show a banner on existing records when last degree deleted #}
+  {# TODO: should this reuse the 'incomplete' above?
+  done separately as seed records don't have 'complete' as a concept #}
+  {% if degrees | length == 0 %}
+    {% set incompleteText = "Degree details not provided" %}
+    {% set incompleteLink = recordPath + "/degree/add" | addReferrer(referrer) %}
+    {% set incompleteLinkText = "Add degree details" %}
+    {% include "_includes/incomplete.njk" %}
+  {% endif %}
+
   {% for degree in degrees %}
     {% include "_includes/summary-cards/single-degree-details.html" %}
   {% endfor %}

--- a/app/views/record/details-and-education.html
+++ b/app/views/record/details-and-education.html
@@ -19,14 +19,16 @@
 
   {% include "_includes/summary-cards/degree-details.html" %}
 
-  {% set degreeCount = record.qualifications.degree | length %}
+  {% set degreeCount = record.degree.items | length %}
 
-  <div class="govuk-form-group">
-    {{ govukButton({
-      "text": "Add another degree" if degreeCount > 0 else "Add a degree",
-      href: recordPath + "/degree/add",
-      classes: "govuk-button--secondary"
-    }) }}
-  </div>
+  {% if degreeCount %}
+    <div class="govuk-form-group">
+      {{ govukButton({
+        text: "Add another degree",
+        href: recordPath + "/degree/add",
+        classes: "govuk-button--secondary"
+      }) }}
+    </div>
+  {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
We allow users to delete degrees from trainees' profiles. When all degrees are deleted this leaves the 'Add a degree' button oddly placed against another section - it's not clear that anything is missing.

Instead, show a banner when there are no degrees on a record:
![Screenshot 2020-12-07 at 14 53 02](https://user-images.githubusercontent.com/2204224/101365606-ee0f5280-389b-11eb-844f-6d786db6af4a.png)

Before:
![Screenshot 2020-12-07 at 14 51 30](https://user-images.githubusercontent.com/2204224/101365626-f4053380-389b-11eb-91aa-b1c1fa7dc6a5.png)
