### PR TITLE
Add support for multiple skip links in header

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -34,6 +34,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "components/banner";
 @import "components/button-as-link";
 @import "components/cookie-banner";
+@import "components/filters";
 @import "components/record-header";
 @import "components/record-actions";
 @import "components/sub-navigation";
@@ -45,11 +46,13 @@ $govuk-assets-path: '/govuk/assets/';
 @import "overrides/govuk-header";
 @import "overrides/govuk-panel";
 @import "overrides/govuk-error-summary";
+@import "overrides/govuk-skip-link";
 @import "overrides/moj-filter";
 @import "overrides/moj-pagination";
 @import "overrides/tabs";
 @import "overrides/dash-list";
 @import "overrides/summary-card";
+
 
 
 

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -34,7 +34,6 @@ $govuk-assets-path: '/govuk/assets/';
 @import "components/banner";
 @import "components/button-as-link";
 @import "components/cookie-banner";
-@import "components/filters";
 @import "components/record-header";
 @import "components/record-actions";
 @import "components/sub-navigation";

--- a/app/assets/sass/overrides/_govuk-skip-link.scss
+++ b/app/assets/sass/overrides/_govuk-skip-link.scss
@@ -1,0 +1,101 @@
+$important: true;
+
+// This is basically a copy of the Design System govuk-visually-hidden-focusable mixin
+// except it targets the :focus-within pseudo selector rather than :focus
+@mixin visually-hidden-focus-withinable {
+  position: absolute if($important, !important, null);
+
+  width: 1px if($important, !important, null);
+  height: 1px if($important, !important, null);
+  // If margin is set to a negative value it can cause text to be announced in
+  // the wrong order in VoiceOver for OSX
+  margin: 0 if($important, !important, null);
+
+  overflow: hidden if($important, !important, null);
+  clip: rect(0 0 0 0) if($important, !important, null);
+  clip-path: inset(50%) if($important, !important, null);
+
+  // For long content, line feeds are not interpreted as spaces and small width
+  // causes content to wrap 1 word per line:
+  // https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
+  white-space: nowrap if($important, !important, null);
+
+  &:focus-within:active,
+  &:focus-within {
+    position: static if($important, !important, null);
+
+    width: auto if($important, !important, null);
+    height: auto if($important, !important, null);
+    margin: inherit if($important, !important, null);
+
+    overflow: visible if($important, !important, null);
+    clip: auto if($important, !important, null);
+    clip-path: none if($important, !important, null);
+
+    white-space: inherit if($important, !important, null);
+  }
+}
+
+// The :focus parts of @mixin govuk-visually-hidden-focusable and .govuk-skip-link
+@mixin clear-visually-hidden-focusable {
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+  outline-offset: 0;
+  background-color: $govuk-focus-colour;
+
+  position: static if($important, !important, null);
+
+  width: auto if($important, !important, null);
+  height: auto if($important, !important, null);
+  margin: inherit if($important, !important, null);
+
+  overflow: visible if($important, !important, null);
+  clip: auto if($important, !important, null);
+  clip-path: none if($important, !important, null);
+
+  white-space: inherit if($important, !important, null);
+}
+
+// Selecting on :focus-within and :not(:focus-within) should mean this rule only
+// applies to browsers that support the :focus-within pseudo property. Using this instead
+// of @supports as it doens't support pseudo properties well yet.
+// Many of the stiles within are from the .govuk-skip-link class
+.app-skip-link--container:focus-within, .app-skip-link--container:not(:focus-within) {
+  @include visually-hidden-focus-withinable;
+  display: block;
+  padding: govuk-spacing(2) govuk-spacing(3);
+
+  // Respect 'display cutout' safe area (avoids notches and rounded corners)
+  @supports (padding: unquote("max(calc(0px))")) {
+    $padding-safe-area-right: calc(#{govuk-spacing(3)} + env(safe-area-inset-right));
+    $padding-safe-area-left: calc(#{govuk-spacing(3)} + env(safe-area-inset-left));
+
+    // Use max() to pick largest padding, default or with safe area
+    // Escaped due to Sass max() vs. CSS native max()
+    padding-right: unquote("max(#{govuk-spacing(3)}, #{$padding-safe-area-right})");
+    padding-left: unquote("max(#{govuk-spacing(3)}, #{$padding-safe-area-left})");
+  }
+
+  .govuk-skip-link {
+    display: inline-block;
+    padding: 0;
+    // margin: govuk-spacing(2);
+    @include clear-visually-hidden-focusable; // Override design system styles
+  }
+
+  .govuk-skip-link:focus {
+    @include govuk-focused-text; // Thick black underline on focus
+  }
+
+  // Spacing around links
+  .app-skip-link--item {
+    padding: govuk-spacing(1);
+    text-decoration: none;
+  }
+}
+
+.app-skip-link--container:focus-within {
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+  outline-offset: 0;
+  background-color: $govuk-focus-colour;
+}
+

--- a/app/assets/sass/overrides/_govuk-skip-link.scss
+++ b/app/assets/sass/overrides/_govuk-skip-link.scss
@@ -38,10 +38,6 @@ $important: true;
 
 // The :focus parts of @mixin govuk-visually-hidden-focusable and .govuk-skip-link
 @mixin clear-visually-hidden-focusable {
-  outline: $govuk-focus-width solid $govuk-focus-colour;
-  outline-offset: 0;
-  background-color: $govuk-focus-colour;
-
   position: static if($important, !important, null);
 
   width: auto if($important, !important, null);
@@ -55,10 +51,10 @@ $important: true;
   white-space: inherit if($important, !important, null);
 }
 
-// Selecting on :focus-within and :not(:focus-within) should mean this rule only
-// applies to browsers that support the :focus-within pseudo property. Using this instead
-// of @supports as it doens't support pseudo properties well yet.
-// Many of the stiles within are from the .govuk-skip-link class
+// Selecting :focus-within and :not(:focus-within) together should mean this rule only
+// applies to browsers that support the :focus-within pseudo property. 
+// Using this instead of @supports as it doens’t support pseudo properties well yet.
+// Many of the styles within are from the .govuk-skip-link class
 .app-skip-link--container:focus-within, .app-skip-link--container:not(:focus-within) {
   @include visually-hidden-focus-withinable;
   display: block;
@@ -75,24 +71,26 @@ $important: true;
     padding-left: unquote("max(#{govuk-spacing(3)}, #{$padding-safe-area-left})");
   }
 
+  // Override default .govuk-skip-link styles
   .govuk-skip-link {
     display: inline-block;
     padding: 0;
-    // margin: govuk-spacing(2);
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    outline-offset: 0;
+    background-color: $govuk-focus-colour;
     @include clear-visually-hidden-focusable; // Override design system styles
+
+    &:focus {
+      @include govuk-focused-text; // Thick black underline on focus
+    }
   }
 
-  .govuk-skip-link:focus {
-    @include govuk-focused-text; // Thick black underline on focus
-  }
-
-  // Spacing around links
   .app-skip-link--item {
     padding: govuk-spacing(1);
-    text-decoration: none;
   }
 }
 
+// Same styling as .govuk-skip-link
 .app-skip-link--container:focus-within {
   outline: $govuk-focus-width solid $govuk-focus-colour;
   outline-offset: 0;

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -5,21 +5,20 @@
 {% set navActive = "records" %}
 
 {% block skipLink %}
- 
-<div class="app-skip-link--container">
-  <span class="app-skip-link--item">
-    {{ govukSkipLink({
-      href: '#main-content',
-      text: 'Skip to main content'
-    }) }}
-  </span>
-  <span class="app-skip-link--item">
-    {{ govukSkipLink({
-      href: '#records-list',
-      text: 'Skip to results' if selectedFilters else 'Skip to records'
-    }) }}
-  </span>
-</div>
+  <div class="app-skip-link--container">
+    <span class="app-skip-link--item">
+      {{ govukSkipLink({
+        href: '#main-content',
+        text: 'Skip to main content'
+      }) }}
+    </span>
+    <span class="app-skip-link--item">
+      {{ govukSkipLink({
+        href: '#records-list',
+        text: 'Skip to results' if selectedFilters else 'Skip to records'
+      }) }}
+    </span>
+  </div>
 {% endblock %}
 
 {% block content %}

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -19,7 +19,6 @@
       text: 'Skip to results' if selectedFilters else 'Skip to records'
     }) }}
   </span>
