### PR TITLE
Read schools data inside of a function to save memory

### DIFF
--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -3,8 +3,11 @@ const path = require('path')
 const moment = require('moment')
 const utils = require('./../lib/utils')
 const _ = require('lodash')
-const schools = require('./../data/gis-schools.js') // Loaded manually because this is too big to pass around in session
 
+// In function because this is too big to pass around in session
+const getSchools = () => {
+  return require('./../data/gis-schools.js')
+}
 
 module.exports = router => {
 
@@ -110,6 +113,7 @@ module.exports = router => {
     let record = data.record
     let recordPath = utils.getRecordPath(req)
     let referrer = utils.getReferrer(req.query.referrer)
+    let schools = getSchools()
 
     // Input added with js by the autocomplete
     let autocompleteRawValue = req.body?._autocomplete_raw_value_school_picker
@@ -200,6 +204,7 @@ module.exports = router => {
     if (schoolSearchTerm){
       let results = false
       let resultsCount = 0
+      let schools = getSchools()
       results = utils.searchSchools(schools, schoolSearchTerm)
       resultsCount = results.length
       results = results.slice(0, 15) // truncate results
@@ -218,6 +223,7 @@ module.exports = router => {
     let record = data.record
     let recordPath = utils.getRecordPath(req)
     let referrer = utils.getReferrer(req.query.referrer)
+    let schools = getSchools()
 
     // Input added with js by the autocomplete
     let autocompleteRawValue = req.body?._autocomplete_raw_value_school_picker
@@ -232,6 +238,7 @@ module.exports = router => {
     // raw autocomplete string submitted. If they don’t match, wipe the UUID as it’s invalid - and instead we should
     // run a string search for the given name.
     if (autocompleteUuid && autocompleteRawValue){
+
       let selectedSchool = schools.find(school => school.uuid == autocompleteUuid)
       if (selectedSchool?.schoolName != autocompleteRawValue){
         autocompleteUuid = undefined

--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -91,6 +91,7 @@ module.exports = router => {
     let recordPath = utils.getRecordPath(req)
     let referrer = utils.getReferrer(req.query.referrer)
     let schoolSearchTerm = req.query?._schoolSearch
+    const schools = getSchools()
 
     if (schoolSearchTerm){
       let results = false
@@ -113,7 +114,7 @@ module.exports = router => {
     let record = data.record
     let recordPath = utils.getRecordPath(req)
     let referrer = utils.getReferrer(req.query.referrer)
-    let schools = getSchools()
+    const schools = getSchools()
 
     // Input added with js by the autocomplete
     let autocompleteRawValue = req.body?._autocomplete_raw_value_school_picker
@@ -200,11 +201,12 @@ module.exports = router => {
     let recordPath = utils.getRecordPath(req)
     let referrer = utils.getReferrer(req.query.referrer)
     let schoolSearchTerm = req.query?._schoolSearch
+    const schools = getSchools()
 
     if (schoolSearchTerm){
       let results = false
       let resultsCount = 0
-      let schools = getSchools()
+      
       results = utils.searchSchools(schools, schoolSearchTerm)
       resultsCount = results.length
       results = results.slice(0, 15) // truncate results
@@ -223,7 +225,7 @@ module.exports = router => {
     let record = data.record
     let recordPath = utils.getRecordPath(req)
     let referrer = utils.getReferrer(req.query.referrer)
-    let schools = getSchools()
+    const schools = getSchools()
 
     // Input added with js by the autocomplete
     let autocompleteRawValue = req.body?._autocomplete_raw_value_school_picker


### PR DESCRIPTION
This was previously reading in the schools data (quite a large file) each time `shared-edit-routes.js` was loaded - slowing down the prototype considerably.

This moves it to a function that only gets called for the routes that actually need the data.