### PR TITLE
Extend support for routes with ambiguous dates

### DIFF
--- a/app/data/training-route-data.js
+++ b/app/data/training-route-data.js
@@ -123,7 +123,8 @@ let baseRouteData = {
           ],
         value: "9000"
       }
-    ]
+    ],
+    courseDatesAreAmgiguous: true
   },
   "Provider-led (postgrad)": {
     defaultEnabled: true,
@@ -254,7 +255,8 @@ let baseRouteData = {
       "Now teach",
       "Transition to teach"
     ],
-    bursariesAvailable: false
+    bursariesAvailable: false,
+    courseDatesAreAmgiguous: true
   },
   "Opt-in (undergrad)": {
     defaultEnabled: true,
@@ -283,7 +285,8 @@ let baseRouteData = {
           ],
         value: "9000"
       }
-    ]
+    ],
+    courseDatesAreAmgiguous: true
   },
   "Early years (salaried)": {
     defaultEnabled: true,
@@ -391,7 +394,8 @@ let baseRouteData = {
       "EYTS"
     ],
     qualificationsSummary: "EYTS full time",
-    bursariesAvailable: false
+    bursariesAvailable: false,
+    courseDatesAreAmgiguous: true
   }
 }
 

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -658,6 +658,11 @@ exports.isApprenticeship = record => {
   return record?.route == "Teaching apprenticeship (postgrad)"
 }
 
+// For some courses, the the wider course might be longer than the itt bit we’re interested in
+exports.courseDatesAreAmbiguous = record => {
+  return trainingRoutes?.[record?.route]?.courseDatesAreAmgiguous || false
+}
+
 // Levels
 
 // Unlike the other levels, this is probably reliable - as it checcks the route rather than the age

--- a/app/views/_includes/forms/course-details/early-years.html
+++ b/app/views/_includes/forms/course-details/early-years.html
@@ -24,17 +24,36 @@
 
 {% set programmeStartDateArray = record.courseDetails.startDate | toDateArray %}
 
