### PR TITLE
Default to single provider view

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -49,7 +49,7 @@ settings.providerModel = "blended-model"
 // The providers the signed-in user belongs to
 settings.userProviders = [
   "Coventry University",
-  "University of Buckingham"
+  // "University of Buckingham"
 ]
 
 // The ‘active’ provider for the current user if using hat model

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -79,7 +79,9 @@
   }) }}
 
   {% set rightHandSideNavHtml %}
-    {% if data.isHatModel %}
+    {# Only show provider link if there’s more than one #}
+    {% if data.isHatModel and data.signedInProviders | length > 1 %}
+
       <nav class="moj-primary-navigation">
         <ul class="moj-primary-navigation__list">
           


### PR DESCRIPTION
Changes the prototype to default to a single provider view. This more closely matches the majority of use cases, and we're not going to explore multiple providers again for a while.