### PR TITLE
uppercase versus lowercase

### DIFF
--- a/app/views/sign-in.html
+++ b/app/views/sign-in.html
@@ -4,7 +4,7 @@
 {% set hideNav = true %}
 {% set hidePrimaryNav = true %}
 
-{% set pageHeading = 'Sign in to Register trainee teachers' %}
+{% set pageHeading = 'Sign in to register trainee teachers' %}
 
 {% block content %}
 
@@ -13,14 +13,14 @@
 
     <h1 class="govuk-heading-l">{{pageHeading}}</h1>
 
-    <p class="govuk-body">Use DfE Sign-in to access your account.</p>
+    <p class="govuk-body">Use DfE Sign-in to access your Register account.</p>
 
     {{ govukButton({
       "text": "Continue to DfE Sign-in",
       href: 'declaration' if data.settings.includeDeclaration else 'home'
     }) }}
 
-    <p class="govuk-body">If you do not have a DfE Sign-in account but need access to Register trainee teachers, email <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Get%20access%20to%20Register%20trainee%20teachers">becomingateacher@digital.education.gov.uk</a>.</p>
+    <p class="govuk-body">If you do not have a DfE Sign-in account but need access to this service, email <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Get%20access%20to%20Register%20trainee%20teachers">becomingateacher@digital.education.gov.uk</a>.</p>
 
   </div>
 </div>


### PR DESCRIPTION
@johndoates pointed out to me the other day that we have to tendency to not utilise our service names as verbs, continually repeating the service name as a proper noun rather than a verb, resulting in a seemingly random capital letter mid sentence 

up for trying a different approach, so have used the service name as a verb in this heading

![Screenshot 2020-12-08 at 13 05 54](https://user-images.githubusercontent.com/56349171/101487462-1c516880-3956-11eb-806f-d73068cc78f0.png)
