### PR TITLE
Content changes following ur

### DIFF
--- a/app/views/_includes/record-sub-nav.njk
+++ b/app/views/_includes/record-sub-nav.njk
@@ -3,7 +3,7 @@
   label: 'Sub navigation',
   classes: 'govuk-!-margin-bottom-4',
   items: [{
-    text: 'Training record',
+    text: 'About their training',
     href: recordPath,
     active: (activeTab == "trainee-details")
   },

--- a/app/views/_includes/summary-cards/student-record.html
+++ b/app/views/_includes/summary-cards/student-record.html
@@ -177,7 +177,7 @@
   {% if traineeStarted %}
     {{(record.trainingDetails.commencementDate | govukDate) or 'Not provided'}}
   {% else %}
-    Trainee yet to start course 
+    Trainee yet to start course
   {% endif %}
 {% endset %}
 
@@ -226,6 +226,6 @@
 
 {{ appSummaryCard({
   classes: "govuk-!-margin-bottom-6",
-  titleText: "Training details",
+  titleText: "Trainee progress",
   html: studentRecordHtml
 }) }}

--- a/app/views/_includes/summary-cards/training-details.html
+++ b/app/views/_includes/summary-cards/training-details.html
@@ -82,8 +82,8 @@
 
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
-    titleText: "Training details",
+    titleText: "Trainee start date and ID",
     html: trainingDetailsHtml
   }) }}
-  
+
 {% endif %}

--- a/app/views/data-requirements.html
+++ b/app/views/data-requirements.html
@@ -129,7 +129,7 @@
 
     <h2 class='govuk-heading-m'>Allocations information</h2>
 
-    <p class="govuk-body">If the course has allocated places, you'll need to know whether the trainee is using an allocated place.</p>
+    <p class="govuk-body">If the course has allocated places, you’ll need to know whether the trainee is using an allocated place.</p>
 
   </div>
 </div>

--- a/app/views/data-requirements.html
+++ b/app/views/data-requirements.html
@@ -69,7 +69,7 @@
 
     <h2 class='govuk-heading-m'>Degrees</h2>
 
-    <h3 class='govuk-heading-s'>If it's a UK degree</h3>
+    <h3 class='govuk-heading-s'>If it’s a UK degree</h3>
 
     <ul class='govuk-list'>
       <li>

--- a/app/views/data-requirements.html
+++ b/app/views/data-requirements.html
@@ -10,7 +10,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-9">{{pageHeading}}</h1>
 
-    <p class='govuk-body'>You'll need the following information about a trainee to complete their record.</p>
+    <p class='govuk-body'>You’ll need the following information about a trainee to complete their record.</p>
 
     <h2 class="govuk-heading-m">Personal details</h2>
 

--- a/app/views/data-requirements.html
+++ b/app/views/data-requirements.html
@@ -8,194 +8,129 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">{{pageHeading}}</h1>
-    <ul class="govuk-list govuk-list--dash govuk-!-margin-bottom-8">
-      <li><a class="govuk-link" href="#section-all-routes">Standard data for all trainees</a></li>
-      <li><a class="govuk-link" href="#section-assessment-only">Specific data for assessment-only candidates</a></li>
-      <li><a class="govuk-link" href="#section-provider-led">Specific data for provider-led trainees</a></li>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-9">{{pageHeading}}</h1>
+
+    <p class='govuk-body'>You'll need the following information about a trainee to complete their record.</p>
+
+    <h2 class="govuk-heading-m">Personal details</h2>
+
+    <ul class='govuk-list'>
+      <li>
+        First names
+      </li>
+      <li>
+        Middle names
+      </li>
+      <li>
+        Last or family name
+      </li>
+      <li>
+        Date of birth
+      </li>
+      <li>
+        Gender
+      </li>
+      <li>
+        Nationality
+      </li>
     </ul>
