### PR TITLE
Swapping between UK and Non-UK degrees

### DIFF
--- a/app/data/generators/degree.js
+++ b/app/data/generators/degree.js
@@ -72,7 +72,7 @@ module.exports = (params, application) => {
         subject,
         isInternational: "false",
         org,
-        country: 'United Kingdom',
+        // country: 'United Kingdom',
         grade,
         predicted,
         startDate,

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -1468,7 +1468,7 @@ exports.markInput = function(data, params){
   else if (type == 'invalid'){
     message = `${key} is not recognised`
     data.errorMessage = {
-      html: `The trainee entered ‘${valueCleaned}’, which was not recognised. ${params.invalidMessage || 'You need to search for the closest match.'}`
+      html: `The trainee entered ‘${valueCleaned}’${params.invalidMessage || ', which was not recognised. You need to search for the closest match.'}`
     }
     data.classes = (data.classes) ? `${data.classes} app-invalid-answer` : 'app-invalid-answer'
     delete data.value

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -1443,7 +1443,8 @@ exports.markSummaryRowMissing = function(row) {
 }
 
 
-exports.markInput = function(data, type){
+exports.markInput = function(data, params){
+  let type = params.type
   // Keys are stored two possible places
   let key = data?.label?.html || data?.label?.text || data?.fieldset?.legend?.html || data?.fieldset?.legend?.text
 
@@ -1467,7 +1468,7 @@ exports.markInput = function(data, type){
   else if (type == 'invalid'){
     message = `${key} is not recognised`
     data.errorMessage = {
-      text: `The trainee entered ‘${valueCleaned}’. You need to search for the closest match.`
+      html: `The trainee entered ‘${valueCleaned}’, which was not recognised. ${params.invalidMessage || 'You need to search for the closest match.'}`
     }
     data.classes = (data.classes) ? `${data.classes} app-invalid-answer` : 'app-invalid-answer'
     delete data.value
@@ -1478,7 +1479,7 @@ exports.markInput = function(data, type){
     message = `${key} is missing`
     
     data.errorMessage = {
-      text: message
+      html: message
     }
     data.classes = (data.classes) ? `${data.classes} app-invalid-answer` : 'app-invalid-answer'
     delete data.value
@@ -1502,18 +1503,20 @@ exports.markInputMissing = function(data) {
 } 
 // Take in a form object to 
 
-exports.highlightInvalidInputs = function(data){
+exports.highlightInvalidInputs = function(data, params={}){
 
   let value = data.value
 
   if (value && value.includes('**invalid**')) {
+    params.type = 'invalid'
     // Using .apply() to pass on value of 'this'
-    data = exports.markInput.apply(this, [data, 'invalid'])
+    data = exports.markInput.apply(this, [data, params])
   }
 
   if (value && value.includes('**missing**')) {
+    params.type = 'missing'
     // Using .apply() to pass on value of 'this'
-    data = exports.markInput.apply(this, [data, 'missing'])
+    data = exports.markInput.apply(this, [data, params])
   }
 
   return data

--- a/app/views/_includes/forms/degree/details-international.html
+++ b/app/views/_includes/forms/degree/details-international.html
@@ -33,9 +33,9 @@
   },
   id: 'degree-country',
   name: "degreeTemp[country]",
-  items: data.countries,
+  items: data.countries | removeArrayItem("United Kingdom"),
   classes: "app-!-autocomplete--max-width-two-thirds",
-  value: degreeTemp.country,
+  value: degreeTemp.country if data.country != "United Kingdom",
   minLength: 2,
   autoSelect: true,
   showAllValues: false

--- a/app/views/_includes/forms/degree/details-international.html
+++ b/app/views/_includes/forms/degree/details-international.html
@@ -9,8 +9,10 @@
   {% set ukHintText = "For example, BA, BSc, Masters or PhD" %}
 {% endif %}
 
-{#
+
 {# Disabled for now in favour of a link in an error message for invalid data #}
+
+{#
 
 {% set insetTextHtml %}
   <p class="govuk-body">Change this to an <a href="./details?degreeTemp[isInternational]=false{{'' | addReferrer(referrer) }}" class="govuk-link">UK degree</a>.</p>

--- a/app/views/_includes/forms/degree/details-international.html
+++ b/app/views/_includes/forms/degree/details-international.html
@@ -9,6 +9,19 @@
   {% set ukHintText = "For example, BA, BSc, Masters or PhD" %}
 {% endif %}
 
+{#
+{# Disabled for now in favour of a link in an error message for invalid data #}
+
+{% set insetTextHtml %}
+  <p class="govuk-body">Change this to an <a href="./details?degreeTemp[isInternational]=false{{'' | addReferrer(referrer) }}" class="govuk-link">UK degree</a>.</p>
+{% endset %}
+
+{{ govukInsetText({
+  html: insetTextHtml
+}) }} 
+
+#}
+
 
 {# Degree country #}
 {{ appAutocomplete({

--- a/app/views/_includes/forms/degree/details-uk.html
+++ b/app/views/_includes/forms/degree/details-uk.html
@@ -13,6 +13,28 @@
     {% set ukHintText = "For example, BA, BSc, Masters or PhD" %}
   {% endif %}
 
+  {% set insetTextHtml %}
+    <p class="govuk-body">If this is not a UK degree you can change it to a <a href="./details?degreeTemp[isInternational]=true{{'' | addReferrer(referrer) }}" class="govuk-link">non-UK degree</a>.</p>
+  {% endset %}
+
+  {# Show toggle for non-UK degree if the insitution is invalid #}
+  {% if degreeTemp.org | includes("**invalid**") %}
+    {{ govukInsetText({
+      html: insetTextHtml
+    }) }} 
+  {% endif %}
+
+  {% set changeDegreeTypeLink %}
+    <a href="./details?degreeTemp[isInternational]=true{{'' | addReferrer(referrer) }}" class="govuk-link">change to a non-UK degree</a>
+  {%- endset %}
+
+  {# {% set institutionNotRecognisedHtml %}
+    Search for the correct institution or {{changeDegreeTypeLink | safe}}.
+  {% endset %}
+ #}
+  {% set institutionNotRecognisedHtml %}
+    Search for the correct institution or change to a non-UK degree.
+  {% endset %}
 
   {# Degree institution #}
   {{ appAutocomplete({
@@ -28,7 +50,7 @@
     minLength: 2,
     autoSelect: true,
     showAllValues: false
-  } | highlightInvalidInputs ) }}
+  } | highlightInvalidInputs({invalidMessage: institutionNotRecognisedHtml}) ) }}
 
   {# Degree subject #}
   {{ appAutocomplete({

--- a/app/views/_includes/forms/degree/details-uk.html
+++ b/app/views/_includes/forms/degree/details-uk.html
@@ -32,8 +32,7 @@
     Search for the correct institution or {{changeDegreeTypeLink | safe}}.
   {% endset %}
  #}
-  {% set institutionNotRecognisedHtml %}
-    Search for the correct institution or change to a non-UK degree.
+  {% set institutionNotRecognisedHtml %}, which was not recognised as a UK institution. Search for the correct institution or change to a non-UK degree.
   {% endset %}
 
   {# Degree institution #}

--- a/app/views/_includes/summary-cards/degree/single-degree-details.html
+++ b/app/views/_includes/summary-cards/degree/single-degree-details.html
@@ -2,15 +2,15 @@
 
 {% set ukOrNonUkText %}
   {% if isInternational %}
-    Non-UK degree
+    No
   {% else %}
-    UK degree
+    Yes
   {% endif %}
 {% endset %}
 
 {% set ukOrNonUkRow = {
   key: {
-    text: "UK or non-UK degree"
+    text: "UK degree"
   },
   value: {
     text: ukOrNonUkText if (degree.isInternational != undefined) else 'Not provided'

--- a/app/views/_includes/summary-cards/degree/single-degree-details.html
+++ b/app/views/_includes/summary-cards/degree/single-degree-details.html
@@ -1,5 +1,31 @@
 {% set isInternational = degree.isInternational | falsify %}
 
+{% set ukOrNonUkText %}
+  {% if isInternational %}
+    Non-UK degree
+  {% else %}
+    UK degree
+  {% endif %}
+{% endset %}
+
+{% set ukOrNonUkRow = {
+  key: {
+    text: "UK or non-UK degree"
+  },
+  value: {
+    text: ukOrNonUkText if (degree.isInternational != undefined) else 'Not provided'
+  },
+  actions: {
+    items: [
+      {
+        href: recordPath + "/degree/" + loop.index0 + "/type" | addReferrer(referrer),
+        text: "Change",
+        visuallyHiddenText: "UK or non-UK type"
+      }
+    ]
+  } if canAmend
+} %}
+
 {% set subjectRow = {
   key: {
     text: "Subject"
@@ -129,6 +155,7 @@
 
 {% if isInternational %}
   {% set degreeDetailsRows = [
+    ukOrNonUkRow,
     countryRow,
     subjectRow,
     degreeTypeRow,
@@ -137,6 +164,7 @@
   ] %}
 {% else %}
   {% set degreeDetailsRows = [
+    ukOrNonUkRow,
     institutionRow,
     subjectRow,
     degreeTypeRow,


### PR DESCRIPTION
This exposes the answer to UK / Non-UK as an explicit row in the summary list so degrees can be changed type after they're created. Previously, to change the type the user would have had to have deleted the degree and re-added it.

This wasn't so much an issue for manual trainees, but we can see in the Apply data that some applicants may be incorrectly picking UK when they have a non-UK degree. It might not be viable to delete the degree in this case if the Provider doesn't have access to those details.

As well as having a row in the summary card for this, I've also added an explicit toggle from the UK degree details page, which is shown if the institution is invalid - as this is the main time I think someone might want to swap to Non-UK.

## UK degree row on summary cards
![Screenshot 2021-07-29 at 15 34 27](https://user-images.githubusercontent.com/2204224/127511773-9633cbfe-975d-46f1-b00e-daf12fd3e44a.png)

## Inset text shown on UK degrees if the institution is invalid.
![Screenshot 2021-08-09 at 11 50 24](https://user-images.githubusercontent.com/2204224/128695758-bb057414-df98-49ab-ad65-d2191b30b21a.png)

