### PR TITLE
Include trainee name with success message

### DIFF
--- a/app/views/record/qts/passed/recommended.html
+++ b/app/views/record/qts/passed/recommended.html
@@ -11,9 +11,12 @@
 
 {% block formContent %}
 
+{% set panelTitleText %}
+  {{ record.personalDetails.shortName or 'Trainee' }} recommended for QTS
+{% endset %}
+
 {{ govukPanel({
-  titleText: pageHeading,
-  html: "Your reference number<br><strong>HDJ2123F</strong>" if false,
+  titleText: panelTitleText,
   classes: "govuk-!-margin-bottom-6"
 }) }}
 


### PR DESCRIPTION
Done in colab with @EmmaFrith, include the trainee name in the success banner.