### PR TITLE
Remove flash message when using draft link as things are already saved

### DIFF
--- a/app/routes/new-record-routes.js
+++ b/app/routes/new-record-routes.js
@@ -133,7 +133,7 @@ module.exports = router => {
       newRecord.status = "Draft" // just in case
       utils.deleteTempData(data)
       utils.updateRecord(data, newRecord)
-      req.flash('success', 'Record saved as draft')
+      // req.flash('success', 'Record saved as draft')
       res.redirect('/records')
     }
   })


### PR DESCRIPTION
We show a flash message when using the 'return to this draft record later' link but this isn't correct. On prod drafts are *always* saved, so there wouldn't be a flash message at this point.