### PR TITLE
Update button text to match the change on trainee record

### DIFF
--- a/app/views/record/qts/passed/confirm.html
+++ b/app/views/record/qts/passed/confirm.html
@@ -24,7 +24,7 @@
   }) }} #}
 
   {{ govukButton({
-    text: "Recommend for QTS"
+    text: "Recommend trainee for QTS"
   }) }}
 
 {% endblock %}


### PR DESCRIPTION
I missed updating this button in the [previous PR](https://github.com/DFE-Digital/register-trainee-teachers-prototype/pull/169r). Doh! This PR aligns this button text with the CTA at the start of the flow.