### PR TITLE
Fix unsafe deletes and add ability to directly import json

### DIFF
--- a/app/data/direct-add-record.json
+++ b/app/data/direct-add-record.json
@@ -1,0 +1,100 @@
+{
+  "status": "Draft",
+  "events": {
+    "items": []
+  },
+  "provider": "Coventry University",
+  "route": "Assessment only",
+  "personalDetails": {
+    "nationality": [
+      "Irish",
+      "American"
+    ],
+    "givenName": "Sarah Lilia",
+    "middleNames": "",
+    "familyName": "Jones",
+    "dateOfBirth": [
+      "3",
+      "12",
+      "1987"
+    ],
+    "sex": "Female",
+    "status": [
+      "Completed"
+    ]
+  },
+  "contactDetails": {
+    "internationalAddress": "",
+    "addressType": "domestic",
+    "address": {
+      "line1": "260 Bradford Street",
+      "line2": "Deritend",
+      "level2": "Birmingham",
+      "postcode": "B12 0QY"
+    },
+    "phoneNumber": "07700 900941",
+    "email": "s.jones@example.com",
+    "status": [
+      "Completed"
+    ]
+  },
+  "diversity": {
+    "diversityDisclosed": "false",
+    "status": [
+      "Completed"
+    ]
+  },
+  "degree": {
+    "items": [
+      {
+        "isInternational": "true",
+        "subject": "Biology",
+        "country": "United States",
+        "endDate": "2013",
+        "type": "Bachelor degree",
+        "id": "31dc5e93-b521-425c-98d8-dec96eb2388c"
+      },
+      {
+        "isInternational": "false",
+        "subject": "Sport and exercise sciences",
+        "org": "The University of Manchester",
+        "endDate": "2016",
+        "type": "BSc - Bachelor of Science",
+        "grade": "First-class honours",
+        "id": "1faf0ae6-4c01-4224-9e49-06beffc0c5d0"
+      }
+    ],
+    "degreeToBeUsedForBursaries": "31dc5e93-b521-425c-98d8-dec96eb2388c",
+    "status": [
+      "Completed"
+    ]
+  },
+  "programmeDetails": {
+    "subject": "Business studies",
+    "ageRange": "3 to 11 programme",
+    "startDate": [
+      "1",
+      "2",
+      "2021"
+    ],
+    "endDate": [
+      "1",
+      "6",
+      "2021"
+    ],
+    "status": [
+      "Completed"
+    ]
+  },
+  "trainingDetails": {
+    "commencementDate": [
+      "1",
+      "2",
+      "2021"
+    ],
+    "traineeId": "AO/03/21",
+    "status": [
+      "Completed"
+    ]
+  }
+}

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -297,10 +297,10 @@ exports.updateRecord = (data, newRecord, timelineMessage) => {
     exports.addEvent(newRecord, message)
   }
   if (newRecord.addressType == "domestic"){
-    delete newRecord.contactDetails.internationalAddress
+    delete newRecord?.contactDetails?.internationalAddress
   }
   if (newRecord.addressType == "international"){
-    delete newRecord.contactDetails.address
+    delete newRecord?.contactDetails?.address
   }
   data.record = newRecord
 
@@ -388,7 +388,7 @@ exports.registerForTRN = (record) => {
   }
   else {
     record.status = 'Pending TRN'
-    delete record.placement.status
+    delete record?.placement?.status
     record.submittedDate = new Date()
     record.updatedDate = new Date()
     record.programmeDetails = {

--- a/app/routes/existing-record-routes.js
+++ b/app/routes/existing-record-routes.js
@@ -154,12 +154,12 @@ module.exports = router => {
         req.flash('success', 'Training outcome recorded')   
       }
       newRecord.previousQtsOutcome = newRecord.notPassedReason
-      delete newRecord.notPassedReason
+      delete newRecord?.notPassedReason
       newRecord.previousQtsOutcomeOther = newRecord.notPassedReasonOther
-      delete newRecord.notPassedReasonOther
-      delete newRecord.qtsDetails.standardsAssessedOutcome
-      delete newRecord.qtsDetails.withdrawalStatus
-      delete newRecord.qtsDetails.qtsOutcomeRecordedDateRadio
+      delete newRecord?.notPassedReasonOther
+      delete newRecord?.qtsDetails?.standardsAssessedOutcome
+      delete newRecord?.qtsDetails?.withdrawalStatus
+      delete newRecord?.qtsDetails?.qtsOutcomeRecordedDateRadio
       utils.updateRecord(data, newRecord, false)
       res.redirect(`/record/${req.params.uuid}`)
     }

--- a/app/routes/new-record-routes.js
+++ b/app/routes/new-record-routes.js
@@ -7,6 +7,15 @@ const utils = require('./../lib/utils')
 
 module.exports = router => {
 
+  // Hacky solution to manually import a record to draft state
+  // Useful for testing bugs so we can quickly restore a state
+  router.get('/new-record/direct-add', function (req, res) {
+    const data = req.session.data
+    utils.deleteTempData(data)
+    data.record = require('./../data/direct-add-record.json')
+    res.redirect('/new-record/check-record')
+  })
+
   // Delete data when starting new
   router.get(['/new-record/new', '/new-record'], function (req, res) {
     const data = req.session.data

--- a/app/routes/records-list-routes.js
+++ b/app/routes/records-list-routes.js
@@ -28,7 +28,7 @@ module.exports = router => {
     // We're not in a record, so make sure to flush record data
     // Nb this only deletes on second page load because session data
     // is already set at this point and we're not redirecting
-    delete req.session.data.record
+    delete req.session?.data?.record
 
     // Copy the query
     let query = Object.assign({}, req.query)

--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -19,7 +19,7 @@ module.exports = router => {
     let recordPath = utils.getRecordPath(req)
     let referrer = utils.getReferrer(req.query.referrer)
     if (traineeStarted == "false"){
-      delete record.trainingDetails.commencementDate
+      delete record?.trainingDetails?.commencementDate
     }   
     res.redirect(`${recordPath}/training-details/confirm${referrer}`)
 
@@ -302,7 +302,7 @@ module.exports = router => {
       req.flash('success', 'Trainee degree deleted')
       // Delete degree section if it’s empty
       if (data.record.degree.items.length == 0){
-        delete data.record.degree
+        delete data?.record?.degree
       }
     }
     if (referrer){
@@ -404,7 +404,7 @@ module.exports = router => {
     // Are they able to add placement details? (Shared on both draft and record)
     if (record.placement.hasPlacements == 'Yes'){
       // carry on and add one
-      delete record.placement.status
+      delete record?.placement.status
       res.redirect(`${recordPath}/placements/add${referrer}`)
     }
     // Record specific routes


### PR DESCRIPTION
This fixes a bug where we were unsafely using `delete` to attempt to delete properties of objects that didn't exist.

I had a search through the codebase and added optional chaining to all our nested deletes.

I also added a hacky feature I used for testing it. Visiting the `direct-add` route will load in a json blob for the record. This was particularly helpful for manually testing - without having to generate new seed data.