### PR TITLE
Add hint to course selection page

### DIFF
--- a/app/views/_includes/forms/course-details/pick-course.html
+++ b/app/views/_includes/forms/course-details/pick-course.html
@@ -36,6 +36,10 @@ defer to an id if one exists. #}
     checked: checked(selectedCourse, "Other")
   }) %}
 
+  {% set hintText %}
+    Your {{record.route | lower}} courses in the Publish service
+  {% endset %}
+
   {{ govukRadios({
     fieldset: {
       legend: {
@@ -43,6 +47,9 @@ defer to an id if one exists. #}
         isPageHeading: true,
         classes: "govuk-fieldset__legend--l"
       }
+    },
+    hint: {
+      text: hintText
     },
     items: courseItems
   } | decorateAttributes(record, "record.selectedCourseTemp")) }}

--- a/app/views/_includes/forms/course-details/pick-course.html
+++ b/app/views/_includes/forms/course-details/pick-course.html
@@ -37,7 +37,7 @@ defer to an id if one exists. #}
   }) %}
 
   {% set hintText %}
-    Your {{record.route | lower}} courses in the Publish service
+    Your {{record.route | lower | replace("(", "") | replace(")", "")}} courses in the Publish service
   {% endset %}
 
   {{ govukRadios({


### PR DESCRIPTION
We've seen some users unsure where these courses are from, or why they're just *some* of the courses. This should help reinforce that these are from Publish and that they're for the route the user has selected.

![Screenshot 2021-03-31 at 16 43 54](https://user-images.githubusercontent.com/2204224/113172413-51a0ff80-9240-11eb-940c-1dd385f44a7f.png)

Note the 'stored' route name includes brackets around `postgrad` and `undergrad`. This looks a bit weird in a sentence so I've stripped them here.
