### PR TITLE
Add an override on the MoJ filter to remove the horizontal scrollbar

### DIFF
--- a/app/assets/sass/overrides/_moj-filter.scss
+++ b/app/assets/sass/overrides/_moj-filter.scss
@@ -62,3 +62,7 @@
 .moj-action-bar__filter:after {
   background: none;
 }
+
+.moj-filter-layout__content {
+  overflow: hidden;
+}


### PR DESCRIPTION
The MoJ filter pattern is designed to include a horizontal overflow which isn't relative to our situation. 

I'm suggesting we remove the ability to overflow horizontally.

This PR is a bit of a band aid solution, I'd like to follow it up with some refactoring of the layout on this page. 

![Screenshot 2021-03-08 at 07 41 08](https://user-images.githubusercontent.com/1108991/110290346-9b504e80-7fe2-11eb-902f-1b8e87e4546d.png)