### PR TITLE
swap sign in and get started

### DIFF
--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -41,7 +41,7 @@
               isStartButton: true
             }) }}
             <p class="govuk-body start-page-banner__text">or
-            <a class="govuk-link govuk-link--no-visited-state" href="/home">request access if you have not used this service before</a></p>
+            <a class="govuk-link govuk-link--no-visited-state" href="/home">request an account</a></p>
           </div>
 
         </div>

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -36,7 +36,7 @@
           <div class="start-page-banner__actions">
             {{ govukButton({
               text: "Sign in",
-              href: "sign-in",
+              href: "/sign-in",
               classes: "start-page-banner__button",
               isStartButton: true
             }) }}

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -35,14 +35,13 @@
           <p class="start-page-banner__text start-page-banner__description govuk-body govuk-!-font-size-27">Register trainees with the Department for Education and record the outcome of their training.</p>
           <div class="start-page-banner__actions">
             {{ govukButton({
-              text: "Get started",
-              href: "/home",
+              text: "Sign in",
+              href: "sign-in",
               classes: "start-page-banner__button",
               isStartButton: true
             }) }}
             <p class="govuk-body start-page-banner__text">or
-            <a class="govuk-link govuk-link--no-visited-state" href="sign-in">sign in</a>
-            if you’ve used it before</p>
+            <a class="govuk-link govuk-link--no-visited-state" href="/home">request access if you have not used this service before</a></p>
           </div>
 
         </div>


### PR DESCRIPTION
More users will eventually be "signing in" than "getting started". The more clear call to action should be tailored to the majority of users. 

**Before**

![Screenshot 2020-12-08 at 12 13 54](https://user-images.githubusercontent.com/56349171/101482627-e78de300-394e-11eb-9ab4-65d37e76fa56.png)

**After** 

![Screenshot 2020-12-08 at 12 45 37](https://user-images.githubusercontent.com/56349171/101485584-48b7b580-3953-11eb-9005-71612bdcb448.png)
