### PR TITLE
Don't exclude British and Irish from autocomplete

### DIFF
--- a/app/data/providers.js
+++ b/app/data/providers.js
@@ -315,7 +315,7 @@ const getSelectedProviders = () => {
   })
   
   reducedProviders = reducedProviders.concat(permProviders).sort()
-  return [...reducedProviders] // Uniq
+  return [...new Set(reducedProviders)] // Uniq
 }
 
 module.exports = {

--- a/app/filters/arrays.js
+++ b/app/filters/arrays.js
@@ -19,6 +19,10 @@ filters.isArray = arr => {
   return _.isArray(arr)
 }
 
+filters.uniq = arr => {
+  return [...new Set(arr || [])]
+}
+
 
 /*
   ====================================================================

--- a/app/views/_includes/forms/personal-details.html
+++ b/app/views/_includes/forms/personal-details.html
@@ -84,8 +84,6 @@
   ]
 } | decorateAttributes(record, "record.personalDetails.sex"))}}
 
-{% set nationalitiesWithoutBritishAndIrish = data.nationalities | removeArrayItems(['British', 'Irish']) %}
-
 {# Separate out nationalities #}
 {% set otherNationalities = record.personalDetails.nationality | removeArrayItems(['British', 'Irish', 'Other'] | removeEmpty )%}
 
@@ -109,7 +107,7 @@
       },
       id: 'nationality-other-' + nationalityIndex,
       name: "record[personalDetails][nationality][" + nationalityIndex + "]",
-      items: nationalitiesWithoutBritishAndIrish,
+      items: data.nationalities,
       classes: "app-!-autocomplete--max-width-one-half",
       value: nationality
       }

--- a/app/views/_includes/summary-cards/personal-details.html
+++ b/app/views/_includes/summary-cards/personal-details.html
@@ -51,7 +51,7 @@
       text: "Nationality"
     },
     value: {
-      text: record.personalDetails.nationality | removeArrayItem("Other") | joinify or 'Not entered'
+      text: record.personalDetails.nationality | uniq | removeArrayItem("Other") | joinify or 'Not entered'
     },
     actions: {
       items: [


### PR DESCRIPTION
We've seen a couple users in user research choose the option for 'other' when they have two nationalities to fill in. But we're currently excluding British and Irish from the autocomplete because they already have checkboxes.

This includes all nationalities in the autocomplete - so users can use the checkbox or 'other' and either way it will work.