### PR TITLE
Make trainee start date required

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -46,6 +46,9 @@ settings.includeDeclaration = false
 // Enable timeline on records
 settings.showBulkLinks = false
 
+// Start date is required when registering trainees
+settings.requireTraineeStartDate = 'true'
+
 // Default number of Publish courses that the provider offers
 settings.courseLimit = 20
 

--- a/app/views/_includes/forms/training-details.html
+++ b/app/views/_includes/forms/training-details.html
@@ -1,4 +1,4 @@
-{# <span class="govuk-caption-l">{{'Add a trainee'}}</span> #}
+
 <h1 class="govuk-heading-l">{{pageHeading}}</h1>
 
 {% set commencementStartDateArray = record.trainingDetails.commencementDate | toDateArray %}
@@ -41,30 +41,38 @@
   }) }}
 {% endset %}
 
-{{ govukRadios({
-  fieldset: {
-    legend: {
-      text: "Has the trainee started the course?",
-      classes: "govuk-fieldset__legend--s"
-    }
-  },
-  hint: {
-    text: "If the trainee has not started yet, you can still submit their record, but will need to provide their start date later"
-  },
-  items: [
-    {
-      value: "true",
-      text: "Yes",
-      conditional: {
-        html: commencementDateInputHtml
+{% if data.settings.requireTraineeStartDate %}
+
+  {{ commencementDateInputHtml | safe }}
+
+{% else %}
+
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        text: "Has the trainee started the course?",
+        classes: "govuk-fieldset__legend--s"
       }
     },
-    {
-      value: "false",
-      text: "No, the trainee has not started yet"
-    }
-  ]
-} | decorateAttributes(record, "record.trainingDetails.traineeStarted")) }}
+    hint: {
+      text: "If the trainee has not started yet, you can still submit their record, but will need to provide their start date later"
+    },
+    items: [
+      {
+        value: "true",
+        text: "Yes",
+        conditional: {
+          html: commencementDateInputHtml
+        }
+      },
+      {
+        value: "false",
+        text: "No, the trainee has not started yet"
+      }
+    ]
+  } | decorateAttributes(record, "record.trainingDetails.traineeStarted")) }}
+{% endif %}
+
 
 {{ govukInput({
   label: {

--- a/app/views/_includes/summary-cards/training-details.html
+++ b/app/views/_includes/summary-cards/training-details.html
@@ -1,5 +1,5 @@
 {% set commencementDateLabel -%}
-  {%- if record.trainingDetails.traineeStarted | falsify -%}
+  {%- if (record.trainingDetails.traineeStarted | falsify) or data.settings.requireTraineeStartDate -%}
     {{- record.trainingDetails.commencementDate | govukDate -}}
   {%- else -%}
     Trainee yet to start course
@@ -14,7 +14,7 @@
       text: "Start date"
     },
     value: {
-      text: (record.trainingDetails.commencementDate | govukDate or "Not provided") if traineeStarted else "Trainee yet to start course"
+      text: commencementDateLabel
     },
     actions: {
       items: [

--- a/app/views/admin.html
+++ b/app/views/admin.html
@@ -57,6 +57,15 @@
         ]
       } | decorateAttributes(data, "data.settings.showBulkLinks")) }}
 
+      {{ govukCheckboxes({
+        items: [
+          {
+            value: 'true',
+            text: "Trainees need a start date to register for TRN"
+          }
+        ]
+      } | decorateAttributes(data, "data.settings.requireTraineeStartDate")) }}
+
       {{ govukInput({
         label: {
           text: "Number of publish courses the provider offers",


### PR DESCRIPTION
For the first version of trainee start date, we'll just make it required to register for TRN

This should be ok for Assessment only candidates - and we can do more work in the future to consider if we want to make it required for other routes.

![Screenshot 2020-12-21 at 16 49 01](https://user-images.githubusercontent.com/2204224/102800903-71589a00-43ac-11eb-89e7-79900855fbfd.png)
