### PR TITLE
Initial support for selecting trainees directly for bulk actions

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -32,6 +32,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "components/all-records-header";
 @import "components/all-records-search";
 @import "components/banner";
+@import "components/button-as-link";
 @import "components/cookie-banner";
 @import "components/record-header";
 @import "components/record-actions";
@@ -185,3 +186,9 @@ span.summary-validation-symbol {
 .confirmation-next-button {
   margin-right: 20px;
 }
+
+.align-right {
+  text-align: right;
+  float: right;
+}
+

--- a/app/assets/sass/components/_application-card.scss
+++ b/app/assets/sass/components/_application-card.scss
@@ -15,6 +15,14 @@
 }
 
 // Trainee column
+.app-application-card_col:nth-last-child(4) {
+  @include govuk-media-query($from: tablet) {
+    width: 5%;
+    padding-right: 10px;
+  }
+}
+
+// Trainee column
 .app-application-card_col:nth-last-child(3) {
   @include govuk-media-query($from: tablet) {
     width: 40%;

--- a/app/assets/sass/components/_button-as-link.scss
+++ b/app/assets/sass/components/_button-as-link.scss
@@ -1,0 +1,16 @@
+
+.app-button-as-link {
+  // Reset default button styling
+  background: none;
+  margin: 0;
+  padding: 0;
+  border: none;
+  cursor: pointer;
+
+  // GOV.UK link styles
+  @include govuk-link-common;
+  @include govuk-link-style-default;
+  @include govuk-link-print-friendly;
+  color: $govuk-link-colour; // Needed as govuk-link only targets :link
+  text-decoration: underline;
+}

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -24,11 +24,28 @@ let trainingRoutes = trainingRouteData.trainingRoutes
 let allTrainingRoutes       = Object.values(trainingRoutes).map(route => route.name)
 
 let courses                 = require('./courses.json')
-// Things that can be changed from the /admin page
+
+// =============================================================================
+// Settings - things that can be changed from /admin
+// =============================================================================
+
 let settings = {}
-// Simplify structure so it can be worked with from admin page
+
+// Currently enabled routes
 settings.enabledTrainingRoutes = Object.values(trainingRoutes).filter(route => route.defaultEnabled == true).map(route => route.name).sort()
+
+// Enable timeline on records
 settings.includeTimeline = 'true'
+
+// Enable timeline on records
+settings.includeGuidance = false
+
+// Enable timeline on records
+settings.includeDeclaration = false
+
+// Enable timeline on records
+settings.showBulkLinks = false
+
 // Default number of Publish courses that the provider offers
 settings.courseLimit = 20
 

--- a/app/filters/records.js
+++ b/app/filters/records.js
@@ -5,9 +5,12 @@ const _ = require('lodash')
 const trainingRouteData = require('./../data/training-route-data')
 const trainingRoutes = trainingRouteData.trainingRoutes
 const recordUtils = require('./../lib/record')
+const routeUtils = require('./../routes/route-utils')
 
 // Leave this filters line
 var filters = {}
+
+filters.recordIsComplete = routeUtils.recordIsComplete
 
 // Check if the course route requires this field
 filters.requiresField = recordUtils.requiresField

--- a/app/routes/bulk-action-routes.js
+++ b/app/routes/bulk-action-routes.js
@@ -52,6 +52,25 @@ module.exports = router => {
     res.redirect(`/bulk-action/filter-trainees`)
   })
 
+  // Bypass action page
+  router.get('/bulk-action/new/direct', (req, res) => {
+    const data = req.session.data
+    let bulk = data.bulk
+    bulk.directAction = true
+
+    if (bulk.filteredTrainees){
+      bulk.selectedTrainees = bulk.filteredTrainees
+      if (bulk.action != "Recommend a group of trainees for QTS") res.redirect(`/bulk-action/confirm`)
+
+      // Date answer needed
+      else res.redirect(`/bulk-action/date`)
+    }
+    else {
+      res.redirect(`/bulk-action/filter-trainees`)
+    }
+
+  })
+
   // WIP example for starting with a predefined list of trainees
   router.get('/bulk-action/example', (req, res) => {
     const data = req.session.data

--- a/app/views/_includes/trainee-record-card.njk
+++ b/app/views/_includes/trainee-record-card.njk
@@ -3,7 +3,18 @@
 {% endif %}
 
 <div class="app-application-card {{justNowClass}}">
-
+  {% if data.settings.showBulkLinks %}
+    <div class="app-application-card_col">
+      <div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox">
+        {% if record.status == 'TRN received' or (record.status == 'Draft' and record | recordIsComplete) %}
+          <input type="checkbox" name="[bulk][filteredTrainees]" class="govuk-checkboxes__input" id="checkbox-{{record.id}}" value="{{record.id}}">
+          <label class="govuk-label govuk-checkboxes__label" for="checkbox-{{record.id}}">
+            <span class="govuk-visually-hidden">Select {{record.personalDetails.shortName}}</span>
+          </label>
+        {% endif %}
+      </div>
+    </div>
+  {% endif %}
   <div class="app-application-card_col">
     <h3 class="govuk-heading-m govuk-!-margin-bottom-3">
       <a href="/record/{{ record.id }}" class="govuk-link govuk-link--no-visited-state">

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -135,11 +135,11 @@
                   {% if data.settings.showBulkLinks %}
                     <div class="govuk-grid-column-one-half">
                       <input type="hidden" name="[bulk][action]" value="Recommend a group of trainees for QTS">
-                      {# <button role="link" class="govuk-body app-button-as-link govuk-link align-right">Recommend trainees for QTS</button> #}
-                      {{ govukButton({
+                      <button role="link" class="govuk-body app-button-as-link govuk-link align-right">Recommend trainees for QTS</button>
+                      {# {{ govukButton({
                         "text": "Recommend trainees for QTS",
                         classes: "govuk-button--secondary align-right"
-                      }) }}
+                      }) }} #}
                   </div>
                   {% endif %}
                   

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -72,102 +72,130 @@
   <div class="govuk-grid-column-full">
 
     <div class="moj-filter-layout">
-      
-      <form method="get" action="">
-      
-        <div class="moj-filter-layout__filter-wrapper">
-          
+
+      <div class="moj-filter-layout__filter-wrapper">
+        <form method="get" action="">
           <div class="moj-filter-layout__filter">
             {% include "_includes/filter-panel.njk" %}
           </div>
+        </form>
+        <p class="govuk-body"><a href="#" class="govuk-link">Export these records</a></p>
+      </div>
 
-          <p class="govuk-body"><a href="#" class="govuk-link">Export these records</a></p>
+      <div class="moj-filter-layout__content">
 
+        <div class="moj-action-bar">
+          <div class="moj-action-bar__filter">   
+          </div>
         </div>
 
-        <div class="moj-filter-layout__content">
+        {# Only sort if there's at least two items #}
+        {% if filteredRecords.length > 1 %}
+          {% include "_includes/record-sort-order.njk" %}
+        {% endif %}
 
-          <div class="moj-action-bar">
-            <div class="moj-action-bar__filter">   
-            </div>
-          </div>
-          
+        {% if filteredRecords.length %}
 
-          {# Only sort if there's at least two items #}
-          {% if filteredRecords.length > 1 %}
-            {% include "_includes/record-sort-order.njk" %}
-          {% endif %}
+          <div class="app-application-cards">
 
-          {% if filteredRecords.length %}
+            {% set draftRecords = filteredRecords | where("status", "Draft") %}
 
-
-            <div class="app-application-cards">
-
-              {% set draftRecords = filteredRecords | where("status", "Draft") %}
-             
-              {% if (draftRecords | length) %}
+            {% if (draftRecords | length) %}
+              <form action="/bulk-action/new/direct" method="post" novalidate>
                 <div class="govuk-!-margin-bottom-8">
-                  <h2 class="govuk-heading-m">Draft records ({{draftRecords | length}})</h2>
+                  <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-one-half">
+                      <h2 class="govuk-heading-m">Draft records ({{draftRecords | length}})</h2>
+                    </div>
+                    {% if data.settings.showBulkLinks %}
+                      <div class="govuk-grid-column-one-half">
+                        <input type="hidden" name="[bulk][action]" value="Submit a group of records and request TRNs">
+                        <button role="link" class="govuk-body app-button-as-link govuk-link align-right">Submit draft records for TRN</button>
+                      </div>
+                    {% endif %}
+
+                  </div>
+
                   {% for record in draftRecords %}
                     {% include "_includes/trainee-record-card.njk" %}
                   {% endfor %}
-                </div>
-              {% endif %}
 
-              {% set nonDraftRecords = filteredRecords | removeWhere("status", "Draft") %}
-              {% if (nonDraftRecords | length) %} 
-                <h2 class="govuk-heading-m">Records ({{nonDraftRecords | length}})</h2>
+                </div>
+              </form>
+
+            {% endif %}
+
+            {% set nonDraftRecords = filteredRecords | removeWhere("status", "Draft") %}
+            {% if (nonDraftRecords | length) %} 
+              <form action="/bulk-action/new/direct" method="post" novalidate>
+                <div class="govuk-grid-row">
+                  <div class="govuk-grid-column-one-half">
+                    <h2 class="govuk-heading-m">Records ({{nonDraftRecords | length}})</h2>
+                  </div>
+                  {% if data.settings.showBulkLinks %}
+                    <div class="govuk-grid-column-one-half">
+                      <input type="hidden" name="[bulk][action]" value="Recommend a group of trainees for QTS">
+                      {# <button role="link" class="govuk-body app-button-as-link govuk-link align-right">Recommend trainees for QTS</button> #}
+                      {{ govukButton({
+                        "text": "Recommend trainees for QTS",
+                        classes: "govuk-button--secondary align-right"
+                      }) }}
+                  </div>
+                  {% endif %}
+                  
+                </div>
+
                 {% for record in nonDraftRecords %}
                     {% include "_includes/trainee-record-card.njk" %}
                 {% endfor %}
-              {% endif %}
 
-            </div>
-
-            {# Don't show pagination when it's clear there's not many results #}
-            {% if filteredRecords | length > 20 %}
-              {% set pagination = {
-                from: 1,
-                to: 50,
-                count: 346,
-                next: {
-                  text: 'Next',
-                  href: '?page=' + 2
-                },
-                items: [{
-                  text: '1',
-                  href: '?page=1',
-                  selected: true
-                  }, {
-                  text: '2',
-                  href: '?page=2',
-                  selected: false
-                  }, {
-                  text: '3',
-                  href: '?page=3'
-                  }]
-              } %}
-
-              {{ mojPagination({
-                results: {
-                  from: pagination.from,
-                  to: pagination.to,
-                  count: pagination.count
-                },
-                previous: pagination.previous,
-                next: pagination.next,
-                items: pagination.items,
-                classes: 'govuk-!-margin-bottom-3'
-              }) }}
+              </form>
             {% endif %}
+          </div>
           
-          {% else %}
-            <h2 class="govuk-heading-m">No records found.</h2>
-            <p class="govuk-body">Try <a href="/records">clearing your search and filters</a>.</p>
-          {% endif %}
-        </div>
 
-      </form>
+          {# Don't show pagination when it's clear there's not many results #}
+          {% if filteredRecords | length > 20 %}
+            {% set pagination = {
+              from: 1,
+              to: 50,
+              count: 346,
+              next: {
+                text: 'Next',
+                href: '?page=' + 2
+              },
+              items: [{
+                text: '1',
+                href: '?page=1',
+                selected: true
+                }, {
+                text: '2',
+                href: '?page=2',
+                selected: false
+                }, {
+                text: '3',
+                href: '?page=3'
+                }]
+            } %}
+
+            {{ mojPagination({
+              results: {
+                from: pagination.from,
+                to: pagination.to,
+                count: pagination.count
+              },
+              previous: pagination.previous,
+              next: pagination.next,
+              items: pagination.items,
+              classes: 'govuk-!-margin-bottom-3'
+            }) }}
+          {% endif %}
+        
+        {% else %}
+          <h2 class="govuk-heading-m">No records found.</h2>
+          <p class="govuk-body">Try <a href="/records">clearing your search and filters</a>.</p>
+        {% endif %}
+      </div>
 
     </div>
   </div>


### PR DESCRIPTION
Adds some initial support for directly selecting trainees from the records page to do bulk actions.

![Screenshot 2020-12-21 at 14 34 10](https://user-images.githubusercontent.com/2204224/102787876-a8718000-4399-11eb-9295-c6cb0e40c4f6.png)

If any trainees are selected here, we can jump straight to the date / confirmation page.

If no trainees are selected, then we can show the filter-trainees page.