+{% set startDateHint = "For example, " + "" | today | toDateArray | spaceSeparate %}
+
+{% if record | courseDatesAreAmbiguous %}
+  {% set startDateLabel = "ITT start date" %}
+{% else %}
+  {% set startDateLabel = "Course start date" %}
+{% endif %}
+
+{% if record | courseDatesAreAmbiguous %}
+  {% set startDateHint %}
+    <p class="govuk-body govuk-hint">
+      The start date of the Initial Teacher Training portion of their course.
+    </p>
+    <p class="govuk-body govuk-hint">
+      {{startDateHint | safe }}
+    </p>
+  {% endset %}
+{% endif %}
+
 {{ govukDateInput({
   id: "programme-start-date",
   namePrefix: "record[courseDetails][startDate]",
   fieldset: {
     legend: {
-      text: "Course start date",
+      text: startDateLabel,
       classes: "govuk-fieldset__legend--s"
     }
   },
   hint: {
-    text: "For example, " + "" | today | toDateArray | spaceSeparate
+    html: startDateHint
   },
   items: [
       {
@@ -55,18 +74,37 @@
     ]
 }) }}
 
+{% set endDateHint = "For example, " + "" | today | moment('add', 1, 'years') | toDateArray | spaceSeparate %}
+
+{% if record | courseDatesAreAmbiguous %}
+  {% set endDateLabel = "ITT end date" %}
+{% else %}
+  {% set endDateLabel = "Course end date" %}
+{% endif %}
+
+{% if record | courseDatesAreAmbiguous %}
+  {% set endDateHint %}
+    <p class="govuk-body govuk-hint">
+      The end date of the Initial Teacher Training portion of their course.
+    </p>
+    <p class="govuk-body govuk-hint">
+      {{ endDateHint | safe }}
+    </p>
+  {% endset %}
+{% endif %}
+
 {% set programmeEndDateArray = record.courseDetails.endDate | toDateArray %}
 {{ govukDateInput({
   id: "programme-end-date",
   namePrefix: "record[courseDetails][endDate]",
   fieldset: {
     legend: {
-      text: "Course end date",
+      text: endDateLabel,
       classes: "govuk-fieldset__legend--s"
     }
   },
   hint: {
-    text: "For example, " + "" | today | moment('add', 1, 'years') | toDateArray | spaceSeparate
+    html: endDateHint
   },
   items: [
       {

--- a/app/views/_includes/forms/course-details/index.html
+++ b/app/views/_includes/forms/course-details/index.html
@@ -189,7 +189,6 @@
 
 {% set startDateHint = "For example, " + "" | today | toDateArray | spaceSeparate %}
 
-{{record | courseDatesAreAmbiguous | log}}
 {% if record | courseDatesAreAmbiguous %}
   {% set startDateLabel = "ITT start date" %}
 {% else %}

--- a/app/views/_includes/forms/course-details/index.html
+++ b/app/views/_includes/forms/course-details/index.html
@@ -62,8 +62,9 @@
   open: true if hasMultipleSubjects
 }) }}
 
-{# These account for 91% of choices #}
+{# These account for 97.4% of choices #}
 {% set commonAgeRanges = [
+  "3 to 7",
   "3 to 11",
   "5 to 11",
   "11 to 16",
@@ -188,13 +189,14 @@
 
 {% set startDateHint = "For example, " + "" | today | toDateArray | spaceSeparate %}
 
-{% if record | isApprenticeship %}
+{{record | courseDatesAreAmbiguous | log}}
+{% if record | courseDatesAreAmbiguous %}
   {% set startDateLabel = "ITT start date" %}
 {% else %}
   {% set startDateLabel = "Course start date" %}
 {% endif %}
 
-{% if record | isApprenticeship %}
+{% if record | courseDatesAreAmbiguous %}
   {% set startDateHint %}
     <p class="govuk-body govuk-hint">
       The start date of the Initial Teacher Training portion of their course.
@@ -240,13 +242,13 @@
 
 {% set endDateHint = "For example, " + "" | today | moment('add', 1, 'years') | toDateArray | spaceSeparate %}
 
-{% if record | isApprenticeship %}
+{% if record | courseDatesAreAmbiguous %}
   {% set endDateLabel = "ITT end date" %}
 {% else %}
   {% set endDateLabel = "Course end date" %}
 {% endif %}
 
-{% if record | isApprenticeship %}
+{% if record | courseDatesAreAmbiguous %}
   {% set endDateHint %}
     <p class="govuk-body govuk-hint">
       The end date of the Initial Teacher Training portion of their course.

--- a/app/views/_includes/forms/course-details/start-date.html
+++ b/app/views/_includes/forms/course-details/start-date.html
@@ -2,7 +2,7 @@
 
 {% set startDateHint = "For example, " + "" | today | toDateArray | spaceSeparate %}
 
-{% if record | isApprenticeship %}
+{% if record | courseDatesAreAmbiguous %}
   {% set startDateHint %}
     <p class="govuk-body govuk-hint">
       The start date of the Initial Teacher Training portion of their course.

--- a/app/views/_includes/summary-cards/course-details/non-publish-course.html
+++ b/app/views/_includes/summary-cards/course-details/non-publish-course.html
@@ -92,7 +92,7 @@
   },
   {
     key: {
-      text: "Course start date" if not record | isApprenticeship else "ITT start date"
+      text: "Course start date" if not record | courseDatesAreAmbiguous else "ITT start date"
     },
     value: {
       text: record.courseDetails.startDate | govukDate or 'Not provided'
@@ -102,14 +102,14 @@
         {
           href: recordPath + "/course-details/details" | addReferrer(referrer),
           text: "Change",
-          visuallyHiddenText: "course start date" if not record | isApprenticeship else "ITT start date"
+          visuallyHiddenText: "course start date" if not record | courseDatesAreAmbiguous else "ITT start date"
         }
       ]
     } if canAmend
   },
   {
     key: {
-      text: "Course end date" if not record | isApprenticeship else "ITT end date"
+      text: "Course end date" if not record | courseDatesAreAmbiguous else "ITT end date"
     },
     value: {
       text: record.courseDetails.endDate | govukDate or 'Not provided'
@@ -119,7 +119,7 @@
         {
           href: recordPath + "/course-details/details" | addReferrer(referrer),
           text: "Change",
-          visuallyHiddenText: "course end date" if not record | isApprenticeship else "ITT end date"
+          visuallyHiddenText: "course end date" if not record | courseDatesAreAmbiguous else "ITT end date"
         }
       ]
     } if canAmend

--- a/app/views/_includes/summary-cards/course-details/publish-course.html
+++ b/app/views/_includes/summary-cards/course-details/publish-course.html
@@ -135,7 +135,7 @@
 
 {% set startDateRow = {
   key: {
-    text: "Start date" if not record | isApprenticeship else "ITT start date"
+    text: "Start date" if not record | courseDatesAreAmbiguous else "ITT start date"
   },
   value: {
     text: courseDetails.startDate | govukDate or 'Not provided'
@@ -145,7 +145,7 @@
       {
         href: recordPath + "/course-details/details" | addReferrer(referrer),
         text: "Change",
-        visuallyHiddenText: "course start date" if not record | isApprenticeship else "ITT start date"
+        visuallyHiddenText: "course start date" if not record | courseDatesAreAmbiguous else "ITT start date"
       }
     ]
   } if canAmend
@@ -153,7 +153,7 @@
 
 {% set endDateRow = {
   key: {
-    text: "End date" if not record | isApprenticeship else "ITT end date"
+    text: "End date" if not record | courseDatesAreAmbiguous else "ITT end date"
   },
   value: {
     text: courseDetails.endDate | govukDate("MMMM YYYY") or 'Not provided'
@@ -163,7 +163,7 @@
       {
         href: recordPath + "/course-details/details" | addReferrer(referrer),
         text: "Change",
-        visuallyHiddenText: "course end date" if not record | isApprenticeship else "ITT end date"
+        visuallyHiddenText: "course end date" if not record | courseDatesAreAmbiguous else "ITT end date"
       }
     ]
   } if canAmend

--- a/app/views/new-record/course-details/start-date.html
+++ b/app/views/new-record/course-details/start-date.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_new-record.html" %}
 
-{% if data.record | isApprenticeship %}
+{% if data.record | courseDatesAreAmbiguous %}
   {% set pageHeading = "ITT start date" %}
 {% else %}
   {% set pageHeading = "Course start date" %}

--- a/app/views/record/course-details/start-date.html
+++ b/app/views/record/course-details/start-date.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_record-form.html" %}
 
-{% if data.record | isApprenticeship %}
+{% if data.record | courseDatesAreAmbiguous %}
   {% set pageHeading = "ITT start date" %}
 {% else %}
   {% set pageHeading = "Course start date" %}


### PR DESCRIPTION
This extends the work from #306 so that undergrad and opt in courses refer to ITT dates rather than the ambiguous `Course start date` and `Course end date`.