### PR TITLE
Home status cards update

### DIFF
--- a/app/assets/sass/components/_status-card.scss
+++ b/app/assets/sass/components/_status-card.scss
@@ -102,7 +102,7 @@ $statuses: (
   }
 }
 
-.status-card__type {
+.status-card__status {
   text-decoration: underline;
   overflow-wrap: break-word;
   word-wrap: break-word;

--- a/app/assets/sass/components/_status-card.scss
+++ b/app/assets/sass/components/_status-card.scss
@@ -104,4 +104,7 @@ $statuses: (
 
 .status-card__type {
   text-decoration: underline;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  hyphens: auto;
 }

--- a/app/assets/sass/components/_status-card.scss
+++ b/app/assets/sass/components/_status-card.scss
@@ -101,3 +101,7 @@ $statuses: (
     display: block;
   }
 }
+
+.status-card__type {
+  text-decoration: underline;
+}

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -67,7 +67,7 @@
       {% set eytsCount = records | where("status", ['EYTS recommended', 'EYTS awarded']) | length %}
       {% set qtsCount = records | where("status", ['QTS recommended', 'QTS awarded']) | length %}
       
-      {% if qtsCount == 0 %}
+      {% if eytsCount == 0 %}
         <div class="govuk-grid-row govuk-!-margin-bottom-6 home-statuses__flex-row">
           {% set statuses = ['QTS recommended','QTS awarded', 'Deferred', 'Withdrawn'] %}
           {% for status in statuses %}
@@ -76,7 +76,7 @@
             </div>
           {% endfor %}
         </div>
-      {% elseif eytsCount == 0 %}
+      {% elseif qtsCount == 0 %}
         <div class="govuk-grid-row govuk-!-margin-bottom-6 home-statuses__flex-row">
           {% set statuses = ['EYTS recommended', 'EYTS awarded', 'Deferred', 'Withdrawn'] %}
           {% for status in statuses %}

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -50,7 +50,7 @@
       <a href="/records?filterStatus={{status}}" class="status-card status-card--{{status | lower | kebabCase }}">
         {% set recordCount = records | where("status", status) | length %}
         <span class="status-card__count">{{recordCount}}</span>
-        <span class="status-card__type">{{status}}</span><span class="govuk-visually-hidden"> records. View these records.</span>
+        <span class="status-card__status">{{status}}</span><span class="govuk-visually-hidden"> records. View these records.</span>
       </a>
     {% endmacro %}
 
@@ -91,14 +91,14 @@
             <a href="/records?filterStatus=EYTS recommended&filterStatus=QTS recommended" class="status-card status-card--recommended">
               {% set recordCount = records | where("status", ['EYTS recommended','QTS recommended']) | length %}
               <span class="status-card__count">{{recordCount}}</span>
-              <span class="status-card__type">Qualification recommended</span> <span class="govuk-visually-hidden"> records. View these records.</span>
+              <span class="status-card__status">Qualification recommended</span> <span class="govuk-visually-hidden"> records. View these records.</span>
             </a>
           </div>
           <div class="govuk-grid-column-one-quarter">
             <a href="/records?filterStatus=EYTS awarded&filterStatus=QTS awarded" class="status-card status-card--awarded">
               {% set recordCount = records | where("status", ['EYTS awarded','QTS awarded']) | length %}
               <span class="status-card__count">{{recordCount}}</span>
-              <span class="status-card__type">Qualification awarded</span><span class="govuk-visually-hidden"> records. View these records.</span>
+              <span class="status-card__status">Qualification awarded</span><span class="govuk-visually-hidden"> records. View these records.</span>
             </a>
           </div>
           {% set statuses = ['Deferred', 'Withdrawn'] %}

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -67,8 +67,8 @@
       {% set eytsCount = records | where("status", ['EYTS recommended', 'EYTS awarded']) | length %}
       {% set qtsCount = records | where("status", ['QTS recommended', 'QTS awarded']) | length %}
       
-      {% if eytsCount == 0 %}
-        <div class="govuk-grid-row govuk-!-margin-bottom-6">
+      {% if qtsCount == 0 %}
+        <div class="govuk-grid-row govuk-!-margin-bottom-6 home-statuses__flex-row">
           {% set statuses = ['QTS recommended','QTS awarded', 'Deferred', 'Withdrawn'] %}
           {% for status in statuses %}
             <div class="govuk-grid-column-one-quarter">
@@ -76,8 +76,8 @@
             </div>
           {% endfor %}
         </div>
-      {% elseif qtsCount == 0 %}
-        <div class="govuk-grid-row govuk-!-margin-bottom-6">
+      {% elseif eytsCount == 0 %}
+        <div class="govuk-grid-row govuk-!-margin-bottom-6 home-statuses__flex-row">
           {% set statuses = ['EYTS recommended', 'EYTS awarded', 'Deferred', 'Withdrawn'] %}
           {% for status in statuses %}
             <div class="govuk-grid-column-one-quarter">

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -50,7 +50,7 @@
       <a href="/records?filterStatus={{status}}" class="status-card status-card--{{status | lower | kebabCase }}">
         {% set recordCount = records | where("status", status) | length %}
         <span class="status-card__count">{{recordCount}}</span>
-        {{status}}
+        <span class="status-card__type">{{status}}</span><span class="govuk-visually-hidden"> records. View these records.</span>
       </a>
     {% endmacro %}
 
@@ -63,31 +63,56 @@
           </div>
         {% endfor %}
       </div>
-      <div class="govuk-grid-row govuk-!-margin-bottom-6 home-statuses__flex-row">
-        <div class="govuk-grid-column-one-quarter">
-          <a href="/records?filterStatus=EYTS recommended&filterStatus=QTS recommended" class="status-card status-card--recommended">
-            {% set recordCount = records | where("status", ['EYTS recommended','QTS recommended']) | length %}
-            <span class="status-card__count">{{recordCount}}</span>
-            Qualification recommended
-          </a>
-        </div>
-        <div class="govuk-grid-column-one-quarter">
-          <a href="/records?filterStatus=EYTS awarded&filterStatus=QTS awarded" class="status-card status-card--awarded">
-            {% set recordCount = records | where("status", ['EYTS awarded','QTS awarded']) | length %}
-            <span class="status-card__count">{{recordCount}}</span>
-            Qualification awarded
-          </a>
-        </div>
-        {% set statuses = ['Deferred', 'Withdrawn'] %}
-        {% for status in statuses %}
-          <div class="govuk-grid-column-one-quarter">
-            {{ statusCard(records, status) }}
-          </div>
-        {% endfor %}
-      </div>
-    </div>
-  </div>
 
+      {% set eytsCount = records | where("status", ['EYTS recommended', 'EYTS awarded']) | length %}
+      {% set qtsCount = records | where("status", ['QTS recommended', 'QTS awarded']) | length %}
+      
+      {% if eytsCount == 0 %}
+        <div class="govuk-grid-row govuk-!-margin-bottom-6">
+          {% set statuses = ['QTS recommended','QTS awarded', 'Deferred', 'Withdrawn'] %}
+          {% for status in statuses %}
+            <div class="govuk-grid-column-one-quarter">
+              {{ statusCard(records, status) }}
+            </div>
+          {% endfor %}
+        </div>
+      {% elseif qtsCount == 0 %}
+        <div class="govuk-grid-row govuk-!-margin-bottom-6">
+          {% set statuses = ['EYTS recommended', 'EYTS awarded', 'Deferred', 'Withdrawn'] %}
+          {% for status in statuses %}
+            <div class="govuk-grid-column-one-quarter">
+              {{ statusCard(records, status) }}
+            </div>
+          {% endfor %}
+        </div>
+      {% else %}
+        <div class="govuk-grid-row govuk-!-margin-bottom-6 home-statuses__flex-row">
+          <div class="govuk-grid-column-one-quarter">
+            <a href="/records?filterStatus=EYTS recommended&filterStatus=QTS recommended" class="status-card status-card--recommended">
+              {% set recordCount = records | where("status", ['EYTS recommended','QTS recommended']) | length %}
+              <span class="status-card__count">{{recordCount}}</span>
+              <span class="status-card__type">Qualification recommended</span> <span class="govuk-visually-hidden"> records. View these records.</span>
+            </a>
+          </div>
+          <div class="govuk-grid-column-one-quarter">
+            <a href="/records?filterStatus=EYTS awarded&filterStatus=QTS awarded" class="status-card status-card--awarded">
+              {% set recordCount = records | where("status", ['EYTS awarded','QTS awarded']) | length %}
+              <span class="status-card__count">{{recordCount}}</span>
+              <span class="status-card__type">Qualification awarded</span><span class="govuk-visually-hidden"> records. View these records.</span>
+            </a>
+          </div>
+          {% set statuses = ['Deferred', 'Withdrawn'] %}
+          {% for status in statuses %}
+            <div class="govuk-grid-column-one-quarter">
+              {{ statusCard(records, status) }}
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+
+    </div>
+
+  </div>
 </div>
 
 


### PR DESCRIPTION
This PR:

- Sets up three conditional rows to show either QTS, EYTS or a combined qualification depending on the status count
- An underline on the status to give more affordance that they are links
- Screen reader only text to provide context to the links
- Additional styles added to ensure text wraps nicely inside the boxes and that the boxes remain the same height at smaller viewports

**Preview**

![Screenshot 2021-04-01 at 15 20 36](https://user-images.githubusercontent.com/1108991/113310900-9ee4a600-9300-11eb-9847-a17a7baa1458.png)

**Before @ smaller viewport (~650px)** 

![Screenshot 2021-04-01 at 15 33 50](https://user-images.githubusercontent.com/1108991/113310698-6b098080-9300-11eb-8423-8b85c67b8cf0.png)

**After @ smaller viewport (~650px)**

![Screenshot 2021-04-01 at 15 34 02](https://user-images.githubusercontent.com/1108991/113310739-73fa5200-9300-11eb-8890-287919b0b39e.png)
