### PR TITLE
Offer deferred date when withdrawing if trainee is deferred

### DIFF
--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -180,6 +180,18 @@ exports.routeHasPublishCourses = function(record){
 // Records
 // -------------------------------------------------------------------
 
+exports.isAwarded = record =>{
+  return record.status == "QTS awarded" || record.status == "EYTS awarded"
+}
+
+exports.isDeferred = record =>{
+  return record.status == "Deferred"
+}
+
+exports.isWithdrawn = record =>{
+  return record.status == "Withdrawn"
+}
+
 // Check if all sections are complete
 exports.recordIsComplete = record => {
   if (!record || !_.get(record, "route")) return false

--- a/app/routes/existing-record-routes.js
+++ b/app/routes/existing-record-routes.js
@@ -287,12 +287,16 @@ module.exports = router => {
     }
     else {
       let radioChoice = newRecord.withdrawalDateRadio
+      console.log({radioChoice})
+      if (radioChoice == "Deferred date"){
+        newRecord.withdrawalDate = newRecord.deferredDate
+      }
       if (radioChoice == "Today") {
         newRecord.withdrawalDate = filters.toDateArray(filters.today())
       } 
       if (radioChoice == "Yesterday") {
         newRecord.withdrawalDate = filters.toDateArray(moment().subtract(1, "days"))
-      } 
+      }
       res.redirect('/record/' + req.params.uuid + '/withdraw/confirm')
     }
   })

--- a/app/routes/existing-record-routes.js
+++ b/app/routes/existing-record-routes.js
@@ -286,17 +286,20 @@ module.exports = router => {
       res.redirect('/record/:uuid')
     }
     else {
-      let radioChoice = newRecord.withdrawalDateRadio
-      console.log({radioChoice})
-      if (radioChoice == "Deferred date"){
+
+      if (utils.isDeferred(newRecord)){
         newRecord.withdrawalDate = newRecord.deferredDate
       }
-      if (radioChoice == "Today") {
-        newRecord.withdrawalDate = filters.toDateArray(filters.today())
-      } 
-      if (radioChoice == "Yesterday") {
-        newRecord.withdrawalDate = filters.toDateArray(moment().subtract(1, "days"))
+      else {
+        let radioChoice = newRecord.withdrawalDateRadio
+        if (radioChoice == "Today") {
+          newRecord.withdrawalDate = filters.toDateArray(filters.today())
+        } 
+        if (radioChoice == "Yesterday") {
+          newRecord.withdrawalDate = filters.toDateArray(moment().subtract(1, "days"))
+        }
       }
+
       res.redirect('/record/' + req.params.uuid + '/withdraw/confirm')
     }
   })

--- a/app/views/_includes/forms/withdraw.html
+++ b/app/views/_includes/forms/withdraw.html
@@ -36,35 +36,51 @@
   }) }}
 {% endset %}
 
