### PR TITLE
Hiding the failure options from the training outcome flow

### DIFF
--- a/app/views/_includes/summary-cards/qts-assessment-details.html
+++ b/app/views/_includes/summary-cards/qts-assessment-details.html
@@ -1,29 +1,4 @@
-{% set qtsDetailsRowOutcomeText%}
-  {% if record.qtsDetails.standardsAssessedOutcome == "Yes" %}
-    Standards met 
-  {% else %} 
-    Not provided
-  {% endif %}
-{% endset %}
-
 {% set qtsDetailsRows = [
-  {
-    key: {
-      text: "Outcome"
-    },
-    value: {
-      text: qtsDetailsRowOutcomeText
-    },
-    actions: {
-      items: [
-        {
-          href: recordPath + "/qts/outcome" | addReferrer(referrer),
-          text: "Change",
-          visuallyHiddenText: "outcome"
-        }
-      ]
-    } if canAmend
-  },
   {
     key: {
       text: "Date standards met"
@@ -88,7 +63,7 @@
 
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
-    titleText: "Outcome details",
+    titleText: "QTS details",
     html: qtsDetailsHtml
   }) }}
   

--- a/app/views/record.html
+++ b/app/views/record.html
@@ -25,7 +25,7 @@
         {% if record.status | getCanRecommendForQts %}
           {% if hasCommencementDate%}
             {{ govukButton({
-              text: "Record training outcome",
+              text: "Recommend trainee for QTS",
               href: referrer + '/qts/outcome-date',
               classes: "govuk-!-margin-bottom-0"
             }) }}

--- a/app/views/record.html
+++ b/app/views/record.html
@@ -26,7 +26,7 @@
           {% if hasCommencementDate%}
             {{ govukButton({
               text: "Record training outcome",
-              href: referrer + '/qts/outcome',
+              href: referrer + '/qts/outcome-date',
               classes: "govuk-!-margin-bottom-0"
             }) }}
           {% else %}

--- a/app/views/record/qts/outcome-date.html
+++ b/app/views/record/qts/outcome-date.html
@@ -10,7 +10,7 @@
   {% endif %}
 {% endset %} #}
 
-{% set pageHeading = 'When did they meet the standards?' %}
+{% set pageHeading = 'When did they meet the QTS standards?' %}
 
 {% set formAction = "./outcome-date-answer" %}
   

--- a/app/views/record/qts/outcome-date.html
+++ b/app/views/record/qts/outcome-date.html
@@ -2,13 +2,15 @@
 
 {% set pageHeadingTraineeName = data.record.personalDetails.shortName %}
 
-{% set pageHeading %}
+{# {% set pageHeading %}
   {% if data.record.qtsDetails.standardsAssessedOutcome == "Yes" %}
     When did they meet the standards? 
   {% else %} 
     When should they be recorded as having not met the standards?
   {% endif %}
-{% endset %}
+{% endset %} #}
+
+{% set pageHeading = 'When did they meet the standards?' %}
 
 {% set formAction = "./outcome-date-answer" %}
   

--- a/app/views/record/qts/passed/confirm.html
+++ b/app/views/record/qts/passed/confirm.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_record-form.html" %}
 {% set pageHeadingTraineeName = data.record.personalDetails.shortName %}
-{% set pageHeading = "Check outcome details" %}
+{% set pageHeading = "Check QTS details" %}
 {% set gridColumn = 'govuk-grid-column-full' %}
 {% set formAction = "./update" %}
 


### PR DESCRIPTION
This PR:

- Skips the question: "Have they met the standards for QTS?"
- Removes the outcome row from the summary card
- Updates to content in the check answers page