### PR TITLE
What is the trainee’s highest academic qualification? — July 2021

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -201,3 +201,6 @@ span.summary-validation-symbol {
   float: right;
 }
 
+app-nowrap {
+  white-space: nowrap;
+}

--- a/app/data/training-route-data.js
+++ b/app/data/training-route-data.js
@@ -106,7 +106,7 @@ let baseRouteData = {
       'personalDetails',
       'contactDetails',
       'diversity',
-      'undergraduateQualification',
+      // 'undergraduateQualification',
       // 'placement',
       'funding'
     ],
@@ -275,7 +275,7 @@ let baseRouteData = {
       'personalDetails',
       'contactDetails',
       'diversity',
-      'undergraduateQualification',
+      // 'undergraduateQualification',
       // 'placement',
       'funding'
     ],
@@ -402,7 +402,7 @@ let baseRouteData = {
       'personalDetails',
       'contactDetails',
       'diversity',
-      'undergraduateQualification',
+      // 'undergraduateQualification',
       // 'placement',
       'funding'
     ],

--- a/app/data/undergraduate-qualifications.js
+++ b/app/data/undergraduate-qualifications.js
@@ -22,7 +22,7 @@ module.exports = [
   // 'Certificate at level M',
   // 'Certificate in Education (CertEd) or Diploma in Education (DipEd) (i.e. non-graduate initial teacher training qualification)',
   // 'Certificate of Higher Education (CertHE)',
-  'Certificate (CertEd) or Diploma (DipEd) in Education  ',
+  'Certificate (CertEd) or Diploma (DipEd) in Education',
   'Certificate (CertHE) or Diploma (DipHE) of Higher Education',
   'Diploma at level 3',
   'Diploma at level 2',

--- a/app/views/_includes/forms/undergraduate-qualification.html
+++ b/app/views/_includes/forms/undergraduate-qualification.html
@@ -1,8 +1,8 @@
 {% set customUndergraduateQualification %}
   {{ govukInput({
     label: {
-        text: "Add the qualification",
-        classes: "govuk-label govuk-label--s"
+        text: "Qualification",
+        classes: "govuk-label"
     },
     classes: "govuk-!-width-two-thirds"
   } | decorateAttributes(record, "record.undergraduateQualification.typeOther")) }}
@@ -10,30 +10,32 @@
 
 {% set undergraduateQualifications = []  %}
 
-{% for undergraduateQualification in data.ugEntryQualifications %}
+{# {% for undergraduateQualification in data.ugEntryQualifications %}
   {% set undergraduateQualifications = undergraduateQualifications | push ({ 
     text: undergraduateQualification
   }) %}
-{% endfor %}
+{% endfor %} #}
 
 {% set undergraduateQualifications = undergraduateQualifications | push ({ 
-  divider: "or"
-}) %}
-
-{% set undergraduateQualifications = undergraduateQualifications | push ({ 
-  text: "Another qualification not listed",
-  checked: storeQualificationOther,
-  conditional: {
-    html: customUndergraduateQualification
+  text: "Level 3",
+  hint: {
+    text: "For example, A levels, Scottish Highers, Access to Higher Education, or an international Baccalaureate diploma."
   }
 }) %}
 
 {% set undergraduateQualifications = undergraduateQualifications | push ({ 
-  text: "No formal qualification"
+  text: "Level 4 and above",
+  hint: {
+    text: "For example, a foundation diploma, an undergraduate degree, or a postgraduate degree."
+  }
 }) %}
 
 {% set undergraduateQualifications = undergraduateQualifications | push ({ 
-  text: "Unknown"
+  text: "Other qualification",
+  checked: storeQualificationOther,
+  conditional: {
+    html: customUndergraduateQualification
+  }
 }) %}
 
 {{ govukRadios({
@@ -43,6 +45,9 @@
       isPageHeading: true,
       classes: "govuk-fieldset__legend--l"
     }
+  },
+  hint: {
+    text: "Give the qualification they’ll have when they start teacher training."
   },
   items: undergraduateQualifications
 } | decorateAttributes(record, "record.undergraduateQualification.type")) }}

--- a/app/views/_includes/forms/undergraduate-qualification.html
+++ b/app/views/_includes/forms/undergraduate-qualification.html
@@ -10,12 +10,6 @@
 
 {% set undergraduateQualifications = []  %}
 
-{# {% for undergraduateQualification in data.ugEntryQualifications %}
-  {% set undergraduateQualifications = undergraduateQualifications | push ({ 
-    text: undergraduateQualification
-  }) %}
-{% endfor %} #}
-
 {% set undergraduateQualifications = undergraduateQualifications | push ({ 
   text: "Level 3",
   hint: {

--- a/app/views/_includes/summary-cards/undergraduate-qualification.html
+++ b/app/views/_includes/summary-cards/undergraduate-qualification.html
@@ -1,5 +1,5 @@
 {% set undergraduateQualification %}
-  {% if record.undergraduateQualification.type == "Another qualification not listed" %}
+  {% if record.undergraduateQualification.type == "Other qualification" %}
     {{record.undergraduateQualification.typeOther}}
   {% else%}
     {{record.undergraduateQualification.type}}
@@ -45,11 +45,11 @@
   {% set incompleteType = "warning" if errorList %}
   {% set incompleteId = "undergraduateQualification" %}
   {% if status == "In progress" %}
-    {% set incompleteText = "Academic qualification not marked as complete" %}
+    {% set incompleteText = "Qualification on entry not marked as complete" %}
     {% set incompleteLink = recordPath + "/undergraduate-qualification/confirm" %}
     {% set incompleteLinkText = "Continue section" %}
   {% else %}
-    {% set incompleteText = "Academic qualification not started" %}
+    {% set incompleteText = "Qualification on entry not started" %}
     {% set incompleteLink = recordPath + "/undergraduate-qualification" %}
     {% set incompleteLinkText = "Start section" %}
   {% endif %}
@@ -60,7 +60,7 @@
 
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
-    titleText: "Academic qualification details",
+    titleText: "Qualification on entry details",
     html: undergraduateQualificationDetailsHtml
   }) }}
   

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -26,8 +26,8 @@
 
     <h2 class="govuk-heading-m">Pages</h2>
 
-    <p class="govuk-body">Main pages</p>
-    <ul class="govuk-list govuk-list--bullet">
+    <h3 class="govuk-heading-s">Main pages</h3>
+    <ul class="govuk-list">
       <li><a href="start-page" class="govuk-link">Start page</a></li>
       <li><a href="sign-in" class="govuk-link">Sign in</a></li>
       <li><a href="declaration" class="govuk-link">Declaration</a></li>
@@ -39,8 +39,8 @@
       <li><a href="record/0cd6b365-a287-4099-bad1-14e2aaa13656" class="govuk-link">Trainee record</a></li>
     </ul>
 
-    <p class="govuk-body">Content pages</p>
-    <ul class="govuk-list govuk-list--bullet">
+    <h3 class="govuk-heading-s">Content pages</h3>
+    <ul class="govuk-list">
       <li><a href="data-requirements" class="govuk-link">Check what data you need</a></li>
       <li><a href="guidance" class="govuk-link">Guidance</a></li>
       <li><a href="accessibility-statement" class="govuk-link">Accessibility statement</a></li>
@@ -48,11 +48,16 @@
       <li><a href="privacy-policy" class="govuk-link">Privacy policy</a></li>
     </ul>
 
-    <p class="govuk-body">Error pages</p>
-    <ul class="govuk-list govuk-list--bullet">
+    <h3 class="govuk-heading-s">Error pages</h3>
+    <ul class="govuk-list">
       <li><a href="403" class="govuk-link">400 - Access denied</a></li>
       <li><a href="404" class="govuk-link">404 - Page not found</a></li>
       <li><a href="500" class="govuk-link">500 - Something went wrong</a></li>
+    </ul>
+
+    <h3 class="govuk-heading-s">Alternate or unused pages</h3>
+    <ul class="govuk-list">
+      <li><a href="new-record/undergraduate-qualification" class="govuk-link">What is the trainee’s highest academic qualification?</a></li>
     </ul>
 
   </div>

--- a/app/views/new-record/overview.html
+++ b/app/views/new-record/overview.html
@@ -77,7 +77,7 @@
     }
   } if record | requiresSection("degree"),
   {
-    text: "Academic qualification",
+    text: "Qualifications on entry",
     href: "undergraduate-qualification/confirm" if (record.undergraduateQualification) else "undergraduate-qualification",
     id: "entry-qualification",
     tag: {

--- a/app/views/new-record/undergraduate-qualification/confirm.html
+++ b/app/views/new-record/undergraduate-qualification/confirm.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_new-record.html" %}
 
-{% set pageHeading = "Confirm academic qualification" %}
+{% set pageHeading = "Confirm qualification on entry" %}
 {% set backLink = './../overview' %}
 {% set backText = "Back to draft record" %}
 {% set gridColumn = 'govuk-grid-column-full' %}

--- a/app/views/record/undergraduate-qualification/confirm.html
+++ b/app/views/record/undergraduate-qualification/confirm.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_record-form.html" %}
 
-{% set pageHeading = "Confirm undergraduate qualification" %}
+{% set pageHeading = "Confirm qualification on entry" %}
 
 {% set backLink = ("/record/" + data.record.id) | orReferrer(referrer) %}
 {% set backText = "Back to record" %}


### PR DESCRIPTION
The previous iteration of the question "What is the trainee’s highest academic qualification?" confused users.

I tried a different approach to see if we could make it work better for users.

![localhost_3000_new-record_undergraduate-qualification(screenshot for design history) (2)](https://user-images.githubusercontent.com/8417288/127190932-304b2868-5d0d-4310-9097-13d4519fff07.png)

In the meantime I also looked at some of the data from DTTP and it doesn't seem to offer much value:

```
72.38%		76 	        Level 3
20.95%		22		Other higher qualification
4.76%		5		Foundation course at FE level
0.95%		1		Advanced Modern Apprenticeships
0.95%		1		Baccalaureate
```

Basically, the majority of users told us exactly what we'd expect, 20% gave us no meaningful data and the rest can't have much statistical significance. So we're going to remove the question entirely, hopefully.

I've added it to the prototype, but hidden it from the trainee creation flows.