### PR TITLE
fix bug with early years course details

### DIFF
--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -599,7 +599,7 @@ module.exports = router => {
     let subjectAutocomplete1 = req.body?._autocompleteRawValue_subject_1
 
     // Make an array of subjects data - easier to work with
-    let subjectsArray = Object.values(record.courseDetails.subjects).filter(Boolean)
+    let subjectsArray = record?.courseDetails?.subjects && Object.values(record.courseDetails.subjects).filter(Boolean) || []
 
     // Special handling to cope with users deleting values from autocompletes.
     // Autocompletes make it hard to clear a value when used as an enhanced select.
@@ -625,7 +625,7 @@ module.exports = router => {
     // Remove empty and force in to array
     subjectsArray = [].concat(subjectsArray.filter(Boolean))
     // Map back to cardinal object
-    record.courseDetails.subjects = utils.arrayToOrdinalObject(subjectsArray)
+    courseDetails.subjects = utils.arrayToOrdinalObject(subjectsArray)
 
     // Merge autocomplete and radio answers
     if (courseDetails.ageRange == 'Other age range'){
@@ -633,6 +633,7 @@ module.exports = router => {
       delete courseDetails.ageRangeOther
     }
 
+    // Save back to record
     record.courseDetails = courseDetails
 
     let isAllocated = utils.hasAllocatedPlaces(record)

--- a/app/views/_includes/forms/course-details/early-years.html
+++ b/app/views/_includes/forms/course-details/early-years.html
@@ -1,5 +1,27 @@
 <h1 class="govuk-heading-l">{{pageHeading}}</h1>
 
+<input name='record[courseDetails][subjects][first]' type="hidden" id="subject" value="Early years teaching">
+
+{{ govukRadios({
+  fieldset: {
+    legend: {
+      text: "Full time or part time?",
+      classes: "govuk-fieldset__legend--s"
+    }
+  },
+  hint: {
+    text: ""
+  },
+  items: [
+    {
+      text: "Full time"
+    },
+    {
+      text: "Part time"
+    }
+  ]
+} | decorateAttributes(record, "record.courseDetails.studyMode")) }}
+
 {% set programmeStartDateArray = record.courseDetails.startDate | toDateArray %}
 
 {{ govukDateInput({


### PR DESCRIPTION
#293 introduced a bug where it was assumed course details would always be given subjects. This wasn't the case for Early years, so submitting the early years course details failed.

This PR fixes that bug so subjects aren't assumed - but also updates the Early years form to have a hidden field that sets the first subject to `Early years teaching` - which matches what the seed generator sets and how our other systems model the subjects for Early years.