### PR TITLE
Don't prefill invalid answers

### DIFF
--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -714,7 +714,8 @@ exports.captureInvalid = function(data){
   if (data.value && data.value.includes("**invalid**")){
     // data.value = data.value.replace("**invalid**", "")
     _.set(this.ctx, 'data.temp.invalidString', data.value)
-    data.value = data.value.replace("**invalid**", "")
+    // data.value = data.value.replace("**invalid**", "")
+    data.value = '' // wipe the value
   }
   return data
 }


### PR DESCRIPTION
Having an invalid answer pre-filled confused our participant as they weren't clear they needed to enter something.

![Screenshot 2021-05-05 at 13 56 24](https://user-images.githubusercontent.com/2204224/117144328-b6a0c580-ada9-11eb-8395-a72c48c265e3.png)