-  </div>
-</div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <section id="section-all-routes">
-      {{ govukTable({
-        caption: "Data requirements",
-        captionClasses: "govuk-visually-hidden",
-        head: [
-          {
-            text: "Standard data for all trainees",
-			classes: "govuk-heading-m"
-          }
-        ],
-        rows: [
-          [
-            {
-              html: "
-              <h2 class='govuk-heading-s'>Personal details</h2>
-              <ul class='govuk-list'>
-                <li>
-                  First or given names
-                </li>
-                <li>
-                  Middle names
-                </li>
-                <li>
-                  Last or family name
-                </li>
-                <li>
-                  Date of birth
-                </li>
-                <li>
-                  Gender
-                </li>
-                <li>
-                  Nationality
-                </li>
-              </ul>
-              "
-            }
-          ],
-          [
-            {
-              html: "
-              <h2 class='govuk-heading-s'>Contact details</h2>
-              <ul class='govuk-list'>
-                <li>
-                  Address
-                </li>
-                <li>
-                  Phone number
-                </li>
-                <li>
-                  Email address
-                </li>
-              </ul>
-              "
-            }
-          ],
-          [
-            {
-              html: "
-              <h2 class='govuk-heading-s'>Diversity information (optional)</h2>
-              <p class='govuk-body'>If the trainee chose not to share diversity information during the application process, you should not ask them for it for the purpose of registering them.</p>
-              <ul class='govuk-list'>
-                <li>
-                  Ethnicity
-                </li>
-                <li>
-                  Disability
-                </li>
-              </ul>
-              "
-            }
-          ],
-          [
-            {
-              html: "
-              <h2 class='govuk-heading-s'>UK degrees</h2>
-              <ul class='govuk-list'>
-                <li>
-                  Type, for example, BA, BSc or other
-                </li>
-                <li>
-                  Subject
-                </li>
-                <li>
-                  Institution
-                </li>
-                <li>
-                  Graduation year
-                </li>
-                <li>
-                  Grade
-                </li>
-              </ul>
-              "
-            }
-          ],
-          [
-            {
-              html: "
-              <h2 class='govuk-heading-s'>Non-UK degrees</h2>
-              <ul class='govuk-list'>
-                <li>
-                  NARIC comparable UK degree (if provided)
-                </li>
-                <li>
-                  Degree subject
-                </li>
-                <li>
-                  Country where the degree was obtained
-                </li>
-                <li>
-                  Graduation year
-                </li>
-              </ul>
-              "
-            }
-          ]
-        ]
-      }) }}
-    </section>
-    <section id="section-assessment-only">
-      {{ govukTable({
-        caption: "Data requirements",
-        captionClasses: "govuk-visually-hidden",
-        head: [
-          {
-            text: "Specific data for assessment-only candidates",
-			classes: "govuk-heading-m"
-          }
-        ],
-        rows: [
-          [
-            {
-              html: "
-              <h2 class='govuk-heading-s'>Programme details</h2>
-              <ul class='govuk-list'>
-                <li>
-                  Subject
-                </li>
-                <li>
-                  Age range
-                </li>
-                <li>
-                  Start date
-                </li>
-                <li>
-                  End date (to recommend for QTS)
-                </li>
-              </ul>
-              "
-            }
-          ]
-        ]
-      }) }}
-    </section>
-    <section id="section-provider-led">
-      {{ govukTable({
-        caption: "Data requirements",
-        captionClasses: "govuk-visually-hidden",
-        head: [
-          {
-            text: "Specific data for provider-led trainees",
-			classes: "govuk-heading-m"
-          }
-        ],
-        rows: [
-          [
-            {
-              html: "
-              <h2 class='govuk-heading-s'>This is a placeholder for provider-led trainee data</h2>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-              "
-            }
-          ]
-        ]
-      }) }}
-    </section>
+    <h2 class='govuk-heading-m'>Contact details</h2>
+
+    <ul class='govuk-list'>
+      <li>
+        Address
+      </li>
+      <li>
+        Email address
+      </li>
+    </ul>
+
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <h2 class='govuk-heading-m'>Diversity information (optional)</h2>
+
+    <div class="govuk-inset-text">
+      If the trainee chose not to share this information during the application process, do not ask for it for the purpose of registering them.
+    </div>
+
+    <ul class='govuk-list'>
+      <li>
+        Ethnicity
+      </li>
+      <li>
+        Disability
+      </li>
+    </ul>
+
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <h2 class='govuk-heading-m'>Degrees</h2>
+
+    <h3 class='govuk-heading-s'>If it's a UK degree</h3>
+
+    <ul class='govuk-list'>
+      <li>
+        Type (for example, BA, BSc or other)
+      </li>
+      <li>
+        Subject
+      </li>
+      <li>
+        Institution
+      </li>
+      <li>
+        Graduation year
+      </li>
+      <li>
+        Grade
+      </li>
+    </ul>
+
+    <h3 class='govuk-heading-s'>If it's not a UK degree</h3>
+
+    <ul class='govuk-list'>
+      <li>
+        NARIC comparable UK degree (if provided)
+      </li>
+      <li>
+        Subject
+      </li>
+      <li>
+        Country where the degree was obtained
+      </li>
+      <li>
+        Graduation year
+      </li>
+    </ul>
+
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <h2 class='govuk-heading-m'>Course or programme details</h2>
+
+    <ul class='govuk-list'>
+      <li>
+        Subject
+      </li>
+      <li>
+        Age range
+      </li>
+      <li>
+        Start date
+      </li>
+      <li>
+        End date
+      </li>
+    </ul>
+
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <h2 class='govuk-heading-m'>Allocations information</h2>
+
+    <p class="govuk-body">If the course has allocated places, you'll need to know whether the trainee is using an allocated place.</p>
+
   </div>
 </div>
 

