### PR TITLE
Update limits so we use radios by default for publish courses

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -78,7 +78,7 @@ settings.showBulkLinks = false
 settings.requireTraineeStartDate = 'true'
 
 // Default number of Publish courses that the provider offers
-settings.courseLimit = 20
+settings.courseLimit = 12
 
 // the minimum number of placements before EYTS/QTS can be awarded
 settings.minPlacementsRequired = 2

--- a/app/views/_includes/forms/course-details/pick-course.html
+++ b/app/views/_includes/forms/course-details/pick-course.html
@@ -119,7 +119,7 @@ defer to an id if one exists. #}
   <h1 class="govuk-heading-l">No courses found</h1>
   <p class="govuk-body">You shouldn’t be seeing this page</p>
 
-{% elseif providerCourses | length < 10 %}
+{% elseif providerCourses | length < 25 %}
   
   {{ providerHasFewPublishCourses | safe }}
 

--- a/app/views/new-record/course-details/pick-course.html
+++ b/app/views/new-record/course-details/pick-course.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_new-record.html" %}
 
-{% if data.courses | getProviderCourses(data.record.provider, data.record.route) | length < 10 %}
+{% if data.courses | getProviderCourses(data.record.provider, data.record.route) | length < 25 %}
   {% set pageHeading = "What course are they doing?" %}
 {% else %}
   {% set pageHeading = "Are the course details stored on Publish?" %}

--- a/app/views/record/course-details/pick-course.html
+++ b/app/views/record/course-details/pick-course.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_record-form.html" %}
 
-{% if data.courses | getProviderCourses(data.record.provider, data.record.route) | length < 10 %}
+{% if data.courses | getProviderCourses(data.record.provider, data.record.route) | length < 25 %}
   {% set pageHeading = "What course are they doing?" %}
 {% else %}
   {% set pageHeading = "Are the course details stored on Publish?" %}


### PR DESCRIPTION
This increases the limit before we swap over to an autocomplete for courses, and reduces the default truncation of courses - so that the default will be to show the page with radio options for courses - which we want to test, and that our developers are going to start building.