### PR TITLE
Tweak early years bursary content and add level filters

### DIFF
--- a/app/data/generators/course-generator.js
+++ b/app/data/generators/course-generator.js
@@ -146,9 +146,11 @@ module.exports = (params) => {
 
   const route = params.route || pickRoute(isPublishCourse)
 
+  let isEarlyYears = route.includes('Early years')
+
   let level, qualifications, qualificationsSummary, studyMode
 
-  if (route.includes('Early years')){
+  if (isEarlyYears){
     level = 'Early years'
   }
   // else level = faker.helpers.randomize(['Primary', 'Secondary'])
@@ -160,7 +162,7 @@ module.exports = (params) => {
 
   let subjects
 
-  if (route.includes('Early years')){
+  if (isEarlyYears){
     // This subject isn’t really used or shown - but matches how DTTP handles it
     subjects = 'Early years teaching'
   }
@@ -192,7 +194,7 @@ module.exports = (params) => {
     studyMode = "Full time"
     // If early years or AO, just use route defaults
     // Todo: extend this to add academic qualifications possible for early years
-    if (route.includes('Early years') || route.includes('Assessment only')){
+    if (isEarlyYears || route.includes('Assessment only')){
       qualifications = enabledRoutes[route].qualifications
       qualificationsSummary = enabledRoutes[route].qualificationsSummary
     }
@@ -210,7 +212,7 @@ module.exports = (params) => {
   // Part time
   else {
     studyMode = "Part time"
-    if (route.includes('Early years')){
+    if (isEarlyYears){
       qualifications = enabledRoutes[route].qualifications
       qualificationsSummary = enabledRoutes[route].qualificationsSummary
     }

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -120,7 +120,7 @@ exports.getCourseLevel = record => {
   if (record?.courseDetails?.level) matchedLevel = record?.courseDetails?.level
 
   // Early years routes don’t have an age range - but they’re all implicitly 'Early years'
-  else if (record?.route && record?.route.includes("Early years")) matchedLevel = "Early years"
+  else if (exports.routeIsEarlyYears(record?.route)) matchedLevel = "Early years"
 
   // Age range can be used to derive the level
   else if (record?.courseDetails?.ageRange) {
@@ -197,7 +197,7 @@ exports.getBursaryByRouteAndSubject = (route, subject) => {
     }
     // Early years don’t really have subjects - but we can check the route instead
     // Todo: should we just copy over the entire object?
-    else if (route.includes("Early years") && bursaryLevel.subjects.includes("Early years")){
+    else if (exports.routeIsEarlyYears(route) && bursaryLevel.subjects.includes("Early years")){
       bursary.value = bursaryLevel.value
       bursary.subjects = bursaryLevel.subjects
       bursary.subject = "Early years"
@@ -243,7 +243,7 @@ exports.bursariesApply = (record) => {
 exports.canStartFundingSection = record => {
   if (!exports.routeHasBursaries(record?.route)) return true
   // Early years routes with bursaries need no extra info
-  else if (record?.route.includes("Early years")) return true
+  else if (exports.isEarlyYears(record)) return true
   // Other routes need course details to start bursaries
   else {
     let courseDetailsComplete = exports.sectionIsComplete(record.courseDetails)
@@ -463,6 +463,31 @@ exports.sourceIsApply = record => {
 
 exports.sourceIsManual = record => {
   return record?.source != "Apply"
+}
+
+// Levels
+
+// Unlike the other levels, this is probably reliable - as it checcks the route rather than the age
+// ranges of the course
+exports.isEarlyYears = record => {
+  return exports.getCourseLevel(record) == "Early years"
+}
+
+// Explicitly test the route only - as
+exports.routeIsEarlyYears = route => {
+  return route && route.includes("Early years")
+}
+
+// TODO: this might not be reliable - need to check all age ranges
+// map to one of the levels
+exports.isPrimary = record => {
+  return exports.getCourseLevel(record) == "Primary"
+}
+
+// TODO: this might not be reliable - need to check all age ranges
+// map to one of the levels
+exports.isSecondary = record => {
+  return exports.getCourseLevel(record) == "Secondary"
 }
 
 exports.sectionIsComplete = section => {

--- a/app/views/_includes/forms/course-details.html
+++ b/app/views/_includes/forms/course-details.html
@@ -1,4 +1,4 @@
-{% if record.route | includes("Early years") %}
+{% if record | isEarlyYears %}
   {% include "_includes/forms/course-details/early-years.html" %}
 {% else %}
   {% include "_includes/forms/course-details/index.html" %}

--- a/app/views/_includes/forms/funding/bursary.html
+++ b/app/views/_includes/forms/funding/bursary.html
@@ -4,14 +4,21 @@
 {# We might not always have a bursary value at this stage - so conditionally set it #}
 {% set bursaryValue = record | getBursaryValue %}
 {% if bursaryValue | falsify %}
-  {% set bursaryValueText %}
-    of {{ bursaryValue | currency }}
-  {% endset %}
+  {% set bursaryValueText %} of {{ bursaryValue | currency }}{% endset %}
 {% endif %}
 
-<p class="govuk-body">
-  The course you have selected has a bursary available {{ bursaryValueText }} for {{ bursary.subject | dynamicLowercase }}. You need to check if the trainee is eligible for this bursary.
-</p>
+{# Early years either have a bursary or not - it’s not based on subject #}
+{% if record | isEarlyYears %}
+  <p class="govuk-body">
+    {{ record.route }} has a bursary available{{ bursaryValueText }}. You need to check if the trainee is eligible for this bursary.
+  </p>
+
+{# For other courses, bursaries are only available for specific courses #}
+{% else %}
+  <p class="govuk-body">
+    The course you have selected has a bursary available{{ bursaryValueText }} for {{ bursary.subject | dynamicLowercase }}. You need to check if the trainee is eligible for this bursary.
+  </p>
+{% endif %}
 
 <p class="govuk-body"><a href="https://www.gov.uk/government/publications/initial-teacher-training-itt-bursary-funding-manual/initial-teacher-training-bursaries-funding-manual-2021-to-2022-academic-year#training-bursary-award-and-eligibility" class="govuk-link" rel="noreferrer noopener" target="_blank">DfE bursary guidance for academic year 2021 to 2022 (opens in new tab)</a></p>
 

--- a/app/views/_includes/summary-cards/course-details.html
+++ b/app/views/_includes/summary-cards/course-details.html
@@ -4,7 +4,7 @@
 
 {% if sectionIsRequired %}
   
-  {% if record.route | includes("Early years") %}
+  {% if record | isEarlyYears %}
     {% include "_includes/summary-cards/course-details/early-years-course.html" %}
   {% elseif record.courseDetails.isPublishCourse %}
     {% include "_includes/summary-cards/course-details/publish-course.html" %}


### PR DESCRIPTION
The lead in sentence for Early years bursaries was awkward - as I was trying to dynamically generate it.

Instead, show a bespoke sentence for early years.

Before:
![Screenshot 2021-06-28 at 12 00 30](https://user-images.githubusercontent.com/2204224/123626180-74738d80-d808-11eb-974f-60d35a00df71.png)

After:
![Screenshot 2021-06-28 at 11 18 04](https://user-images.githubusercontent.com/2204224/123626093-5a39af80-d808-11eb-90b8-477067232022.png)
![Screenshot 2021-06-28 at 11 19 32](https://user-images.githubusercontent.com/2204224/123626106-5dcd3680-d808-11eb-932b-8ae028e877e6.png)
