### PR TITLE
Include degree grade on bursary question and fix degree bugs

### DIFF
--- a/app/filters/app-misc.js
+++ b/app/filters/app-misc.js
@@ -49,7 +49,18 @@ filters.getFullName = ({
   return names.filter(Boolean).join(' ')
 }
 
-
+// Prepend with 'Other grade:' if grade isn’t a pre-set type
+filters.prettifyDegreeGrade = grade => {
+  if (!grade) return ""
+  let isOtherGrade = ![
+    "First-class honours",
+    "Upper second-class honours (2:1)",
+    "Lower second-class honours (2:2)",
+    "Third-class honours",
+    "Pass"
+  ].includes(grade)
+  return (isOtherGrade) ? `Other grade: ${grade.toLowerCase()}` : grade
+}
 
 // Metadata about a school as a string
 // URN 1234567, City, Postcode

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -765,6 +765,12 @@ exports.highlightInvalidRows = function(rows) {
   return rows
 }
 
+// Strip invalid strings from input
+exports.stripInvalidText = input => {
+  if (!input) return ""
+  else return input.replace("**invalid**", "")
+}
+
 exports.captureInvalid = function(data){
   let ctx = Object.assign({}, this.ctx)
   let invalidAnswers = ctx.data?.temp?.invalidAnswers || []

--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -665,9 +665,11 @@ module.exports = router => {
       delete newDegree.typeInt
     }
 
-    // Combine radio and text inputs
+    // Degree grade is collected using a choice of radios or 'other'
+    // if 'other', users can type a degree grade. These are submitted to two different
+    // data items, which we now combine in to a single grade.
     if (newDegree.baseGrade){
-      if (newDegree.baseGrade == "Grade known"){
+      if (newDegree.baseGrade == "Other"){
         newDegree.grade = newDegree.otherGrade
         delete newDegree.baseGrade
         delete newDegree.otherGrade
@@ -686,7 +688,6 @@ module.exports = router => {
     else {
       existingDegrees.push(newDegree)
     }
-
     _.set(data, 'record.degree.items', existingDegrees)
 
     if (existingDegrees?.length > 1){

--- a/app/views/_includes/forms/degree/bursary-selection.html
+++ b/app/views/_includes/forms/degree/bursary-selection.html
@@ -9,11 +9,22 @@
 
 {% for degree in degrees %}
 
+  {% set hint %}
+    {% if degree.grade %}
+      <p class="govuk-body govuk-hint govuk-!-margin-bottom-1">
+        {{ degree.grade | prettifyDegreeGrade }}
+      </p>
+    {% endif %}
+    <p class="govuk-body govuk-hint">
+      {{degree | getDegreeHint}}
+    </p>
+  {% endset %}
+
   {% set degreeItems = degreeItems | push({
-    text: degree | getDegreeName,
+    text: degree | getDegreeName | stripInvalidText,
     value: degree.id,
     hint: {
-      text: degree | getDegreeHint
+      html: hint | safe
     }
   }) %}
 

--- a/app/views/_includes/forms/degree/details-uk.html
+++ b/app/views/_includes/forms/degree/details-uk.html
@@ -100,8 +100,8 @@
     "Upper second-class honours (2:1)",
     "Lower second-class honours (2:2)",
     "Third-class honours",
-    "Pass",
-    "The trainee is still studying for their degree"] %}
+    "Pass"
+  ] %}
     {% set storedGradeOther = true %}
   {% endif %}
 


### PR DESCRIPTION
Adds the degree grade as one of the items shown when choosing which degree relates to the bursary.

<img width="1070" alt="Screenshot 2021-05-11 at 10 37 06" src="https://user-images.githubusercontent.com/2204224/117794174-e5ed8180-b244-11eb-83e3-108c8f0b727b.png">

If the grade is `other`, then the grade is prefaced with `Other grade: `

Nothing is shown for international degrees as we don't capture a grade for them.

---

Also fixes two bugs related to degrees:
* `**invalid**` text leaking through
* `Other` grades not actually storing correctly