### PR TITLE
Content typos bursary funding

### DIFF
--- a/app/views/_includes/forms/funding/bursary.html
+++ b/app/views/_includes/forms/funding/bursary.html
@@ -26,10 +26,10 @@
     },
     {
       text: "No, the trainee is self funded, not eligible or has a scholarship",
-      text: "No, do not apply for bursary",
+      text: "No, do not apply for a bursary",
       value: "true",
       hint: {
-        text: "For example, the trainee is not eligible or has applied for scholarship."
+        text: "For example, the trainee is not eligible or has applied for a scholarship."
       }
     }
   ]


### PR DESCRIPTION
fix 2 typos on the bursary funding page:

1 - On the No radio there's a missing 'a'

2- In the No radio hint text there's a missing 'a'