### PR TITLE
Alternative homepage concept

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -26,6 +26,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "helpers";
 @import "helpers/field-widths";
 @import "helpers/width-container";
+@import "helpers/show-hide-at-breakpoint";
 
 // Components that aren't in Frontend
 @import "components/application-card";

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -35,6 +35,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "components/banner";
 @import "components/button-as-link";
 @import "components/cookie-banner";
+@import "components/dashboard-header";
 @import "components/invalid-answer";
 @import "components/notice-banner";
 @import "components/record-header";

--- a/app/assets/sass/components/_action-required-item.scss
+++ b/app/assets/sass/components/_action-required-item.scss
@@ -14,11 +14,11 @@
 }
 
 .app-action-required-item__content {
-  flex: 1;
+  // flex: 1;
 }
 
 .app-action-required-item__text {
-  @include govuk-font($size: 24);
+  @include govuk-font($size: 19);
   display: inline-block;
   margin-bottom: govuk-spacing(1);
   font-weight: bold;
@@ -29,7 +29,7 @@
 }
 
 .app-action-required-item__count {
-  @include govuk-font($size: 24);
+  @include govuk-font($size: 19);
   display: flex;
   width: 40px;
   height: 40px;

--- a/app/assets/sass/components/_action-required-item.scss
+++ b/app/assets/sass/components/_action-required-item.scss
@@ -14,7 +14,7 @@
 }
 
 .app-action-required-item__content {
-  // flex: 1;
+  flex: 1;
 }
 
 .app-action-required-item__text {

--- a/app/assets/sass/components/_dashboard-header.scss
+++ b/app/assets/sass/components/_dashboard-header.scss
@@ -1,0 +1,14 @@
+// Trainee record actions panel
+
+.app-dashboard-header {
+
+  & > * {
+    margin-bottom: 0 !important;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    display: flex; 
+    justify-content: space-between; 
+    align-items: center
+  }
+}

--- a/app/assets/sass/components/_dashboard-header.scss
+++ b/app/assets/sass/components/_dashboard-header.scss
@@ -1,14 +1,15 @@
-// Trainee record actions panel
+// Dashboard header section
 
 .app-dashboard-header {
 
-  & > * {
-    margin-bottom: 0 !important;
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    // Ensure the items stay at opposite ends of this section 
+    justify-content: space-between;
+
+    & > * {
+      margin-bottom: 0 !important;
+    }
   }
 
-  @include govuk-media-query($from: tablet) {
-    display: flex; 
-    justify-content: space-between; 
-    align-items: center
-  }
 }

--- a/app/assets/sass/components/_status-card.scss
+++ b/app/assets/sass/components/_status-card.scss
@@ -41,6 +41,11 @@
 // Colours sourced from here: https://github.com/alphagov/govuk-frontend/blob/61aabca3d440edee6bdecdd20ea54a241c7bbdd5/src/govuk/components/tag/_index.scss#L42
 
 $statuses: (
+  "total": (
+    "colour":            govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30),
+    "background-colour": govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90),
+    "hover":             govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 80)
+  ),
   "draft": (
     "colour":            govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30),
     "background-colour": govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90),

--- a/app/assets/sass/components/_status-card.scss
+++ b/app/assets/sass/components/_status-card.scss
@@ -6,17 +6,33 @@
   text-decoration: none;
 
   @include govuk-font($size: 19);
-
+  
   @include govuk-media-query($from: desktop) {
     padding: govuk-spacing(4);
   }
-
+  
   &:focus, &:link:focus, &:visited:focus {
     color:  $govuk-text-colour;
     background:  $govuk-focus-colour;
   }
 
 }