-
 </div>
 {% endblock %}
 

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -4,6 +4,25 @@
 {% set backLink = 'false' %}
 {% set navActive = "records" %}
 
+{% block skipLink %}
+ 
+<div class="app-skip-link--container">
+  <span class="app-skip-link--item">
+    {{ govukSkipLink({
+      href: '#main-content',
+      text: 'Skip to main content'
+    }) }}
+  </span>
+  <span class="app-skip-link--item">
+    {{ govukSkipLink({
+      href: '#records-list',
+      text: 'Skip to results' if selectedFilters else 'Skip to records'
+    }) }}
+  </span>
+
+</div>
+{% endblock %}
+
 {% block content %}
 {# super pulling in flash message banner #}
 {{super()}}
@@ -82,7 +101,7 @@
         <p class="govuk-body"><a href="#" class="govuk-link">Export these records</a></p>
       </div>
 
-      <div class="moj-filter-layout__content">
+      <div class="moj-filter-layout__content" id="records-list">
 
         <div class="moj-action-bar">
           <div class="moj-action-bar__filter">   


### PR DESCRIPTION
Our service has a number of filters you can apply to filter a group of records. We recently used the accessibility personas to review these pages - and felt it would be good to provide a way of skipping past the filters to the results.

In this pr I'm experimenting by adding a second skip link in to the header. This uses the _newish_ `:focus-within` property to show the skip-link div if either of the children links are focussed. This should gracefully degrade in browsers that don't support the property to just show two skip links in turn.

The css is mostly copied styles from the `govuk-skip-link` component, but applied to the header instead. If the browser supports `:focus-within` I then remove some of the default styles from the skip links themselves.

## Video:
![dual-skip-links](https://user-images.githubusercontent.com/2204224/107640441-336c4980-6c6a-11eb-9c3d-7595ccefd8cf.gif)

## Without support for the property:
![double-skip-link](https://user-images.githubusercontent.com/2204224/107640466-3bc48480-6c6a-11eb-9c99-f41e18806c68.gif)