--- a/app/views/data-requirements.html
+++ b/app/views/data-requirements.html
@@ -89,7 +89,7 @@
       </li>
     </ul>
 
-    <h3 class='govuk-heading-s'>If it's not a UK degree</h3>
+    <h3 class='govuk-heading-s'>If it’s not a UK degree</h3>
 
     <ul class='govuk-list'>
       <li>

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -34,7 +34,7 @@
       {% endif %}
       <div class="govuk-grid-column-one-third">
         <h2 class="govuk-heading-m"><a href="/data-requirements" class="govuk-link govuk-link--no-visited-state">Check what data you need</a></h2>
-        <p class="govuk-body">The data you need to register your trainees.</p>
+        <p class="govuk-body">The data you need to complete a trainee record.</p>
       </div>
 
     </div>
@@ -77,5 +77,3 @@
 
 
 {% endblock %}
-
-

--- a/app/views/new-record/check-record.html
+++ b/app/views/new-record/check-record.html
@@ -70,7 +70,7 @@
 
 {% include "_includes/summary-cards/degree-details.html" %}
 
-<h2 class="govuk-heading-m">Training details</h2>
+<h2 class="govuk-heading-m">About their training</h2>
 {% include "_includes/summary-cards/record-setup.html" %}
 {% include "_includes/summary-cards/programme-details.html" %}
 {% include "_includes/summary-cards/training-details.html" %}

--- a/app/views/new-record/overview.html
+++ b/app/views/new-record/overview.html
@@ -73,7 +73,7 @@
 }) if not closed }}
 
 
-<h2 class="govuk-heading-m">Training record</h2>
+<h2 class="govuk-heading-m">About their training</h2>
 
 {{ appTaskList({
   classes: "govuk-!-margin-bottom-8",
@@ -96,7 +96,7 @@
     }
   } if record | requiresSection("programmeDetails"),
   {
-    text: "Training details",
+    text: "Trainee start date and ID",
     href: "training-details" | reviewIfInProgress(record.trainingDetails),
     id: "training-details",
     tag: {

--- a/app/views/new-record/training-details/confirm.html
+++ b/app/views/new-record/training-details/confirm.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_new-record.html" %}
 
-{% set pageHeading = "Confirm training details" %}
+{% set pageHeading = "Confirm trainee start date and ID" %}
 {% set backLink = './../overview' %}
 {% set backText = "Back to draft record" %}
 {% set gridColumn = 'govuk-grid-column-full' %}
@@ -29,4 +29,3 @@
   }) }}
 
 {% endblock %}
-

--- a/app/views/new-record/training-details/index.html
+++ b/app/views/new-record/training-details/index.html
@@ -1,10 +1,9 @@
 {% extends "_templates/_new-record.html" %}
 
-{% set pageHeading = "Training details" %}
+{% set pageHeading = "Trainee start date and ID" %}
 
 {# {% set formAction = "./training-details/confirm" %} #}
 
 {% block formContent %}
   {% include "_includes/forms/training-details.html" %}
 {% endblock %}
-

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -63,7 +63,7 @@
     <p class="govuk-body">Use this service to:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>register trainee data with the Department for Education, and keep it updated</li>
-      <li>get a teacher reference number (TRN) for your trainees</li>
+      <li>request a teacher reference number (TRN) for your trainees</li>
       <li>share information about a trainee’s progress, such as whether they withdraw or defer</li>
       <li>recommend your trainees for qualified teacher status (QTS) or early years teacher status (EYTS)</li>
     </ul>


### PR DESCRIPTION
**change 'get' to 'request' …**

- the expectations were not clearly set for one provider. they thought by logging in they'd get a list of TRN numbers. 
 
**change content and formatting in data requirements section …**

- change formatting (existing formatting was used to create different sections for different teaching routes - but we're finding that the data requirements for each route are more or less the same - table not really required
- remove phone number as no longer required
- use 'complete their record' rather than 'register them', because some data might not be needed to initially register someone
- remove 'given names' for consistency in other areas
- put UK and non-UK degrees in one section with 'if' options, as they're variables within the same requirement 
- use inset text to differentiate supporting guidance from data requirements list
- add a section about allocations, as this is needed for some routes 

**training record doesn't work …**

- use 'about their training' in task list and review pages, because it's confusing to use both 'training record' (currently in the task list) AND 'trainee records' (currently describes the list of trainees)
- change section heading 'training details' and relevant confirm/review content so it's clearer what this section is about
- use 'trainee progress' as a catch all for now when reviewing existing records

