### PR TITLE
Add a breadcrumb back to home page

### DIFF
--- a/app/views/records.html
+++ b/app/views/records.html
@@ -3,7 +3,9 @@
   Trainee records ({{filteredRecords | length}} {{ "record" | pluralise(filteredRecords | length)}})
 {% endset %}
 
-{% set backLink = 'false' %}
+
+{% set backText = "Home" %}
+{% set backLink = '/home' %}
 {% set navActive = "records" %}
 
 {% block skipLink %}


### PR DESCRIPTION
We've had some participants struggle to navigate back to where they started. We’ve got a few hypothesises for why this might be and what we can do, but one quick thing is to add a breadcrumb that helps lead there.

If we rename the homepage to 'dashboard' we could then update this link.

![Screenshot 2021-05-10 at 10 31 18](https://user-images.githubusercontent.com/2204224/117638701-081acd00-b17b-11eb-929d-d66902e9f350.png)
