### PR TITLE
Tweak how we refer to an academic year

### DIFF
--- a/app/views/_includes/filter-panel.njk
+++ b/app/views/_includes/filter-panel.njk
@@ -11,12 +11,12 @@
     },
     items: [
       {
-        text: "2020 to 2021 (current)",
-        checked: checked(query.filterCycle, "2020 to 2021 (current)") if query.filterCycle else 'checked'
+        text: "2020/21 (current)",
+        checked: checked(query.filterCycle, "2020/21 (current)") if query.filterCycle else 'checked'
       },
       {
-        text: "2019 to 2020",
-        checked: checked(query.filterCycle, "2019 to 2020")
+        text: "2019/20",
+        checked: checked(query.filterCycle, "2019/20")
       }
     ]
   } | decorateAttributes(data, "data.filterCycle"))}}

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -42,7 +42,7 @@
 
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-    <h2 class="govuk-heading-m">Your 2020 to 2021 trainees</h2>
+    <h2 class="govuk-heading-m">Your 2020/21 trainees</h2>
 
     {% set records = data.providerRecords | filterByYear(data.currentYear)| filterDisabledTrainingRoutes %}
 


### PR DESCRIPTION
We had a participant comment that `2020 to 2021` was incorrect and ambiguous. This makes it closer to other usage.