### PR TITLE
Collect study mode where Publish study mode is ambiguous

### DIFF
--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -758,6 +758,9 @@ exports.hasOutstandingActions = function(record, data = false) {
   return hasOutstandingActions
 }
 
+// Some Publish courses are only `Full time or part time` which isn’t specific enough.
+// TODO: Study mode is not relevant to all routes, this should also check if the route needs
+// study mode
 exports.needsStudyMode = record => {
 
   let allowedStudyModes = [
@@ -767,9 +770,6 @@ exports.needsStudyMode = record => {
   return (!allowedStudyModes.includes(record?.courseDetails?.studyMode))
 }
 
-exports.needsStartDate = record => {
-
-}
 
 // -------------------------------------------------------------------
 // Get records

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -758,6 +758,18 @@ exports.hasOutstandingActions = function(record, data = false) {
   return hasOutstandingActions
 }
 
+exports.needsStudyMode = record => {
+
+  let allowedStudyModes = [
+    "Full time",
+    "Part time"
+  ]
+  return (!allowedStudyModes.includes(record?.courseDetails?.studyMode))
+}
+
+exports.needsStartDate = record => {
+
+}
 
 // -------------------------------------------------------------------
 // Get records

--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -401,12 +401,16 @@ module.exports = router => {
         }
 
         let isAllocated = utils.hasAllocatedPlaces(record)
+        let isMissingStudyMode = utils.needsStudyMode(record)
         let isMissingStartDate = !Boolean(courseDetails?.startDate)
 
         // Not all specialisms are mappable, so for those, send the user to a followup page
         if (utils.hasUnmappedPublishSubjects(record.courseDetails)){
           console.log("Course has unmapped subjects")
           res.redirect(`${recordPath}/course-details/choose-specialisms${referrer}`)
+        }
+        else if (isMissingStudyMode){
+          res.redirect(`${recordPath}/course-details/study-mode${referrer}`)
         }
         else if (isMissingStartDate){
           res.redirect(`${recordPath}/course-details/start-date${referrer}`)
@@ -432,10 +436,15 @@ module.exports = router => {
     let recordPath = utils.getRecordPath(req)
     let referrer = utils.getReferrer(req.query.referrer)
     let isAllocated = utils.hasAllocatedPlaces(record)
+    let isMissingStudyMode = utils.needsStudyMode(record)
     let isMissingStartDate = !Boolean(record?.courseDetails?.startDate)
+
 
     if (utils.hasUnmappedPublishSubjects(record.courseDetails) || utils.subjectsAreIncomplete(record.courseDetails)){
       res.render(`${req.params.recordtype}/course-details/choose-specialisms`)
+    }
+    else if (isMissingStudyMode){
+      res.redirect(`${recordPath}/course-details/study-mode${referrer}`)
     }
     else if (isMissingStartDate){
       res.redirect(`${recordPath}/course-details/start-date${referrer}`)
@@ -457,6 +466,7 @@ module.exports = router => {
     let recordPath = utils.getRecordPath(req)
     let referrer = utils.getReferrer(req.query.referrer)
     let isAllocated = utils.hasAllocatedPlaces(record)
+    let isMissingStudyMode = utils.needsStudyMode(record)
     let isMissingStartDate = !Boolean(record?.courseDetails?.startDate)
 
     let courseDetails = record?.courseDetails
@@ -502,6 +512,9 @@ module.exports = router => {
     if (utils.hasUnmappedPublishSubjects(record.courseDetails) || utils.subjectsAreIncomplete(record.courseDetails)){
       console.log("Course has unmapped subjects")
       res.redirect(`${recordPath}/course-details/choose-specialisms${referrer}`)
+    }
+    else if (isMissingStudyMode){
+      res.redirect(`${recordPath}/course-details/study-mode${referrer}`)
     }
     else if (isMissingStartDate){
       res.redirect(`${recordPath}/course-details/start-date${referrer}`)
@@ -572,7 +585,32 @@ module.exports = router => {
   //   }
   // })
 
-  // Choose between allocated place page and confirm page
+   // Branching route
+  router.post(['/:recordtype/:uuid/course-details/study-mode','/:recordtype/course-details/study-mode'], function (req, res) {
+    const data = req.session.data
+    let record = data.record
+    let recordPath = utils.getRecordPath(req)
+    let referrer = utils.getReferrer(req.query.referrer)
+
+    let isAllocated = utils.hasAllocatedPlaces(record)
+    let isMissingStudyMode = utils.needsStudyMode(record)
+    let isMissingStartDate = !Boolean(record?.courseDetails?.startDate)
+
+
+    if (isMissingStudyMode){
+      res.redirect(`${recordPath}/course-details/study-mode${referrer}`)
+    }
+    else if (isMissingStartDate){
+      res.redirect(`${recordPath}/course-details/start-date${referrer}`)
+    }
+    else if (isAllocated) {
+      // After /allocated-place the journey will match other course-details routes
+      res.redirect(`${recordPath}/course-details/allocated-place${referrer}`)
+    }
+    else res.redirect(`${recordPath}/course-details/confirm${referrer}`)
+  })
+
+  // Branching route
   router.post(['/:recordtype/:uuid/course-details/start-date','/:recordtype/course-details/start-date'], function (req, res) {
     const data = req.session.data
     let record = data.record

--- a/app/views/_includes/forms/course-details/study-mode.html
+++ b/app/views/_includes/forms/course-details/study-mode.html
@@ -1,0 +1,27 @@
+
+{{ govukRadios({
+  fieldset: {
+    legend: {
+      text: pageHeading,
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--l"
+    }
+  },
+  hint: {
+    text: ""
+  },
+  items: [
+    {
+      text: "Full time"
+    },
+    {
+      text: "Part time"
+    }
+  ]
+} | decorateAttributes(record, "record.courseDetails.studyMode")) }}
+
+{{ govukButton({
+  text: "Continue"
+}) }}
+
+

--- a/app/views/_includes/forms/course-details/study-mode.html
+++ b/app/views/_includes/forms/course-details/study-mode.html
@@ -1,4 +1,3 @@
-
 {{ govukRadios({
   fieldset: {
     legend: {
@@ -6,9 +5,6 @@
       isPageHeading: true,
       classes: "govuk-fieldset__legend--l"
     }
-  },
-  hint: {
-    text: ""
   },
   items: [
     {
@@ -23,5 +19,3 @@
 {{ govukButton({
   text: "Continue"
 }) }}
-
-

--- a/app/views/new-record/course-details/study-mode.html
+++ b/app/views/new-record/course-details/study-mode.html
@@ -1,0 +1,12 @@
+{% extends "_templates/_new-record.html" %}
+
+
+{% set pageHeading = "Is the trainee full time or part time?" %}
+
+
+{# {% set formAction = "./confirm" %} #}
+
+{% block formContent %}
+  {% include "_includes/forms/course-details/study-mode.html" %}
+{% endblock %}
+

--- a/app/views/record/course-details/study-mode.html
+++ b/app/views/record/course-details/study-mode.html
@@ -1,0 +1,11 @@
+{% extends "_templates/_record-form.html" %}
+
+{% set pageHeading = "Is the trainee full time or part time?" %}
+
+
+{# {% set formAction = "./confirm" %} #}
+
+{% block formContent %}
+  {% include "_includes/forms/course-details/study-mode.html" %}
+{% endblock %}
+


### PR DESCRIPTION
Publish allows providers to select `Full time or part time` as the study mode - this means that for some courses we won't know enough to correctly set the study mode.

When selecting a Publish course with an ambiguous study mode, we'll ask a followup question to collect it - in a similar way to subject specialism or itt start date.

This should only apply to manually added trainees with Publish courses with ambiguous study modes. For Apply trainees, providers select the study mode when making the offer - so whilst the publish course might be ambiguous, we'll know for the specific trainee if they're full time or part time.

![Screenshot 2021-07-22 at 13 02 48](https://user-images.githubusercontent.com/2204224/126639317-20bce874-9ff8-41b4-a48e-1809606fae2a.png)

## Testing

To test, add a trainee on a route that has Publish courses. Select a course that is listed as `full time or part time`. After being asked about specialisms (if subjects are ambiguous) you should be asked about study mode.

The same should work if changing the course from an existing record or Apply draft - though finding a course with ambiguous study mode might be tricky.