### PR TITLE
Small update added to ensure filter stays visible above 320px viewports

### DIFF
--- a/app/assets/sass/overrides/_moj-filter.scss
+++ b/app/assets/sass/overrides/_moj-filter.scss
@@ -19,6 +19,16 @@
   }
 }
 
+
+.js-enabled .moj-filter-layout__filter {
+  @include govuk-media-query($until: desktop) {
+    // only display a scrollbar if it there is overflow to scroll
+    overflow: auto;
+    // At this width the filter has `position: fixed`. We should set a max width that will safely include the filter and a scrollbar if present 
+    max-width: 300px;
+  }
+}
+
 .moj-filter__header {
   background: govuk-colour('white');
   box-shadow: none;

--- a/app/assets/sass/overrides/_moj-filter.scss
+++ b/app/assets/sass/overrides/_moj-filter.scss
@@ -21,11 +21,11 @@
 
 
 .js-enabled .moj-filter-layout__filter {
-  @include govuk-media-query($until: desktop) {
+  @include govuk-media-query($until: tablet) {
     // only display a scrollbar if it there is overflow to scroll
     overflow: auto;
     // At this width the filter has `position: fixed`. We should set a max width that will safely include the filter and a scrollbar if present 
-    max-width: 300px;
+    max-width: calc(100% - calc(100vw - 100%));
   }
 }
 

--- a/app/assets/sass/overrides/_moj-filter.scss
+++ b/app/assets/sass/overrides/_moj-filter.scss
@@ -25,7 +25,7 @@
     // only display a scrollbar if it there is overflow to scroll
     overflow: auto;
     // At this width the filter has `position: fixed`. We should set a max width that will safely include the filter and a scrollbar if present 
-    max-width: calc(100% - calc(100vw - 100%));
+    max-width: calc(100vw - calc(100vw - 100%));
   }
 }
 


### PR DESCRIPTION
This PR addresses a bug noticed in the accessibility audit which I successfully recreated. In this instance by setting scroll bars to always show (Mac OS). 

## Before (320px)

![Screenshot 2021-02-24 at 14 52 35](https://user-images.githubusercontent.com/1108991/109126594-57895980-7745-11eb-85be-8b8e15083987.png)

## After (320px)

![Screenshot 2021-02-25 at 08 43 20](https://user-images.githubusercontent.com/1108991/109126865-ac2cd480-7745-11eb-8db0-1ce16021f5a3.png)
