### PR TITLE
Fix stemming being incorrectly enabled

### DIFF
--- a/scripts/generate_search_index.js
+++ b/scripts/generate_search_index.js
@@ -31,7 +31,7 @@ module.exports = function buildIndex () {
     // Disable stemming of documents when generating the index
     this.pipeline.remove(lunr.stemmer)
     // Disable stemming of search terms run against this index
-    this.pipeline.remove(lunr.stemmer)
+    this.searchPipeline.remove(lunr.stemmer)
     // Stop lunar from disregarding stop words like "the"
     this.pipeline.remove(lunr.stopWordFilter)
 


### PR DESCRIPTION
Having stemming enabled breaks searches that contain stemmable words.