### PR TITLE
Stop stopwords from being applied and add debug mode

### DIFF
--- a/app/views/_components/school-autocomplete/template.njk
+++ b/app/views/_components/school-autocomplete/template.njk
@@ -20,6 +20,7 @@
   var statusMessage = null
   var searchQuery = ''
   var searchCallback = function () {}
+  var debug = ({{ data.settings.searchDebug or false }}) ? true : false
 
   // Results that are rendered by the autocomplete
   var searchResults = []
@@ -54,7 +55,9 @@
     }).slice(0, 15)
 
     searchResults = lunrSearchResults.map(function (result) {
-      return documentStore[result.ref]
+      let item = documentStore[result.ref]
+      item.score = result.score.toFixed(2)
+      return item
     })
 
     if (searchResults.length === 0) {
@@ -84,8 +87,15 @@
 
   var suggestion = (result) => {
     if (result) {
+      var name
+      if (debug){
+        name = `${result.score}: ${result.name}`
+      }
+      else {
+        name = result.name
+      }
       var hint = `URN ${result.urn}, ${result.town}, ${result.postcode}`
-      return `${result.name}<span class="autocomplete__option-hint">${hint}</span>`
+      return `${name}<span class="autocomplete__option-hint">${hint}</span>`
     }
   }
 

--- a/scripts/generate_search_index.js
+++ b/scripts/generate_search_index.js
@@ -31,7 +31,9 @@ module.exports = function buildIndex () {
     // Disable stemming of documents when generating the index
     this.pipeline.remove(lunr.stemmer)
     // Disable stemming of search terms run against this index
-    this.searchPipeline.remove(lunr.stemmer)
+    this.pipeline.remove(lunr.stemmer)
+    // Stop lunar from disregarding stop words like "the"
+    this.pipeline.remove(lunr.stopWordFilter)
 
     documents.forEach(doc => {
       store[doc.uuid] = {


### PR DESCRIPTION
By default Lunr is excluding stop words. This stopped a participant from being able to search for `The Foo...`

Also adds a debug mode (no ui to enable) to display the Lunr score.