### PR TITLE
Explicitly set back links on confirm pages

### DIFF
--- a/app/views/_templates/_record-form.html
+++ b/app/views/_templates/_record-form.html
@@ -56,7 +56,7 @@
           {% if returnLink %}
             <p class="govuk-body"><a href="{{returnLink.href}}" class="govuk-link">{{returnLink.text}}</a></p>
           {% else %}
-            <p class="govuk-body"><a href="{{recordPath}}" class="govuk-link">Cancel and return to record</a></p>
+            <p class="govuk-body"><a href="{{recordPath | orReferrer(referrer)}}" class="govuk-link">Cancel and return to record</a></p>
           {% endif %}
         {% endif %}
       </div>

--- a/app/views/record/contact-details/confirm.html
+++ b/app/views/record/contact-details/confirm.html
@@ -2,6 +2,9 @@
 
 {% set pageHeading = "Confirm contact details" %}
 
+{% set backLink = referrer or ("/record/" + data.record.id) %}
+{% set backText = "Back to record" %}
+
 {% set gridColumn = 'govuk-grid-column-full' %}
 {% set formAction = "./update" | addReferrer(referrer) %}
 

--- a/app/views/record/defer/confirm.html
+++ b/app/views/record/defer/confirm.html
@@ -2,6 +2,9 @@
 {% set pageHeadingTraineeName = data.record.personalDetails | getShortName %}
 {% set pageHeading = "Check deferral details" %}
 
+{% set backLink = referrer or ("/record/" + data.record.id) %}
+{% set backText = "Back to record" %}
+
 {% set gridColumn = 'govuk-grid-column-full' %}
 {% set formAction = "./update" | addReferrer(referrer) %}
 

--- a/app/views/record/degree/confirm.html
+++ b/app/views/record/degree/confirm.html
@@ -2,6 +2,9 @@
 
 {% set pageHeading = "Confirm degree details" %}
 
+{% set backLink = referrer or ("/record/" + data.record.id) %}
+{% set backText = "Back to record" %}
+
 {% set gridColumn = 'govuk-grid-column-full' %}
 {% set formAction = "./update" | addReferrer(referrer) %}
 

--- a/app/views/record/diversity/confirm.html
+++ b/app/views/record/diversity/confirm.html
@@ -2,6 +2,9 @@
 
 {% set pageHeading = "Confirm diversity information" %}
 
+{% set backLink = referrer or ("/record/" + data.record.id) %}
+{% set backText = "Back to record" %}
+
 {% set gridColumn = 'govuk-grid-column-full' %}
 {% set formAction = "./update" | addReferrer(referrer) %}
 

--- a/app/views/record/gcse/confirm.html
+++ b/app/views/record/gcse/confirm.html
@@ -2,6 +2,9 @@
 
 {% set pageHeading = "Confirm GCSE details" %}
 
+{% set backLink = referrer or ("/record/" + data.record.id) %}
+{% set backText = "Back to record" %}
+
 {% set gridColumn = 'govuk-grid-column-full' %}
 {% set formAction = "./update" | addReferrer(referrer) %}
 

--- a/app/views/record/personal-details/confirm.html
+++ b/app/views/record/personal-details/confirm.html
@@ -2,6 +2,9 @@
 
 {% set pageHeading = "Confirm personal details" %}
 
+{% set backLink = referrer or ("/record/" + data.record.id) %}
+{% set backText = "Back to record" %}
+
 {% set gridColumn = 'govuk-grid-column-full' %}
 {% set formAction = "./update" | addReferrer(referrer) %}
 

--- a/app/views/record/programme-details/confirm.html
+++ b/app/views/record/programme-details/confirm.html
@@ -2,6 +2,9 @@
 
 {% set pageHeading = "Confirm programme details" %}
 
+{% set backLink = referrer or ("/record/" + data.record.id) %}
+{% set backText = "Back to record" %}
+
 {% set gridColumn = 'govuk-grid-column-full' %}
 {% set formAction = "./update" | addReferrer(referrer) %}
 

--- a/app/views/record/qts/not-passed/confirm.html
+++ b/app/views/record/qts/not-passed/confirm.html
@@ -1,6 +1,10 @@
 {% extends "_templates/_record-form.html" %}
 {% set pageHeadingTraineeName = data.record.personalDetails.shortName %}
 {% set pageHeading = "Check outcome details" %}
+
+{% set backLink = referrer or ("/record/" + data.record.id) %}
+{% set backText = "Back to record" %}
+
 {% set gridColumn = 'govuk-grid-column-full' %}
 {% set formAction = "./update" %}
 

--- a/app/views/record/qts/passed/confirm.html
+++ b/app/views/record/qts/passed/confirm.html
@@ -1,6 +1,10 @@
 {% extends "_templates/_record-form.html" %}
 {% set pageHeadingTraineeName = data.record.personalDetails.shortName %}
 {% set pageHeading = "Check QTS details" %}
+
+{% set backLink = referrer or ("/record/" + data.record.id) %}
+{% set backText = "Back to record" %}
+
 {% set gridColumn = 'govuk-grid-column-full' %}
 {% set formAction = "./update" %}
 

--- a/app/views/record/reinstate/confirm.html
+++ b/app/views/record/reinstate/confirm.html
@@ -1,6 +1,10 @@
 {% extends "_templates/_record-form.html" %}
 
 {% set pageHeading = "Check reinstatement details" %}
+
+{% set backLink = referrer or ("/record/" + data.record.id) %}
+{% set backText = "Back to record" %}
+
 {% set gridColumn = 'govuk-grid-column-full' %}
 {% set formAction = "./update" %}
 

--- a/app/views/record/trainee-id/confirm.html
+++ b/app/views/record/trainee-id/confirm.html
@@ -2,6 +2,9 @@
 
 {% set pageHeading = "Confirm trainee ID" %}
 
+{% set backLink = referrer or ("/record/" + data.record.id) %}
+{% set backText = "Back to record" %}
+
 {% set gridColumn = 'govuk-grid-column-full' %}
 {% set formAction = "./update" | addReferrer(referrer) %}
 

--- a/app/views/record/trainee-start-date/confirm.html
+++ b/app/views/record/trainee-start-date/confirm.html
@@ -2,6 +2,9 @@
 
 {% set pageHeading = "Confirm trainee start date" %}
 
+{% set backLink = referrer or ("/record/" + data.record.id) %}
+{% set backText = "Back to record" %}
+
 {% set formAction = "./update" | addReferrer(referrer) %}
 
 {% block formContent %}

--- a/app/views/record/withdraw/confirm.html
+++ b/app/views/record/withdraw/confirm.html
@@ -1,6 +1,10 @@
 {% extends "_templates/_record-form.html" %}
 {% set pageHeadingTraineeName = data.record.personalDetails | getShortName %}
 {% set pageHeading = "Check withdrawal details" %}
+
+{% set backLink = referrer or ("/record/" + data.record.id) %}
+{% set backText = "Back to record" %}
+
 {% set gridColumn = 'govuk-grid-column-full' %}
 {% set formAction = "./update" %}
 


### PR DESCRIPTION
Back links on confirm pages should go 'up' to the page that initiated the flow. This hardcodes them to go 'back' using the referrer (ideally) or the main record page (less ideally).