### PR TITLE
Add links from different parts of the service to the provider feedback form

### DIFF
--- a/app/views/home.html
+++ b/app/views/home.html
@@ -33,7 +33,7 @@
         </div>
       {% endif %}
       <div class="govuk-grid-column-one-third">
-        <h2 class="govuk-heading-m"><a href="https://docs.google.com/forms/d/e/1FAIpQLSfhdvlUkg7oxPjl1C6FcJ2pnlc1OQ82r7o3ZMNKthhVAt_h5g/viewform" class="govuk-link govuk-link--no-visited-state">Give feedback</a></h2>
+        <h2 class="govuk-heading-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Give feedback</a></h2>
         <p class="govuk-body">This is a new service. Your views will help us improve it.</p>
       </div>
       <div class="govuk-grid-column-one-third">

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -33,6 +33,10 @@
         </div>
       {% endif %}
       <div class="govuk-grid-column-one-third">
+        <h2 class="govuk-heading-m"><a href="https://docs.google.com/forms/d/e/1FAIpQLSfhdvlUkg7oxPjl1C6FcJ2pnlc1OQ82r7o3ZMNKthhVAt_h5g/viewform" class="govuk-link govuk-link--no-visited-state">Give feedback</a></h2>
+        <p class="govuk-body">This is a new service. Your views will help us improve it.</p>
+      </div>
+      <div class="govuk-grid-column-one-third">
         <h2 class="govuk-heading-m"><a href="/data-requirements" class="govuk-link govuk-link--no-visited-state">Check what data you need</a></h2>
         <p class="govuk-body">The data you need to complete a trainee record.</p>
       </div>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -124,7 +124,7 @@
     text: "prototype"
   },
   classes: 'govuk-!-margin-top-1',
-  html: 'This is a prototype of a new service. <a href="https://docs.google.com/forms/d/e/1FAIpQLSfhdvlUkg7oxPjl1C6FcJ2pnlc1OQ82r7o3ZMNKthhVAt_h5g/viewform?usp=sf_link" class="govuk-link">Give feedback to help us improve this service</a>.'
+  html: 'This is a prototype of a new service. <a href="#" class="govuk-link">Give feedback to help us improve this service</a>.'
 }) }}
 {% block pageNavigation %}
 {% endblock %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -101,7 +101,7 @@
     ] %}
 
   {% if not hidePrimaryNav %}
-  
+
     {% if data.settings.useDarkHeader %}
       {{ appPrimaryNavigationDark({
         label: 'Primary navigation',
@@ -115,7 +115,7 @@
     {% endif %}
 
   {% endif %}
-  
+
 {% endblock %}
 
 {% block beforeContent %}
@@ -124,7 +124,7 @@
     text: "prototype"
   },
   classes: 'govuk-!-margin-top-1',
-  html: 'This is a prototype of a new service. Some parts of this prototype do not work yet.'
+  html: 'This is a prototype of a new service. <a href="https://docs.google.com/forms/d/e/1FAIpQLSfhdvlUkg7oxPjl1C6FcJ2pnlc1OQ82r7o3ZMNKthhVAt_h5g/viewform?usp=sf_link" class="govuk-link">Give feedback to help us improve this service</a>.'
 }) }}
 {% block pageNavigation %}
 {% endblock %}

--- a/app/views/new-record/submitted.html
+++ b/app/views/new-record/submitted.html
@@ -8,8 +8,6 @@
 {% set backLink = '/records' %}
 {% set backText = 'All records' %}
 
-
-
 {% block formContent %}
 
 {# For this one page, we no longer have record in session data, so have to look it up #}
@@ -39,9 +37,13 @@
 
 <p class="govuk-body govuk-!-margin-bottom-9">or <a href="/records" class="govuk-link">check trainee statuses and manage records</a></p>
 
-<div class="govuk-inset-text">
-  <h2 class="govuk-heading-s govuk-!-margin-bottom-3">How are you finding this process?</h2>
-  <p class="govuk-body"><a href="/records" class="govuk-link">Give feedback to help make the trainee registration process better</a></p>
-</div>
+{% set insetTextHtml %}
+  <h2 class="govuk-heading-s">How are you finding this process?</h2>
+  <p class="govuk-body"><a href="#" class="govuk-link">Give feedback to help make the trainee registration process better</a></p>
+{% endset %}
+
+{{ govukInsetText({
+  html: insetTextHtml
+}) }}
 
 {% endblock %}

--- a/app/views/new-record/submitted.html
+++ b/app/views/new-record/submitted.html
@@ -37,6 +37,11 @@
   href: "/new-record/new"
 }) }}
 
-<p class="govuk-body">or <a href="/records" class="govuk-link">check trainee statuses and manage records</a> </p>
+<p class="govuk-body govuk-!-margin-bottom-9">or <a href="/records" class="govuk-link">check trainee statuses and manage records</a></p>
+
+<div class="govuk-inset-text">
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-3">How are you finding this process?</h2>
+  <p class="govuk-body"><a href="/records" class="govuk-link">Give feedback to help make the trainee registration process better</a></p>
+</div>
 
 {% endblock %}

--- a/app/views/record/qts/passed/recommended.html
+++ b/app/views/record/qts/passed/recommended.html
@@ -19,7 +19,7 @@
 
 <p class="govuk-body">The Department for Education will award QTS where appropriate within 3 working days.</p>
 
-<p class="govuk-body"><a href="/records" class="govuk-link">Check trainee statuses from your list of records</a>.</p>
+<p class="govuk-body govuk-!-margin-bottom-9"><a href="/records" class="govuk-link">Check trainee statuses from your list of records</a></p>
 
 {# {{ govukButton({
   text: "View record",
@@ -31,5 +31,14 @@
   href: "/new-record/new"
 }) }}
  #}
+
+ {% set insetTextHtml %}
+   <h2 class="govuk-heading-s">How are you finding this process?</h2>
+   <p class="govuk-body"><a href="#" class="govuk-link">Give feedback to help improve the process of recommending trainees for QTS</a></p>
+ {% endset %}
+
+ {{ govukInsetText({
+   html: insetTextHtml
+ }) }}
 
 {% endblock %}


### PR DESCRIPTION
Add links to the provider feedback form from:

- home page (for visibility)
- beta banner (so it can be seen no matter where you are in the service)
- after submitting a trainee for TRN (so it's after a meaningful action)
- after submitting a trainee for QTS (so it's after a meaningful action)

![Screenshot 2020-12-11 at 17 44 11](https://user-images.githubusercontent.com/56349171/101936450-7bbeab00-3bd8-11eb-8a69-45ac54cdb29e.png)

![Screenshot 2020-12-11 at 17 44 41](https://user-images.githubusercontent.com/56349171/101936513-8ed17b00-3bd8-11eb-8818-1564a754d1fa.png)

![Screenshot 2020-12-11 at 17 45 47](https://user-images.githubusercontent.com/56349171/101936641-b4f71b00-3bd8-11eb-8120-8dde67f3751c.png)

![Screenshot 2020-12-14 at 11 51 17](https://user-images.githubusercontent.com/56349171/102078341-b0ae4600-3e02-11eb-8dfe-f97b21171bc1.png)