-{{ govukRadios({
-  fieldset: {
-    legend: {
-      text: "What date did the trainee formally withdraw?",
-      classes: "govuk-fieldset__legend--s govuk-!-margin-bottom-4"
-    }
-  },
-  items: [
-    {
-      text: "When they deferred",
-      value: "Deferred date",
-      hint: {
-        text: 'Deferred on ' + record.deferredDate | govukDate
+{# Trainees who withdraw whilst deferred must use deferral date as withdrawal date #}
+{% if record | isDeferred %}
+  {% set deferredTextHtml %}
+    <p class="govuk-body">
+      We’ll use the trainee’s deferral date of <span class="govuk-!-font-weight-bold">{{record.deferredDate | govukDate }}</span> as their withdrawal date.
+    </p>
+    <p class="govuk-body">
+      If you need to use a different date, you should <a href="./reinstate">reinstate this trainee</a> first before withdrawing them.
+    </p>
+  {% endset %}
+
+  <h2 class="govuk-heading-s">Withdrawal date</h2>
+
+  {{ govukInsetText({
+    html: deferredTextHtml
+  }) }}
+
+{% else %}
+
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        text: "What date did the trainee formally withdraw?",
+        classes: "govuk-fieldset__legend--s govuk-!-margin-bottom-4"
       }
-    } if (record.status == "Deferred"),
-    {
-      text: "Today"
     },
-    {
-      text: "Yesterday"
-    },
-    {
-      text: "On another day",
-      conditional: {
-        html: customWithdrawalDate
+    items: [
+      {
+        text: "Today"
+      },
+      {
+        text: "Yesterday"
+      },
+      {
+        text: "On another day",
+        conditional: {
+          html: customWithdrawalDate
+        }
       }
-    }
-  ]
-} | decorateAttributes(record, "record.withdrawalDateRadio")) }}
+    ]
+  } | decorateAttributes(record, "record.withdrawalDateRadio")) }}
+
+{% endif %}
+
+
 
 {% set customWithdrawalReason %}
   {{ govukInput({

--- a/app/views/_includes/forms/withdraw.html
+++ b/app/views/_includes/forms/withdraw.html
@@ -43,7 +43,7 @@
       We’ll use the trainee’s deferral date of <span class="govuk-!-font-weight-bold">{{record.deferredDate | govukDate }}</span> as their withdrawal date.
     </p>
     <p class="govuk-body">
-      If you need to use a different date, you should <a href="./reinstate">reinstate this trainee</a> first before withdrawing them.
+      To use a different date, <a href="./reinstate">reinstate this trainee</a> then withdraw them.
     </p>
   {% endset %}
 

--- a/app/views/_includes/forms/withdraw.html
+++ b/app/views/_includes/forms/withdraw.html
@@ -43,7 +43,7 @@
       We’ll use the trainee’s deferral date of <span class="govuk-!-font-weight-bold">{{record.deferredDate | govukDate }}</span> as their withdrawal date.
     </p>
     <p class="govuk-body">
-      To use a different date, <a href="./reinstate">reinstate this trainee</a> then withdraw them.
+      To use a different date, <a href="./reinstate">reinstate this trainee</a>, then withdraw them.
     </p>
   {% endset %}
 

--- a/app/views/_includes/forms/withdraw.html
+++ b/app/views/_includes/forms/withdraw.html
@@ -39,7 +39,7 @@
 {{ govukRadios({
   fieldset: {
     legend: {
-      text: "What date did the trainee withdraw?",
+      text: "What date did the trainee formally withdraw?",
       classes: "govuk-fieldset__legend--s govuk-!-margin-bottom-4"
     }
   },

--- a/app/views/_includes/forms/withdraw.html
+++ b/app/views/_includes/forms/withdraw.html
@@ -39,11 +39,18 @@
 {{ govukRadios({
   fieldset: {
     legend: {
-      text: "When did the trainee withdraw?",
+      text: "What date did the trainee withdraw?",
       classes: "govuk-fieldset__legend--s govuk-!-margin-bottom-4"
     }
   },
   items: [
+    {
+      text: "When they deferred",
+      value: "Deferred date",
+      hint: {
+        text: 'Deferred on ' + record.deferredDate | govukDate
+      }
+    } if (record.status == "Deferred"),
     {
       text: "Today"
     },

--- a/app/views/_includes/summary-cards/student-record.html
+++ b/app/views/_includes/summary-cards/student-record.html
@@ -111,7 +111,7 @@
   }) %}
 {% endif %}
 
-{% if (record.status == "Deferred") %}
+{% if (record | isDeferred) %}
   {% set deferredContent %}
       {{govukTag({
         text: "Deferred",

--- a/app/views/_includes/summary-cards/withdraw-details.html
+++ b/app/views/_includes/summary-cards/withdraw-details.html
@@ -1,3 +1,12 @@
+{% set withdrawalDate %}
+  {% if record | isDeferred %}
+    {{ record.withdrawalDate | govukDate }} (date of deferral)
+  {% else %}
+    {{ record.withdrawalDate | govukDate or "Not provided" }}
+  {% endif %}
+{% endset %}
+
+
 {% set withdrawalReason %}
   {% if record.withdrawalReason == "For another reason" %}
     {{record.withdrawalReasonOther}}
@@ -6,13 +15,15 @@
   {% endif %}
 {% endset %}
 
+
+
 {% set withdrawDetailsRows = [
   {
     key: {
       text: "Date of withdrawal"
     },
     value: {
-      text: record.withdrawalDate | govukDate or 'Not provided'
+      text: withdrawalDate
     },
     actions: {
       items: [
@@ -22,7 +33,7 @@
           visuallyHiddenText: "withdrawal date"
         }
       ]
-    } if canAmend
+    } if canAmend and record.status != "Deferred"
   },
   {
     key: {


### PR DESCRIPTION
We've heard in user research that trainees will defer for some time, and then may decide to withdraw from the course. In such a situation the provider should use the original deferral date as the withdrawal date - as this is the last time they were on the course.

On our current withdrawal page, the date of deferral isn't visible - but is the likely one. This 'defers' to the deferral date if the trainee is currently deferred.

![Screenshot 2021-04-07 at 17 43 37](https://user-images.githubusercontent.com/2204224/114014080-20d45200-9860-11eb-82b4-98455f3bb4ad.png)

![Screenshot 2021-03-31 at 12 32 51](https://user-images.githubusercontent.com/2204224/113138127-4a1c2f00-921d-11eb-8771-736ec4005642.png)

