### PR TITLE
Update start date question to use course start date if available

### DIFF
--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -333,11 +333,8 @@ module.exports = router => {
     let record = data.record
     let recordPath = utils.getRecordPath(req)
     let referrer = utils.getReferrer(req.query.referrer)
-
     let enabledRoutes = data.settings.enabledTrainingRoutes
     let route = record?.route
-
-    // Set route to false so that provider courses doesn’t filter by route
     if (utils.sourceIsApply(record)) route = false
     let providerCourses = utils.getProviderCourses(data.courses, record.provider, route, data)
     let selectedCourse = _.get(data, 'record.selectedCourseTemp')
@@ -350,7 +347,6 @@ module.exports = router => {
     else if (!selectedCourse){
       res.redirect(`${recordPath}/course-details/pick-course${referrer}`)
     }
-    // They’ve chosen to enter details manually
     else if (selectedCourse == "Other"){
       if (_.get(record, 'courseDetails.isPublishCourse')){
         // User has swapped from a publish to a non-publish course. Delete existing data
@@ -375,7 +371,7 @@ module.exports = router => {
         // Will only exist if js
         if (selectedCourseRawAutocomplete){
           selectedCourse = providerCourses.find(course => {
-            return course.courseNameLong == req.body._autocompleteRawValue_publishCourse
+            return utils.getCourseName(course) == req.body._autocompleteRawValue_publishCourse
           })?.id
         }
       }
@@ -388,119 +384,9 @@ module.exports = router => {
       }
       else {
         // Copy over that provider’s course data
-        let courseDetails = providerCourses[courseIndex]
-
-        // Fill in specialisms that are mappable
-        record.courseDetails = utils.mapMappablePublishSubjects(courseDetails)
-
-        // For apply records we let them pick a Publish course which 
-        // might have a different route.
-        if (record.route != record.courseDetails.route){
-          console.log(`The selected Publish course’s route does not match the draft’s route. Draft route changed to ${record.courseDetails.route}`)
-          record.route = record.courseDetails.route
-        }
-
-        let isAllocated = utils.hasAllocatedPlaces(record)
-
-        // Not all specialisms are mappable, so for those, send the user to a followup page
-        if (utils.hasUnmappedPublishSubjects(record.courseDetails)){
-          console.log("Course has unmapped subjects")
-          res.redirect(`${recordPath}/course-details/choose-specialisms${referrer}`)
-        }
-        else if (isAllocated) {
-          // After /allocated-place the journey will match other course-details routes
-          res.redirect(`${recordPath}/course-details/allocated-place${referrer}`)
-        }
-        else {
-          res.redirect(`${recordPath}/course-details/confirm${referrer}`)
-        }
-
+        record.courseDetails = providerCourses[courseIndex]
+        res.redirect(`${recordPath}/course-details/confirm-publish-details${referrer}`)
       }
-    }
-  })
-
-  // This route is here only to redirect the user *away* if there are no unmapped subjects
-  // We do this because they could have chosen specialisms and then clicked back - this catches that
-  // behavour and at least sends them someplace somewhat sensible.
-  router.get(['/:recordtype/:uuid/course-details/choose-specialisms','/:recordtype/course-details/choose-specialisms'], function (req, res) {
-    const data = req.session.data
-    let record = data.record
-    let recordPath = utils.getRecordPath(req)
-    let referrer = utils.getReferrer(req.query.referrer)
-    let isAllocated = utils.hasAllocatedPlaces(record)
-
-    if (utils.hasUnmappedPublishSubjects(record.courseDetails) || utils.subjectsAreIncomplete(record.courseDetails)){
-      res.render(`${req.params.recordtype}/course-details/choose-specialisms`)
-    }
-    else if (isAllocated) {
-      // After /allocated-place the journey will match other course-details routes
-      res.redirect(`${recordPath}/course-details/allocated-place${referrer}`)
-    }
-
-    else res.redirect(`${recordPath}/course-details/confirm${referrer}`)
-  })
-
-  // Deal with specialisms data as it comes in
-  // Users can loop through this page, so if there are remaining unmapped subjects
-  // we send them back to the page to do the next one.
-  router.post(['/:recordtype/:uuid/course-details/choose-specialisms','/:recordtype/course-details/choose-specialisms'], function (req, res) {
-    const data = req.session.data
-    let record = data.record
-    let recordPath = utils.getRecordPath(req)
-    let referrer = utils.getReferrer(req.query.referrer)
-    let isAllocated = utils.hasAllocatedPlaces(record)
-
-    let courseDetails = record?.courseDetails
-
-    // Special handling for languages
-    if (courseDetails.subjectsArrayTemp){
-
-      // Grab first 3 subjects as that’s all we support
-      // In production we’ll throw a validation error if more are picked
-      let subjectsArray = courseDetails.subjectsArrayTemp.slice(0, 3)
-
-
-      // If there are two Publish subjects, that means we can only have
-      // two languages
-      let publishSubjectsCount = Object.keys(courseDetails.publishSubjects).length
-      if (publishSubjectsCount > 1) subjectsArray = subjectsArray.slice(0, 2)
-
-      // If a subject has already been set, add to it
-      // For instance, it could be Biology with two languages - we don't want to overwrite Biology
-      // as the first subject
-      if (courseDetails?.subjects?.first) {
-        subjectsArray = [courseDetails?.subjects?.first].concat(subjectsArray)
-      }
-      // It’s possible a second subject has already been set. If so, just add it to the end.
-      // This means if the provider picked two languages, the existing second subject would get pushed 
-      // to the third slot
-      else if (courseDetails?.subjects?.second) {
-        subjectsArray.push(courseDetails.subjects.second)
-      }
-      // If there's a null entry that means we've got an unmapped Publish subject - add that to the 
-      // end so we don’t forget about it
-      else if (courseDetails?.subjects?.second === null) {
-        subjectsArray.push(null)
-      }
-
-      delete courseDetails.subjectsArrayTemp // No longer needed
-
-      // Convert back to our object data structure
-      courseDetails.subjects = utils.arrayToOrdinalObject(subjectsArray)
-
-    }
-
-    if (utils.hasUnmappedPublishSubjects(record.courseDetails) || utils.subjectsAreIncomplete(record.courseDetails)){
-      console.log("Course has unmapped subjects")
-      res.redirect(`${recordPath}/course-details/choose-specialisms${referrer}`)
-    }
-    else if (isAllocated) {
-      // After /allocated-place the journey will match other course-details routes
-      res.redirect(`${recordPath}/course-details/allocated-place${referrer}`)
-    }
-    else {
-      console.log("Course does not have unmapped subjects")
-      res.redirect(`${recordPath}/course-details/confirm${referrer}`)
     }
   })
 
@@ -509,56 +395,56 @@ module.exports = router => {
   // reviewing from a summary page, or after editing other details.
   // This route is needed because we need to conditionally pass on to /allocated-place if
   // the route and subject match certain conditions.
-  // router.post(['/:recordtype/:uuid/course-details/confirm-publish-details','/:recordtype/course-details/confirm-publish-details'], function (req, res) {
-  //   const data = req.session.data
-  //   let record = data.record
-  //   let referrer = utils.getReferrer(req.query.referrer)
-  //   let recordPath = utils.getRecordPath(req)
-  //   // Copy route up to higher level
-  //   delete record.selectedCourseTemp
-  //   delete record.selectedCourseAutocompleteTemp
+  router.post(['/:recordtype/:uuid/course-details/confirm-publish-details','/:recordtype/course-details/confirm-publish-details'], function (req, res) {
+    const data = req.session.data
+    let record = data.record
+    let referrer = utils.getReferrer(req.query.referrer)
+    let recordPath = utils.getRecordPath(req)
+    // Copy route up to higher level
+    delete record.selectedCourseTemp
+    delete record.selectedCourseAutocompleteTemp
 
-  //   // For apply records we let them pick a Publish course which 
-  //   // might have a different route
-  //   if (record.route != record.courseDetails.route){
-  //     console.log(`The selected Publish course’s route does not match the draft’s route. Draft route changed to ${record.courseDetails.route}`)
-  //     record.route = record.courseDetails.route
-  //   }
+    // For apply records we let them pick a Publish course which 
+    // might have a different route
+    if (record.route != record.courseDetails.route){
+      console.log(`The selected Publish course’s route does not match the draft’s route. Draft route changed to ${record.courseDetails.route}`)
+      record.route = record.courseDetails.route
+    }
 
-  //   let isAllocated = utils.hasAllocatedPlaces(record)
+    let isAllocated = utils.hasAllocatedPlaces(record)
 
-  //   if (isAllocated) {
-  //     // After /allocated-place the journey will match other course-details routes
-  //     res.redirect(`${recordPath}/course-details/allocated-place${referrer}`)
-  //   }
-  //   else {
-  //     if (req.params.recordtype == 'record'){
-  //       // This is basically the same as the /update route
-  //       utils.updateRecord(data, record)
-  //       utils.deleteTempData(data)
-  //       req.flash('success', 'Trainee record updated')
-  //       // Referrer or non-referrer probably goes to the same place
-  //       if (referrer){
-  //         res.redirect(utils.getReferrerDestination(req.query.referrer))
-  //       }
-  //       else {
-  //         res.redirect(`${recordPath}`)
-  //       }
-  //     }
-  //     else {
-  //       // Implicitly confirm the section by confirming it
-  //       record.courseDetails.status = "Completed"
-  //       if (referrer){
-  //         // Return to check-record page
-  //         res.redirect(utils.getReferrerDestination(req.query.referrer))
-  //       }
-  //       else {
-  //         res.redirect(`${recordPath}/overview`)
-  //       }
-  //     }
+    if (isAllocated) {
+      // After /allocated-place the journey will match other course-details routes
+      res.redirect(`${recordPath}/course-details/allocated-place${referrer}`)
+    }
+    else {
+      if (req.params.recordtype == 'record'){
+        // This is basically the same as the /update route
+        utils.updateRecord(data, record)
+        utils.deleteTempData(data)
+        req.flash('success', 'Trainee record updated')
+        // Referrer or non-referrer probably goes to the same place
+        if (referrer){
+          res.redirect(utils.getReferrerDestination(req.query.referrer))
+        }
+        else {
+          res.redirect(`${recordPath}`)
+        }
+      }
+      else {
+        // Implicitly confirm the section by confirming it
+        record.courseDetails.status = "Completed"
+        if (referrer){
+          // Return to check-record page
+          res.redirect(utils.getReferrerDestination(req.query.referrer))
+        }
+        else {
+          res.redirect(`${recordPath}/overview`)
+        }
+      }
 
-  //   }
-  // })
+    }
+  })
 
   // Picking a course
   router.post(['/:recordtype/:uuid/course-details/pick-route','/:recordtype/course-details/pick-route'], function (req, res) {
@@ -598,9 +484,6 @@ module.exports = router => {
     // Check for autocomplete submitted subject
     let subjectAutocomplete1 = req.body?._autocompleteRawValue_subject_1
 
-    // Make an array of subjects data - easier to work with
-    let subjectsArray = Object.values(record.courseDetails.subjects).filter(Boolean)
-
     // Special handling to cope with users deleting values from autocompletes.
     // Autocompletes make it hard to clear a value when used as an enhanced select.
     // Clearing the answer does not correctly select the empty select item. Instead,
@@ -610,11 +493,10 @@ module.exports = router => {
         .concat(req.body?._autocompleteRawValue_subject_2)
         .concat(req.body?._autocompleteRawValue_subject_3)
         .filter(Boolean)
-      // Now need to compare the values we got from the autocompletes with the values already stored
+      // Now need to compare the values we got from the autocompletes with the values from the selects
       // They have different casing, so need to check caselessly
-      if (subjectsArray){
-        // Filter subjects for only those that were also present in the autocompletes
-        subjectsArray = subjectsArray.filter(subject => {
+      if (record?.courseDetails?.subjects){
+        record.courseDetails.subjects = record.courseDetails.subjects.filter(subject => {
           return subjectsTemp.map(autocompleteSubject => autocompleteSubject.toLowerCase()).includes(subject.toLowerCase())
         })
       }
@@ -623,9 +505,9 @@ module.exports = router => {
 
     // Clean up subjects data
     // Remove empty and force in to array
-    subjectsArray = [].concat(subjectsArray.filter(Boolean))
-    // Map back to cardinal object
-    record.courseDetails.subjects = utils.arrayToOrdinalObject(subjectsArray)
+    if (record?.courseDetails?.subjects){
+      record.courseDetails.subjects = [].concat(record.courseDetails.subjects.filter(Boolean))
+    }
 
     // Merge autocomplete and radio answers
     if (courseDetails.ageRange == 'Other age range'){

--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -52,10 +52,13 @@ module.exports = router => {
     let record = data.record
     let recordPath = utils.getRecordPath(req)
     let referrer = utils.getReferrer(req.query.referrer)
+    let courseStartDate = record?.courseDetails?.startDate
 
     let traineeStarted = record?.trainingDetails?.traineeStarted
-
-    if (traineeStarted == "false"){ // If the answer was explicitly false.
+    if (courseStartDate && traineeStarted == "use-course-start-date"){
+      record.trainingDetails.commencementDate = courseStartDate
+    }
+    else if (traineeStarted == "false"){ // If the answer was explicitly false.
       delete record?.trainingDetails?.commencementDate
     }
     res.redirect(`${recordPath}/training-details/confirm${referrer}`)
@@ -330,8 +333,11 @@ module.exports = router => {
     let record = data.record
     let recordPath = utils.getRecordPath(req)
     let referrer = utils.getReferrer(req.query.referrer)
+
     let enabledRoutes = data.settings.enabledTrainingRoutes
     let route = record?.route
+
+    // Set route to false so that provider courses doesn’t filter by route
     if (utils.sourceIsApply(record)) route = false
     let providerCourses = utils.getProviderCourses(data.courses, record.provider, route, data)
     let selectedCourse = _.get(data, 'record.selectedCourseTemp')
@@ -344,6 +350,7 @@ module.exports = router => {
     else if (!selectedCourse){
       res.redirect(`${recordPath}/course-details/pick-course${referrer}`)
     }
+    // They’ve chosen to enter details manually
     else if (selectedCourse == "Other"){
       if (_.get(record, 'courseDetails.isPublishCourse')){
         // User has swapped from a publish to a non-publish course. Delete existing data
@@ -368,7 +375,7 @@ module.exports = router => {
         // Will only exist if js
         if (selectedCourseRawAutocomplete){
           selectedCourse = providerCourses.find(course => {
-            return utils.getCourseName(course) == req.body._autocompleteRawValue_publishCourse
+            return course.courseNameLong == req.body._autocompleteRawValue_publishCourse
           })?.id
         }
       }
@@ -381,9 +388,119 @@ module.exports = router => {
       }
       else {
         // Copy over that provider’s course data
-        record.courseDetails = providerCourses[courseIndex]
-        res.redirect(`${recordPath}/course-details/confirm-publish-details${referrer}`)
+        let courseDetails = providerCourses[courseIndex]
+
+        // Fill in specialisms that are mappable
+        record.courseDetails = utils.mapMappablePublishSubjects(courseDetails)
+
+        // For apply records we let them pick a Publish course which 
+        // might have a different route.
+        if (record.route != record.courseDetails.route){
+          console.log(`The selected Publish course’s route does not match the draft’s route. Draft route changed to ${record.courseDetails.route}`)
+          record.route = record.courseDetails.route
+        }
+
+        let isAllocated = utils.hasAllocatedPlaces(record)
+
+        // Not all specialisms are mappable, so for those, send the user to a followup page
+        if (utils.hasUnmappedPublishSubjects(record.courseDetails)){
+          console.log("Course has unmapped subjects")
+          res.redirect(`${recordPath}/course-details/choose-specialisms${referrer}`)
+        }
+        else if (isAllocated) {
+          // After /allocated-place the journey will match other course-details routes
+          res.redirect(`${recordPath}/course-details/allocated-place${referrer}`)
+        }
+        else {
+          res.redirect(`${recordPath}/course-details/confirm${referrer}`)
+        }
+
       }
+    }
+  })
+
+  // This route is here only to redirect the user *away* if there are no unmapped subjects
+  // We do this because they could have chosen specialisms and then clicked back - this catches that
+  // behavour and at least sends them someplace somewhat sensible.
+  router.get(['/:recordtype/:uuid/course-details/choose-specialisms','/:recordtype/course-details/choose-specialisms'], function (req, res) {
+    const data = req.session.data
+    let record = data.record
+    let recordPath = utils.getRecordPath(req)
+    let referrer = utils.getReferrer(req.query.referrer)
+    let isAllocated = utils.hasAllocatedPlaces(record)
+
+    if (utils.hasUnmappedPublishSubjects(record.courseDetails) || utils.subjectsAreIncomplete(record.courseDetails)){
+      res.render(`${req.params.recordtype}/course-details/choose-specialisms`)
+    }
+    else if (isAllocated) {
+      // After /allocated-place the journey will match other course-details routes
+      res.redirect(`${recordPath}/course-details/allocated-place${referrer}`)
+    }
+
+    else res.redirect(`${recordPath}/course-details/confirm${referrer}`)
+  })
+
+  // Deal with specialisms data as it comes in
+  // Users can loop through this page, so if there are remaining unmapped subjects
+  // we send them back to the page to do the next one.
+  router.post(['/:recordtype/:uuid/course-details/choose-specialisms','/:recordtype/course-details/choose-specialisms'], function (req, res) {
+    const data = req.session.data
+    let record = data.record
+    let recordPath = utils.getRecordPath(req)
+    let referrer = utils.getReferrer(req.query.referrer)
+    let isAllocated = utils.hasAllocatedPlaces(record)
+
+    let courseDetails = record?.courseDetails
+
+    // Special handling for languages
+    if (courseDetails.subjectsArrayTemp){
+
+      // Grab first 3 subjects as that’s all we support
+      // In production we’ll throw a validation error if more are picked
+      let subjectsArray = courseDetails.subjectsArrayTemp.slice(0, 3)
+
+
+      // If there are two Publish subjects, that means we can only have
+      // two languages
+      let publishSubjectsCount = Object.keys(courseDetails.publishSubjects).length
+      if (publishSubjectsCount > 1) subjectsArray = subjectsArray.slice(0, 2)
+
+      // If a subject has already been set, add to it
+      // For instance, it could be Biology with two languages - we don't want to overwrite Biology
+      // as the first subject
+      if (courseDetails?.subjects?.first) {
+        subjectsArray = [courseDetails?.subjects?.first].concat(subjectsArray)
+      }
+      // It’s possible a second subject has already been set. If so, just add it to the end.
+      // This means if the provider picked two languages, the existing second subject would get pushed 
+      // to the third slot
+      else if (courseDetails?.subjects?.second) {
+        subjectsArray.push(courseDetails.subjects.second)
+      }
+      // If there's a null entry that means we've got an unmapped Publish subject - add that to the 
+      // end so we don’t forget about it
+      else if (courseDetails?.subjects?.second === null) {
+        subjectsArray.push(null)
+      }
+
+      delete courseDetails.subjectsArrayTemp // No longer needed
+
+      // Convert back to our object data structure
+      courseDetails.subjects = utils.arrayToOrdinalObject(subjectsArray)
+
+    }
+
+    if (utils.hasUnmappedPublishSubjects(record.courseDetails) || utils.subjectsAreIncomplete(record.courseDetails)){
+      console.log("Course has unmapped subjects")
+      res.redirect(`${recordPath}/course-details/choose-specialisms${referrer}`)
+    }
+    else if (isAllocated) {
+      // After /allocated-place the journey will match other course-details routes
+      res.redirect(`${recordPath}/course-details/allocated-place${referrer}`)
+    }
+    else {
+      console.log("Course does not have unmapped subjects")
+      res.redirect(`${recordPath}/course-details/confirm${referrer}`)
     }
   })
 
@@ -392,56 +509,56 @@ module.exports = router => {
   // reviewing from a summary page, or after editing other details.
   // This route is needed because we need to conditionally pass on to /allocated-place if
   // the route and subject match certain conditions.
-  router.post(['/:recordtype/:uuid/course-details/confirm-publish-details','/:recordtype/course-details/confirm-publish-details'], function (req, res) {
-    const data = req.session.data
-    let record = data.record
-    let referrer = utils.getReferrer(req.query.referrer)
-    let recordPath = utils.getRecordPath(req)
-    // Copy route up to higher level
-    delete record.selectedCourseTemp
-    delete record.selectedCourseAutocompleteTemp
+  // router.post(['/:recordtype/:uuid/course-details/confirm-publish-details','/:recordtype/course-details/confirm-publish-details'], function (req, res) {
+  //   const data = req.session.data
+  //   let record = data.record
+  //   let referrer = utils.getReferrer(req.query.referrer)
+  //   let recordPath = utils.getRecordPath(req)
+  //   // Copy route up to higher level
+  //   delete record.selectedCourseTemp
+  //   delete record.selectedCourseAutocompleteTemp
 
-    // For apply records we let them pick a Publish course which 
-    // might have a different route
-    if (record.route != record.courseDetails.route){
-      console.log(`The selected Publish course’s route does not match the draft’s route. Draft route changed to ${record.courseDetails.route}`)
-      record.route = record.courseDetails.route
-    }
+  //   // For apply records we let them pick a Publish course which 
+  //   // might have a different route
+  //   if (record.route != record.courseDetails.route){
+  //     console.log(`The selected Publish course’s route does not match the draft’s route. Draft route changed to ${record.courseDetails.route}`)
+  //     record.route = record.courseDetails.route
+  //   }
 
-    let isAllocated = utils.hasAllocatedPlaces(record)
+  //   let isAllocated = utils.hasAllocatedPlaces(record)
 
-    if (isAllocated) {
-      // After /allocated-place the journey will match other course-details routes
-      res.redirect(`${recordPath}/course-details/allocated-place${referrer}`)
-    }
-    else {
-      if (req.params.recordtype == 'record'){
-        // This is basically the same as the /update route
-        utils.updateRecord(data, record)
-        utils.deleteTempData(data)
-        req.flash('success', 'Trainee record updated')
-        // Referrer or non-referrer probably goes to the same place
-        if (referrer){
-          res.redirect(utils.getReferrerDestination(req.query.referrer))
-        }
-        else {
-          res.redirect(`${recordPath}`)
-        }
-      }
-      else {
-        // Implicitly confirm the section by confirming it
-        record.courseDetails.status = "Completed"
-        if (referrer){
-          // Return to check-record page
-          res.redirect(utils.getReferrerDestination(req.query.referrer))
-        }
-        else {
-          res.redirect(`${recordPath}/overview`)
-        }
-      }
+  //   if (isAllocated) {
+  //     // After /allocated-place the journey will match other course-details routes
+  //     res.redirect(`${recordPath}/course-details/allocated-place${referrer}`)
+  //   }
+  //   else {
+  //     if (req.params.recordtype == 'record'){
+  //       // This is basically the same as the /update route
+  //       utils.updateRecord(data, record)
+  //       utils.deleteTempData(data)
+  //       req.flash('success', 'Trainee record updated')
+  //       // Referrer or non-referrer probably goes to the same place
+  //       if (referrer){
+  //         res.redirect(utils.getReferrerDestination(req.query.referrer))
+  //       }
+  //       else {
+  //         res.redirect(`${recordPath}`)
+  //       }
+  //     }
+  //     else {
+  //       // Implicitly confirm the section by confirming it
+  //       record.courseDetails.status = "Completed"
+  //       if (referrer){
+  //         // Return to check-record page
+  //         res.redirect(utils.getReferrerDestination(req.query.referrer))
+  //       }
+  //       else {
+  //         res.redirect(`${recordPath}/overview`)
+  //       }
+  //     }
 
-    }
-  })
+  //   }
+  // })
 
   // Picking a course
   router.post(['/:recordtype/:uuid/course-details/pick-route','/:recordtype/course-details/pick-route'], function (req, res) {
@@ -481,6 +598,9 @@ module.exports = router => {
     // Check for autocomplete submitted subject
     let subjectAutocomplete1 = req.body?._autocompleteRawValue_subject_1
 
+    // Make an array of subjects data - easier to work with
+    let subjectsArray = Object.values(record.courseDetails.subjects).filter(Boolean)
+
     // Special handling to cope with users deleting values from autocompletes.
     // Autocompletes make it hard to clear a value when used as an enhanced select.
     // Clearing the answer does not correctly select the empty select item. Instead,
@@ -490,10 +610,11 @@ module.exports = router => {
         .concat(req.body?._autocompleteRawValue_subject_2)
         .concat(req.body?._autocompleteRawValue_subject_3)
         .filter(Boolean)
-      // Now need to compare the values we got from the autocompletes with the values from the selects
+      // Now need to compare the values we got from the autocompletes with the values already stored
       // They have different casing, so need to check caselessly
-      if (record?.courseDetails?.subjects){
-        record.courseDetails.subjects = record.courseDetails.subjects.filter(subject => {
+      if (subjectsArray){
+        // Filter subjects for only those that were also present in the autocompletes
+        subjectsArray = subjectsArray.filter(subject => {
           return subjectsTemp.map(autocompleteSubject => autocompleteSubject.toLowerCase()).includes(subject.toLowerCase())
         })
       }
@@ -502,9 +623,9 @@ module.exports = router => {
 
     // Clean up subjects data
     // Remove empty and force in to array
-    if (record?.courseDetails?.subjects){
-      record.courseDetails.subjects = [].concat(record.courseDetails.subjects.filter(Boolean))
-    }
+    subjectsArray = [].concat(subjectsArray.filter(Boolean))
+    // Map back to cardinal object
+    record.courseDetails.subjects = utils.arrayToOrdinalObject(subjectsArray)
 
     // Merge autocomplete and radio answers
     if (courseDetails.ageRange == 'Other age range'){

--- a/app/views/_includes/forms/training-details/trainee-start-date-id.html
+++ b/app/views/_includes/forms/training-details/trainee-start-date-id.html
@@ -7,7 +7,7 @@
 {% set commencementStartDateArray = record.trainingDetails.commencementDate | toDateArray %}
 
 {% set commencementDateLabel = "What is the trainee’s start date?" %}
-{% set commencementDateHint = "This the date the trainee starts on the course – not the course start date." %}
+{% set commencementDateHint = "This is the date the trainee starts on the course – not the course start date." %}
 
 
 {% set commencementDateInputHtml %}
@@ -61,9 +61,6 @@
         classes: "govuk-fieldset__legend--s"
       }
     },
-    _hint: {
-      text: "If the trainee has not started yet, you can still submit their record, but will need to provide their start date later"
-    },
     hint: {
       text: "This the date the trainee starts on the course – not the course start date."
     },
@@ -92,12 +89,10 @@
 {# If we don’t have a course start date, just show an input to collect date. This means they don’t
 have to do course details before starting this section. #}
 {% else %}
-
   {{ commencementDateInputHtml | safe }}
-
 {% endif %}
 
-
+{# Trainee ID #}
 {{ govukInput({
   label: {
     text: "Assign a trainee ID",

--- a/app/views/_includes/forms/training-details/trainee-start-date-id.html
+++ b/app/views/_includes/forms/training-details/trainee-start-date-id.html
@@ -62,7 +62,7 @@
       }
     },
     hint: {
-      text: "This the date the trainee starts on the course – not the course start date."
+      text: commencementDateHint
     },
     items: [
       {

--- a/app/views/_includes/forms/training-details/trainee-start-date-id.html
+++ b/app/views/_includes/forms/training-details/trainee-start-date-id.html
@@ -1,21 +1,30 @@
-
 <h1 class="govuk-heading-l">{{pageHeading}}</h1>
+
+{% set courseStartDate = record.courseDetails.startDate or false %}
+
+{% set startDateNotKnownAllowed = not ( data.settings.requireTraineeStartDate | falsify ) %}
 
 {% set commencementStartDateArray = record.trainingDetails.commencementDate | toDateArray %}
 
+{% set commencementDateLabel = "What is the trainee’s start date?" %}
+{% set commencementDateHint = "This the date the trainee starts on the course – not the course start date." %}
+
 
 {% set commencementDateInputHtml %}
-  {% set hintHtml %}
-    When the trainee started the course. This may be different to your overall programme start date.<br>
 
-    <br>For example, {{ "" | today | toDateArray | spaceSeparate }}<br>
+  {% set hintHtml %}
+    {% if not courseStartDate %}
+      {{commencementDateHint}}<br>
+    {% endif %}
+    For example, {{ today() | toDateArray | spaceSeparate }}
   {% endset %}
+
   {{ govukDateInput({
     id: "commencement-start-date",
     namePrefix: "record[trainingDetails][commencementDate]",
     fieldset: {
       legend: {
-        text: "Date trainee started",
+        text: "Trainee start date" if courseStartDate else commencementDateLabel,
         classes: "govuk-fieldset__legend--s"
       }
     },
@@ -42,36 +51,50 @@
   }) }}
 {% endset %}
 
-{% if data.settings.requireTraineeStartDate %}
-
-  {{ commencementDateInputHtml | safe }}
-
-{% else %}
+{# If we have a course start date, offer radio choice betwen that and manual  #}
+{% if courseStartDate %}
 
   {{ govukRadios({
     fieldset: {
       legend: {
-        text: "Has the trainee started the course?",
+        text: commencementDateLabel,
         classes: "govuk-fieldset__legend--s"
       }
     },
-    hint: {
+    _hint: {
       text: "If the trainee has not started yet, you can still submit their record, but will need to provide their start date later"
+    },
+    hint: {
+      text: "This the date the trainee starts on the course – not the course start date."
     },
     items: [
       {
+        value: "use-course-start-date",
+        text: "Use the course start date – " + record.courseDetails.startDate | govukDate
+      } if record.courseDetails.startDate,
+      {
         value: "true",
-        text: "Yes",
+        text: "Enter another date" if record.courseDetails.startDate else "Start date known",
         conditional: {
           html: commencementDateInputHtml
         }
       },
       {
+        divider: "or"
+      } if startDateNotKnownAllowed,
+      {
         value: "false",
-        text: "No, the trainee has not started yet"
-      }
+        text: "Start date not known – provide it later"
+      } if startDateNotKnownAllowed
     ]
   } | decorateAttributes(record, "record.trainingDetails.traineeStarted")) }}
+
+{# If we don’t have a course start date, just show an input to collect date. This means they don’t
+have to do course details before starting this section. #}
+{% else %}
+
+  {{ commencementDateInputHtml | safe }}
+
 {% endif %}
 
 

--- a/app/views/_includes/forms/training-details/trainee-start-date-id.html
+++ b/app/views/_includes/forms/training-details/trainee-start-date-id.html
@@ -7,7 +7,7 @@
 {% set commencementStartDateArray = record.trainingDetails.commencementDate | toDateArray %}
 
 {% set commencementDateLabel = "What is the trainee’s start date?" %}
-{% set commencementDateHint = "This is the date the trainee starts on the course – not the course start date." %}
+{% set commencementDateHint = "This is the date the trainee starts on the course. This can be different from the course start date." %}
 
 
 {% set commencementDateInputHtml %}

--- a/app/views/_includes/forms/training-details/trainee-start-date.html
+++ b/app/views/_includes/forms/training-details/trainee-start-date.html
@@ -1,5 +1,6 @@
 {% set commencementStartDateArray = record.trainingDetails.commencementDate | toDateArray %}
 
+{% set commencementDateHint = "This is the date the trainee starts on the course – not the course start date." %}
 
 {{ govukDateInput({
   id: "commencement-start-date",
@@ -12,7 +13,7 @@
     }
   },
   hint: {
-    html: hintHtml
+    html: commencementDateHint
   },
   items: [
       {

--- a/app/views/_includes/forms/training-details/trainee-start-date.html
+++ b/app/views/_includes/forms/training-details/trainee-start-date.html
@@ -1,6 +1,6 @@
 {% set commencementStartDateArray = record.trainingDetails.commencementDate | toDateArray %}
 
-{% set commencementDateHint = "This is the date the trainee starts on the course – not the course start date." %}
+{% set commencementDateHint = "This is the date the trainee starts on the course. This can be different from the course start date." %}
 
 {{ govukDateInput({
   id: "commencement-start-date",

--- a/app/views/_includes/summary-cards/student-record.html
+++ b/app/views/_includes/summary-cards/student-record.html
@@ -215,7 +215,7 @@
   },
   {
     key: {
-      text: "Trainee start date"
+      text: "Trainee’s start date"
     },
     value: {
       text: commencementDateLabel or "Not provided"
@@ -225,7 +225,7 @@
         {
           href: recordPath + "/trainee-start-date" | addReferrer(referrer),
           text: "Change",
-          visuallyHiddenText: "trainee start date"
+          visuallyHiddenText: "trainee’s start date"
         }
       ]
     } if canAmend

--- a/app/views/_includes/summary-cards/training-details/trainee-start-date.html
+++ b/app/views/_includes/summary-cards/training-details/trainee-start-date.html
@@ -14,7 +14,7 @@
 {% set recordBaseRows = [
   {
     key: {
-      text: "Trainee start date"
+      text: "Trainee’s start date"
     },
     value: {
       text: commencementDateLabel or "Not provided"
@@ -24,7 +24,7 @@
         {
           href: recordPath + "/trainee-start-date" | addReferrer(referrer),
           text: "Change",
-          visuallyHiddenText: "trainee start date"
+          visuallyHiddenText: "trainee’s start date"
         }
       ]
     } if canAmend

--- a/app/views/_includes/summary-cards/training-details/training-details.html
+++ b/app/views/_includes/summary-cards/training-details/training-details.html
@@ -39,7 +39,7 @@
 
 {% set traineeStartDateRow = {
     key: {
-      text: "Date trainee started"
+      text: "Trainee’s start date"
     },
     value: {
       text: commencementDateLabel
@@ -49,7 +49,7 @@
         {
           href: recordPath + "/training-details" | addReferrer(referrer),
           text: "Change",
-          visuallyHiddenText: "start date"
+          visuallyHiddenText: "trainee’s start date"
         }
       ]
     } if canAmend

--- a/app/views/record/trainee-start-date/index.html
+++ b/app/views/record/trainee-start-date/index.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_record-form.html" %}
 
-{% set pageHeading = "Date trainee started" %}
+{% set pageHeading = "What is the trainee’s start date?" %}
 
 {% set formAction = "./trainee-start-date/confirm" | addReferrer(referrer) %}
 


### PR DESCRIPTION
This updates our trainee start date question to do two things:
* Offer to use the course start date if available
* Use tenseless text to avoid implying a trainee needs to have started a course to be registered

We can only offer to use the course start date if we have it available. Right now this section comes after the course details section, but we don't requite course details to be done first - and I'm keen to avoid more conditionality.

If a course start date is available we'll ask like this:
![trainee-start-date-question-2](https://user-images.githubusercontent.com/2204224/123446180-87038200-d5d0-11eb-80a7-2431a8477947.gif)

If a course start date isn't available, we'll just show the date input, but with similar text as used by the radio question:
![Screenshot 2021-06-25 at 16 11 22](https://user-images.githubusercontent.com/2204224/123445716-13fa0b80-d5d0-11eb-8c75-6ec899cc3cf7.png)

Have also updated the record edit page for start date to match:
![Screenshot 2021-06-25 at 16 11 42](https://user-images.githubusercontent.com/2204224/123445731-165c6580-d5d0-11eb-974e-a99ef2836b4e.png)