+
+.status-card--small {
+  @include govuk-font($size: 16);
+
+  .status-card__count {
+    &, &:link, &:visited {
+      @include govuk-font($size: 27, $weight: bold, $tabular: true);
+      display: block;
+    }
+  }
+
+  @include govuk-media-query($from: desktop) {
+    padding: govuk-spacing(2);
+  }
+}
+
 
 .status-card, .status-card:visited {
   color: inherit;

--- a/app/assets/sass/helpers/_show-hide-at-breakpoint.scss
+++ b/app/assets/sass/helpers/_show-hide-at-breakpoint.scss
@@ -1,0 +1,27 @@
+// Helper classes to show/hide an element based on viewport width
+
+// Specifically leaving out a default `display` property as we don't know if it originally would be have been eg inline/flex/block
+
+.hide-from-tablet {
+  @include govuk-media-query($from: tablet) {
+    display: none;
+  }
+}
+
+.hide-from-desktop {
+  @include govuk-media-query($from: desktop) {
+    display: none;
+  }
+}
+
+.hide-until-tablet {
+  @include govuk-media-query($until: tablet) {
+    display: none;
+  }
+}
+
+.hide-until-desktop {
+  @include govuk-media-query($until: desktop) {
+    display: none;
+  }
+}

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -39,6 +39,8 @@
       </div>
       <div class="govuk-grid-column-three-quarters-from-desktop">
 
+        {# suggesting we move these to a dedicated page #}
+        
         {# {% if data.settings.showRequiresAttentionSection and combinedAlertCount > 0 %}
           <h2 class="govuk-heading-m">Requires action</h2>
           {% if applyDraftCount > 0 %}

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -8,48 +8,38 @@
 {% block content %}
 
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds-from-desktop">
-        <h1 class="govuk-heading-l">{{serviceName}}</h1>
-        <p class="govuk-body-l">Register trainees with the Department for Education and record the outcome of their training.</p>
+      <div class="govuk-grid-column-full app-dashboard-header">
+        <h1 class="govuk-heading-l">Trainee teacher dashboard</h1>
         {{ govukButton({
           text: "Add a trainee",
-          href: "./new-record/new",
-          isStartButton: true
+          href: "./new-record/new"
         }) }}
       </div>
     </div>
-    
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
     <div class="govuk-grid-row">
-
-      <div class="govuk-grid-column-one-third">
-        <h2 class="govuk-heading-m"><a href="/records" class="govuk-link govuk-link--no-visited-state">Trainee records</a></h2>
-        <p class="govuk-body">Review and manage your trainee records.</p>
-      </div>
-      {% if data.settings.includeGuidance %}
-        <div class="govuk-grid-column-one-third">
-          <h2 class="govuk-heading-m"><a href="/guidance" class="govuk-link govuk-link--no-visited-state">Guidance</a></h2>
-          <p class="govuk-body">Service guidance for each route.</p>
+      <div class="govuk-grid-column-one-quarter-from-desktop">
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><a href="/records" class="govuk-link govuk-link--no-visited-state">Trainee records</a></h2>
+        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">Review and manage your trainee records.</p>
+        {% if data.settings.includeGuidance %}
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><a href="/guidance" class="govuk-link govuk-link--no-visited-state">Guidance</a></h2>
+          <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">Service guidance for each route.</p>
+        {% endif %}
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><a href="#" class="govuk-link govuk-link--no-visited-state">Give feedback</a></h2>
+        <p class="govuk-body  govuk-!-font-size-16 govuk-!-margin-bottom-1">This is a new service. Your views will help us improve it.</p>
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><a href="/data-requirements" class="govuk-link govuk-link--no-visited-state">Check what data you need</a></h2>
+        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">The data you need to complete a trainee record.</p>
+        <div class="app-action-required-item govuk-!-margin-top-2" style="flex-direction: row-reverse">
+          <span class="app-action-required-item__count govuk-!-margin-right-7" style="width: 30px; height: 30px; font-size: 19px">2</span>
+          <div class="app-action-required-item__content">
+            <a href="/notifications" class="govuk-link app-action-required-item__text">Notifications</a>
+          </div>
         </div>
-      {% endif %}
-      <div class="govuk-grid-column-one-third">
-        <h2 class="govuk-heading-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Give feedback</a></h2>
-        <p class="govuk-body">This is a new service. Your views will help us improve it.</p>
       </div>
-      <div class="govuk-grid-column-one-third">
-        <h2 class="govuk-heading-m"><a href="/data-requirements" class="govuk-link govuk-link--no-visited-state">Check what data you need</a></h2>
-        <p class="govuk-body">The data you need to complete a trainee record.</p>
-      </div>
+      <div class="govuk-grid-column-three-quarters-from-desktop">
 
-    </div>
-
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
-    {% if data.settings.showRequiresAttentionSection and combinedAlertCount > 0 %}
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds-from-desktop">
-          <h2 class="govuk-heading-m">Requires your attention</h2>
+        {# {% if data.settings.showRequiresAttentionSection and combinedAlertCount > 0 %}
+          <h2 class="govuk-heading-m">Requires action</h2>
           {% if applyDraftCount > 0 %}
             <div class="app-action-required-item">
               <span class="app-action-required-item__count">{{applyDraftCount}}</span>
@@ -63,92 +53,133 @@
             <div class="app-action-required-item">
               <span class="app-action-required-item__count">{{recordsToBeReviewedCount}}</span>
               <div class="app-action-required-item__content">
-                <a href="#" class="govuk-link app-action-required-item__text">Records for review before cycle ends</a>
+                <a href="#" class="govuk-link app-action-required-item__text">records for review before cycle ends</a>
                 <span class="app-action-required-item__hint-text govuk-hint govuk-!-font-size-16">The cycle ends on August 27 2021</span>
               </div>
             </div>
           {% endif %}
-        </div>
-      </div>
-      
-      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-    {% endif %}
-
-    <h2 class="govuk-heading-m">Your 2020/21 trainees</h2>
-
-    {% set records = data.filteredRecords | filterByYear(data.currentYear)  %}
-
-    {% macro statusCard(records, status) %}
-      <a href="/records?filterStatus={{status}}" class="status-card status-card--{{status | lower | kebabCase }}">
-        {# Special handling for drafts which have two string names #}
-        {% if status == "Draft" %}
-          {% set searchStatus = ["Draft", "Apply draft"] %}
-        {% else %}
-          {% set searchStatus = status %}
         {% endif %}
-        {% set recordCount = records | where("status", searchStatus) | length %}
-        <span class="status-card__count">{{recordCount}}</span>
-        <span class="status-card__status">{{status}}</span><span class="govuk-visually-hidden"> records. View these records.</span>
-      </a>
-    {% endmacro %}
 
-    <div class="home-statuses">
-      <div class="govuk-grid-row govuk-!-margin-bottom-6">
-        {% set statuses = ['Draft', 'Pending TRN', 'TRN received'] %}
-        {% for status in statuses %}
-          <div class="govuk-grid-column-one-third">
-            {{ statusCard(records, status) }}
-          </div>
-        {% endfor %}
-      </div>
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible"> #}
 
-      {% set eytsCount = records | where("status", ['EYTS recommended', 'EYTS awarded']) | length %}
-      {% set qtsCount = records | where("status", ['QTS recommended', 'QTS awarded']) | length %}
-      
-      {% if eytsCount == 0 %}
-        <div class="govuk-grid-row govuk-!-margin-bottom-6 home-statuses__flex-row">
-          {% set statuses = ['QTS recommended','QTS awarded', 'Deferred', 'Withdrawn'] %}
-          {% for status in statuses %}
-            <div class="govuk-grid-column-one-quarter">
-              {{ statusCard(records, status) }}
-            </div>
-          {% endfor %}
-        </div>
-      {% elseif qtsCount == 0 %}
-        <div class="govuk-grid-row govuk-!-margin-bottom-6 home-statuses__flex-row">
-          {% set statuses = ['EYTS recommended', 'EYTS awarded', 'Deferred', 'Withdrawn'] %}
-          {% for status in statuses %}
-            <div class="govuk-grid-column-one-quarter">
-              {{ statusCard(records, status) }}
-            </div>
-          {% endfor %}
-        </div>
-      {% else %}
-        <div class="govuk-grid-row govuk-!-margin-bottom-6 home-statuses__flex-row">
-          <div class="govuk-grid-column-one-quarter">
-            <a href="/records?filterStatus=EYTS recommended&filterStatus=QTS recommended" class="status-card status-card--recommended">
-              {% set recordCount = records | where("status", ['EYTS recommended','QTS recommended']) | length %}
-              <span class="status-card__count">{{recordCount}}</span>
-              <span class="status-card__status">Qualification recommended</span> <span class="govuk-visually-hidden"> records. View these records.</span>
+        <h2 class="govuk-heading-m">Your total trainees</h2>
+
+        <div class="govuk-grid-row govuk-!-margin-bottom-6">
+          <div class="govuk-grid-column-full">
+            <a href="" class="status-card status-card--pink">
+                <span class="status-card__count">247</span>
+                <span class="status-card__status">Total trainees</span> <span class="govuk-visually-hidden"> records. View these records.</span>
             </a>
           </div>
-          <div class="govuk-grid-column-one-quarter">
-            <a href="/records?filterStatus=EYTS awarded&filterStatus=QTS awarded" class="status-card status-card--awarded">
-              {% set recordCount = records | where("status", ['EYTS awarded','QTS awarded']) | length %}
-              <span class="status-card__count">{{recordCount}}</span>
-              <span class="status-card__status">Qualification awarded</span><span class="govuk-visually-hidden"> records. View these records.</span>
-            </a>
-          </div>
-          {% set statuses = ['Deferred', 'Withdrawn'] %}
-          {% for status in statuses %}
-            <div class="govuk-grid-column-one-quarter">
-              {{ statusCard(records, status) }}
-            </div>
-          {% endfor %}
         </div>
-      {% endif %}
+
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+        {% set records = data.filteredRecords | filterByYear(data.currentYear)  %}
+
+        {% macro statusCard(records, status) %}
+          <a href="/records?filterStatus={{status}}" class="status-card status-card--{{status | lower | kebabCase }} status-card--small">
+            {# Special handling for drafts which have two string names #}
+            {% if status == "Draft" %}
+              {% set searchStatus = ["Draft", "Apply draft"] %}
+            {% else %}
+              {% set searchStatus = status %}
+            {% endif %}
+            {% set recordCount = records | where("status", searchStatus) | length %}
+            <span class="status-card__count">{{recordCount}}</span>
+            <span class="status-card__status">{{status}}</span><span class="govuk-visually-hidden"> records. View these records.</span>
+          </a>
+        {% endmacro %}
+
+        <h2 class="govuk-heading-m">Your 2020/21 trainees</h2>
+
+        <div class="home-statuses">
+          <div class="govuk-grid-row govuk-!-margin-bottom-3">
+            {% set statuses = ['Draft', 'Pending TRN', 'TRN received'] %}
+            {% for status in statuses %}
+              <div class="govuk-grid-column-one-third">
+                {{ statusCard(records, status) }}
+              </div>
+            {% endfor %}
+          </div>
+
+          {% set eytsCount = records | where("status", ['EYTS recommended', 'EYTS awarded']) | length %}
+          {% set qtsCount = records | where("status", ['QTS recommended', 'QTS awarded']) | length %}
+          
+          {% if eytsCount == 0 %}
+            <div class="govuk-grid-row govuk-!-margin-bottom-3 home-statuses__flex-row">
+              {% set statuses = ['QTS recommended','QTS awarded'] %}
+              {% for status in statuses %}
+                <div class="govuk-grid-column-one-half">
+                  {{ statusCard(records, status) }}
+                </div>
+              {% endfor %}
+            </div>
+            <div class="govuk-grid-row govuk-!-margin-bottom-3 home-statuses__flex-row">
+              {% set statuses = ['Deferred', 'Withdrawn'] %}
+              {% for status in statuses %}
+                <div class="govuk-grid-column-one-half">
+                  {{ statusCard(records, status) }}
+                </div>
+              {% endfor %}
+            </div>
+          {% elseif qtsCount == 0 %}
+            <div class="govuk-grid-row govuk-!-margin-bottom-3 home-statuses__flex-row">
+              {% set statuses = ['EYTS recommended', 'EYTS awarded', 'Deferred', 'Withdrawn'] %}
+              {% for status in statuses %}
+                <div class="govuk-grid-column-one-half">
+                  {{ statusCard(records, status) }}
+                </div>
+              {% endfor %}
+            </div>
+          {% else %}
+            <div class="govuk-grid-row govuk-!-margin-bottom-3 home-statuses__flex-row">
+              <div class="govuk-grid-column-one-half">
+                <a href="/records?filterStatus=EYTS recommended&filterStatus=QTS recommended" class="status-card status-card--recommended">
+                  {% set recordCount = records | where("status", ['EYTS recommended','QTS recommended']) | length %}
+                  <span class="status-card__count">{{recordCount}}</span>
+                  <span class="status-card__status">Qualification recommended</span> <span class="govuk-visually-hidden"> records. View these records.</span>
+                </a>
+              </div>
+              <div class="govuk-grid-column-one-half">
+                <a href="/records?filterStatus=EYTS awarded&filterStatus=QTS awarded" class="status-card status-card--awarded">
+                  {% set recordCount = records | where("status", ['EYTS awarded','QTS awarded']) | length %}
+                  <span class="status-card__count">{{recordCount}}</span>
+                  <span class="status-card__status">Qualification awarded</span><span class="govuk-visually-hidden"> records. View these records.</span>
+                </a>
+              </div>
+              {% set statuses = ['Deferred', 'Withdrawn'] %}
+              {% for status in statuses %}
+                <div class="govuk-grid-column-one-quarter">
+                  {{ statusCard(records, status) }}
+                </div>
+              {% endfor %}
+            </div>
+          {% endif %}
+
+        </div>
+      <div>
 
     </div>
+    
+    {# <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <h2 class="govuk-heading-m">Another section</h2>
+
+    <div class="govuk-grid-row govuk-!-margin-bottom-6">
+      <div class="govuk-grid-column-one-half">
+        <a href="" class="status-card status-card--pink status-card--small">
+          <span class="status-card__count govuk-!-font-size-36">3</span>
+          <span class="status-card__status">items of a thing</span> <span class="govuk-visually-hidden"> records. View these records.</span>
+        </a>
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <a href="" class="status-card status-card--pink status-card--small">
+          <span class="status-card__count govuk-!-font-size-36">23</span>
+          <span class="status-card__status">items of a thing</span> <span class="govuk-visually-hidden"> records. View these records.</span>
+        </a>
+      </div>
+    </div> #}
 
   </div>
 </div>

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -79,7 +79,7 @@
           <div class="govuk-grid-column-full">
             <a href="/records?filterStatus=Pending TRN&filterStatus=TRN received&filterStatus=EYTS recommended&filterStatus=EYTS awarded&filterStatus=QTS recommended&filterStatus=QTS awarded&filterStatus=Deferred&filterStatus=Withdrawn" class="status-card status-card--total">
                 <span class="status-card__count">{{nonDraftRecordsCount}}</span>
-                <span class="status-card__status">Trainee records (non-draft)</span> <span class="govuk-visually-hidden"> records. View these records.</span>
+                <span class="status-card__status">Total registered trainees</span> <span class="govuk-visually-hidden"> View these records.</span>
             </a>
           </div>
         </div>

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -12,7 +12,8 @@
         <h1 class="govuk-heading-l">Trainee teacher dashboard</h1>
         {{ govukButton({
           text: "Add a trainee",
-          href: "./new-record/new"
+          href: "./new-record/new",
+          isStartButton: true
         }) }}
       </div>
     </div>

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -13,36 +13,38 @@
         {{ govukButton({
           text: "Add a trainee",
           href: "./new-record/new",
-          isStartButton: true
+          _isStartButton: true
         }) }}
       </div>
     </div>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-quarter-from-desktop">
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><a href="/records" class="govuk-link govuk-link--no-visited-state">Trainee records</a></h2>
-        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">Review and manage your trainee records.</p>
+        <h2 class="govuk-!-font-size-19 govuk-!-margin-bottom-1 govuk-!-margin-top-0"><a href="/records" class="govuk-link govuk-link--no-visited-state">Trainee records</a></h2>
+        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-3">Review and manage your trainee records.</p>
         {% if data.settings.includeGuidance %}
-          <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><a href="/guidance" class="govuk-link govuk-link--no-visited-state">Guidance</a></h2>
-          <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">Service guidance for each route.</p>
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><a href="/guidance" class="govuk-link govuk-link--no-visited-state">Guidance</a></h2>
+          <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-3">Service guidance for each route.</p>
         {% endif %}
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><a href="#" class="govuk-link govuk-link--no-visited-state">Give feedback</a></h2>
-        <p class="govuk-body  govuk-!-font-size-16 govuk-!-margin-bottom-1">This is a new service. Your views will help us improve it.</p>
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><a href="/data-requirements" class="govuk-link govuk-link--no-visited-state">Check what data you need</a></h2>
-        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">The data you need to complete a trainee record.</p>
-        <div class="app-action-required-item govuk-!-margin-top-2" style="flex-direction: row-reverse">
-          <span class="app-action-required-item__count govuk-!-margin-right-7" style="width: 30px; height: 30px; font-size: 19px">2</span>
+        <h2 class="govuk-!-font-size-19 govuk-!-margin-bottom-1"><a href="#" class="govuk-link govuk-link--no-visited-state">Give feedback</a></h2>
+        <p class="govuk-body  govuk-!-font-size-16 govuk-!-margin-bottom-3">This is a new service. Your views will help us improve it.</p>
+        <h2 class="govuk-!-font-size-19 govuk-!-margin-bottom-1"><a href="/data-requirements" class="govuk-link govuk-link--no-visited-state">Check what data you need</a></h2>
+        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-3">The data you need to complete a trainee record.</p>
+        {# <div class="app-action-required-item govuk-!-margin-top-1">
           <div class="app-action-required-item__content">
             <a href="/notifications" class="govuk-link app-action-required-item__text">Notifications</a>
           </div>
-        </div>
+          <span class="app-action-required-item__count govuk-!-margin-left-2" style="width: 30px; height: 30px; font-size: 19px">2</span>
+        </div> #}
       </div>
       <div class="govuk-grid-column-three-quarters-from-desktop">
 
         {# suggesting we move these to a dedicated page #}
         
-        {# {% if data.settings.showRequiresAttentionSection and combinedAlertCount > 0 %}
-          <h2 class="govuk-heading-m">Requires action</h2>
+        {% if data.settings.showRequiresAttentionSection and combinedAlertCount > 0 %}
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible hide-from-desktop">
+
+          <h2 class="govuk-heading-m">Requires your action</h2>
           {% if applyDraftCount > 0 %}
             <div class="app-action-required-item">
               <span class="app-action-required-item__count">{{applyDraftCount}}</span>
@@ -56,29 +58,31 @@
             <div class="app-action-required-item">
               <span class="app-action-required-item__count">{{recordsToBeReviewedCount}}</span>
               <div class="app-action-required-item__content">
-                <a href="#" class="govuk-link app-action-required-item__text">records for review before cycle ends</a>
+                <a href="#" class="govuk-link app-action-required-item__text">Records for review before cycle ends</a>
                 <span class="app-action-required-item__hint-text govuk-hint govuk-!-font-size-16">The cycle ends on August 27 2021</span>
               </div>
             </div>
           {% endif %}
+
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
         {% endif %}
 
-        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible"> #}
-
         <h2 class="govuk-heading-m">Your total trainees</h2>
+        
+        {% set records = data.filteredRecords | filterByYear(data.currentYear)  %}
+
+        {% set nonDraftRecordsCount = records | removeWhere("status", ["Draft", "Apply draft"]) | length %}
 
         <div class="govuk-grid-row govuk-!-margin-bottom-6">
           <div class="govuk-grid-column-full">
-            <a href="" class="status-card status-card--pink">
-                <span class="status-card__count">247</span>
+            <a href="" class="status-card">
+                <span class="status-card__count">{{nonDraftRecordsCount}}</span>
                 <span class="status-card__status">Total trainees</span> <span class="govuk-visually-hidden"> records. View these records.</span>
             </a>
           </div>
         </div>
 
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
-        {% set records = data.filteredRecords | filterByYear(data.currentYear)  %}
 
         {% macro statusCard(records, status) %}
           <a href="/records?filterStatus={{status}}" class="status-card status-card--{{status | lower | kebabCase }} status-card--small">

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -77,9 +77,9 @@
 
         <div class="govuk-grid-row govuk-!-margin-bottom-6">
           <div class="govuk-grid-column-full">
-            <a href="" class="status-card">
+            <a href="/records?filterStatus=Pending TRN&filterStatus=TRN received&filterStatus=EYTS recommended&filterStatus=EYTS awarded&filterStatus=QTS recommended&filterStatus=QTS awarded&filterStatus=Deferred&filterStatus=Withdrawn" class="status-card status-card--total">
                 <span class="status-card__count">{{nonDraftRecordsCount}}</span>
-                <span class="status-card__status">Total trainees</span> <span class="govuk-visually-hidden"> records. View these records.</span>
+                <span class="status-card__status">Trainee records (non-draft)</span> <span class="govuk-visually-hidden"> records. View these records.</span>
             </a>
           </div>
         </div>
@@ -170,25 +170,6 @@
       <div>
 
     </div>
-    
-    {# <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
-    <h2 class="govuk-heading-m">Another section</h2>
-
-    <div class="govuk-grid-row govuk-!-margin-bottom-6">
-      <div class="govuk-grid-column-one-half">
-        <a href="" class="status-card status-card--pink status-card--small">
-          <span class="status-card__count govuk-!-font-size-36">3</span>
-          <span class="status-card__status">items of a thing</span> <span class="govuk-visually-hidden"> records. View these records.</span>
-        </a>
-      </div>
-      <div class="govuk-grid-column-one-half">
-        <a href="" class="status-card status-card--pink status-card--small">
-          <span class="status-card__count govuk-!-font-size-36">23</span>
-          <span class="status-card__status">items of a thing</span> <span class="govuk-visually-hidden"> records. View these records.</span>
-        </a>
-      </div>
-    </div> #}
 
   </div>
 </div>

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -65,6 +65,8 @@
           {% endif %}
 
           <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        {% else %}
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible hide-from-desktop">
         {% endif %}
 
         <h2 class="govuk-heading-m">Your total trainees</h2>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -100,7 +100,7 @@
   {% endset %}
 
   {% set navItems = [{
-      text: 'Home',
+      text: 'Dashboard',
       href: '/home',
       active: true if navActive == 'home'
     },


### PR DESCRIPTION
This PR includes a WIP of an alt concept for `Home`. Its less _homepagey_ and more _dashboardey_.

Things to do:

- decide on the colour of the total records box.
- make the query string for non-draft records less verbose
- consider how to make switching this homepage and the current one via `/admin` a thing 

Things to consider:

- The full width 'total trainees' status box feels a bit of a waste of space. _Maybe_ it's a 2 column row displaying # of records and # of drafts?

## Home without the 'needs action ui'

![localhost_3000_home (8)](https://user-images.githubusercontent.com/1108991/118094581-d26a2400-b3c6-11eb-95d8-48bbd460935c.png)

## Home with the 'needs action ui'

![localhost_3000_home (7)](https://user-images.githubusercontent.com/1108991/117976913-2e31a000-b328-11eb-964f-02e681b9bbdf.png)

## An alternate (preferred) design for the 'needs action ui'

![Screenshot 2021-05-12 at 13 36 24](https://user-images.githubusercontent.com/1108991/117976542-ced39000-b327-11eb-8d80-9a11ce27122d.png)


