### PR TITLE
Hide the notice banner for some statuses

### DIFF
--- a/app/filters/statuses.js
+++ b/app/filters/statuses.js
@@ -120,7 +120,6 @@ filters.getCanReinstate = status => {
   return statusesThatAllowReinstating.includes(status)
 }
 
-
 // -------------------------------------------------------------------
 // keep the following line to return your filters to the app
 // -------------------------------------------------------------------

--- a/app/views/_includes/actions-banner.njk
+++ b/app/views/_includes/actions-banner.njk
@@ -4,7 +4,7 @@
 
 {{ hasCommencementDate | log }}
 
-{% if record | hasOutstandingActions %}
+{% if record | hasOutstandingActions and canAmend %}
 
     {{ appNoticeBanner({
       titleText: "You need to provide additional details before recording an outcome",


### PR DESCRIPTION
QTS Recommended, QTS Awarded and Withdrawn records don't need to see the notice banner.

Deferred records can currently be amended so it makes some sense that we still highlight outstanding actions on these records.