### PR TITLE
be clearer about what trainee ID is for and remove repetitive content

### DIFF
--- a/app/views/_includes/forms/trainee-id.html
+++ b/app/views/_includes/forms/trainee-id.html
@@ -4,9 +4,6 @@
     classes: "govuk-label--l",
     isPageHeading: true
   },
-  hint: {
-    text: "Assign your own ID for this trainee to help you identify them and search for them in your trainee records. You can also use it if you get in touch with DfE about this trainee."
-  },
   classes: "govuk-!-width-one-half"
 } | decorateAttributes(record, "record.trainingDetails.traineeId"))}}
 

--- a/app/views/_includes/forms/training-details.html
+++ b/app/views/_includes/forms/training-details.html
@@ -81,7 +81,7 @@
     classes: "govuk-label--s"
   },
   hint: {
-    text: "This will help you to identify them and search for them in your trainee records. You can also use it if you get in touch with DfE about this trainee."
+    text: "This will help you to identify them and search for them in your trainee records. We may also use it if we need to get in touch with you about this trainee."
   },
   classes: "govuk-!-width-one-half"
 } | decorateAttributes(record, "record.trainingDetails.traineeId"))}}


### PR DESCRIPTION
Change "You can also use it if you get in touch with DfE about this trainee." to "We may also use it if we need to get in touch with you about this trainee."

Remove repetitive hint text from the "change a trainee ID" page 