### PR TITLE
Add page for directly setting prototype data

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -74,6 +74,47 @@ router.post('*', function(req, res, next){
   next()
 })
 
+// For directly setting prototype data in testing
+router.post('/direct-set-data', function(req, res, next){
+  const data = req.session.data
+
+  let theKey = data.directSet?.key
+  let theValue = data.directSet?.value
+  let theValueJson = data.directSet?.valueJson
+  let shouldMerge = data.directSet?.mergeJson == 'true'
+  let parsedJson
+
+  delete data.directSet
+
+  if (theValueJson){
+    try {
+      parsedJson = JSON.parse(theValueJson)
+    } catch (error) {
+      console.error("Couldn't parse Json:", error);
+    }
+  }
+
+  if (parsedJson){
+    theValue = parsedJson
+
+    // Whether to merge in to existing data
+    if (shouldMerge){
+      let currentValue = _.get(data, theKey)
+      if (currentValue){
+        theValue = {...currentValue, ...theValue}
+      }
+    }
+  }
+
+  console.log("Directly setting data")
+  console.log({theKey})
+  console.log({theValue})
+
+  _.set(data, theKey, theValue)
+
+  res.redirect("/direct-set-data")
+})
+
 const getIndex = (f) => {
   fs.readFile('./app/lib/search-index.json', 'utf8', (_, data) => {
     f(JSON.parse(data))

--- a/app/views/admin.html
+++ b/app/views/admin.html
@@ -17,9 +17,19 @@
         More settings: <a href="/admin-providers">providers</a>.
       {% endset %}
 
+
       {{ govukInsetText({
         html: insetHtml
       }) }}
+
+      {% set insetHtml %}
+        <a href="/direct-set-data">Directly set data</a>
+      {% endset %}
+
+      {{ govukInsetText({
+        html: insetHtml
+      }) }}
+
 
       {{ govukCheckboxes({
         items: [

--- a/app/views/direct-set-data.html
+++ b/app/views/direct-set-data.html
@@ -86,7 +86,7 @@
             hint: {
               html: textAreaHintHtml
             }
-          } | decorateAttributes(data, "data.directSetvalueJson")) }}
+          } | decorateAttributes(data, "data.directSet.valueJson")) }}
 
           {{ govukCheckboxes({
             items: [

--- a/app/views/direct-set-data.html
+++ b/app/views/direct-set-data.html
@@ -6,6 +6,7 @@
 
 {% block content %}
 {{super()}}
+{{data | log}}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <h1 class="govuk-heading-l">{{pageHeading}}</h1>
@@ -18,6 +19,7 @@
               text: "Key to set",
               classes: "govuk-label--s"
             },
+            classes: "govuk-!-margin-bottom-9",
             hint: {
               text: "For example, ‘record.personalDetails.givenName’"
             }
@@ -25,7 +27,7 @@
 
           {{ govukInput({
             label: {
-              text: "Value to set",
+              text: "Option A: Value to set",
               classes: "govuk-label--s"
             },
             hint: {
@@ -78,7 +80,7 @@
 
           {{ govukTextarea({
             label: {
-              text: "JSON value to set",
+              text: "Option B: JSON value to set",
               classes: "govuk-label--s",
               isPageHeading: true
             },
@@ -92,7 +94,7 @@
             items: [
               {
                 value: 'true',
-                text: "Merge Json on to existing data"
+                text: "Merge JSON on to existing data"
               }
             ]
           } | decorateAttributes(data, "data.directSet.mergeJson")) }}
@@ -101,7 +103,7 @@
 
 
           {{ govukButton({
-            text: "Continue"
+            text: "Update"
           }) }}
 
 

--- a/app/views/direct-set-data.html
+++ b/app/views/direct-set-data.html
@@ -1,0 +1,114 @@
+{% extends "_templates/_page.html" %}
+
+{% set navActive = "home" %}
+{% set backText = 'All records' %}
+{% set pageHeading = 'Direct set prototype data' %}
+
+{% block content %}
+{{super()}}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-l">{{pageHeading}}</h1>
+
+        <form {{formActionHtml}} method="post" novalidate spellcheck="false">
+
+          {# {{data | log}} #}
+          {{ govukInput({
+            label: {
+              text: "Key to set",
+              classes: "govuk-label--s"
+            },
+            hint: {
+              text: "For example, ‘record.personalDetails.givenName’"
+            }
+          } | decorateAttributes(data, "data.directSet.key")) }}
+
+          {{ govukInput({
+            label: {
+              text: "Value to set",
+              classes: "govuk-label--s"
+            },
+            hint: {
+              text: "For example, ‘Bart’"
+            }
+          } | decorateAttributes(data, "data.directSet.value")) }}
+
+          <p class="govuk-body">or</p>
+
+          {% set jsonExample %}
+          <p class="govuk-body">
+            To set personal details
+            
+          </p>
+
+          <h3 class="govuk-heading-s">Key to set</h3>
+          <pre>record.personalDetails</pre>
+
+          <h3 class="govuk-heading-s">JSON value to set</h3>
+<pre>
+{
+  "givenName": "Sarah Lilia",
+  "familyName": "Jones",
+  "middleNames": "",
+  "nationality": [
+    "Irish",
+    "American"
+  ],
+  "sex": "Female",
+  "dateOfBirth": [
+    "3",
+    "12",
+    "1987"
+  ]
+}
+</pre>
+          {% endset %}
+
+          {% set textAreaHintHtml %}
+            <p class="govuk-body govuk-hint">Needs to use quoted strings</p>
+
+            {{ govukDetails({
+              summaryText: "Show example",
+              html: jsonExample
+            }) }}
+
+            
+            
+          {% endset %}
+
+          {{ govukTextarea({
+            label: {
+              text: "JSON value to set",
+              classes: "govuk-label--s",
+              isPageHeading: true
+            },
+            rows: "20",
+            hint: {
+              html: textAreaHintHtml
+            }
+          } | decorateAttributes(data, "data.directSetvalueJson")) }}
+
+          {{ govukCheckboxes({
+            items: [
+              {
+                value: 'true',
+                text: "Merge Json on to existing data"
+              }
+            ]
+          } | decorateAttributes(data, "data.directSet.mergeJson")) }}
+
+          <input name="successFlash" type="hidden" value="Data set">
+
+
+          {{ govukButton({
+            text: "Continue"
+          }) }}
+
+
+        </form>
+
+    
+
+
+
+{% endblock %}

--- a/app/views/direct-set-data.html
+++ b/app/views/direct-set-data.html
@@ -5,39 +5,41 @@
 {% set pageHeading = 'Direct set prototype data' %}
 
 {% block content %}
-{{super()}}
-{{data | log}}
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds-from-desktop">
-        <h1 class="govuk-heading-l">{{pageHeading}}</h1>
+  {{super()}}
 
-        <form {{formActionHtml}} method="post" novalidate spellcheck="false">
+  {# For browsing in client console #}
+  {{data | log}}
 
-          {# {{data | log}} #}
-          {{ govukInput({
-            label: {
-              text: "Key to set",
-              classes: "govuk-label--s"
-            },
-            classes: "govuk-!-margin-bottom-9",
-            hint: {
-              text: "For example, ‘record.personalDetails.givenName’"
-            }
-          } | decorateAttributes(data, "data.directSet.key")) }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <h1 class="govuk-heading-l">{{pageHeading}}</h1>
 
-          {{ govukInput({
-            label: {
-              text: "Option A: Value to set",
-              classes: "govuk-label--s"
-            },
-            hint: {
-              text: "For example, ‘Bart’"
-            }
-          } | decorateAttributes(data, "data.directSet.value")) }}
+      <form {{formActionHtml}} method="post" novalidate spellcheck="false">
 
-          <p class="govuk-body">or</p>
+        {{ govukInput({
+          label: {
+            text: "Key to set",
+            classes: "govuk-label--s"
+          },
+          classes: "govuk-!-margin-bottom-9",
+          hint: {
+            text: "For example, ‘record.personalDetails.givenName’"
+          }
+        } | decorateAttributes(data, "data.directSet.key")) }}
 
-          {% set jsonExample %}
+        {{ govukInput({
+          label: {
+            text: "Option A: Value to set",
+            classes: "govuk-label--s"
+          },
+          hint: {
+            text: "For example, ‘Bart’"
+          }
+        } | decorateAttributes(data, "data.directSet.value")) }}
+
+        <p class="govuk-body">or</p>
+
+        {% set jsonExample %}
           <p class="govuk-body">
             To set personal details
             
@@ -64,53 +66,47 @@
   ]
 }
 </pre>
-          {% endset %}
+        {% endset %}
 
-          {% set textAreaHintHtml %}
-            <p class="govuk-body govuk-hint">Needs to use quoted strings</p>
+        {% set textAreaHintHtml %}
+          <p class="govuk-body govuk-hint">Needs to use quoted strings</p>
 
-            {{ govukDetails({
-              summaryText: "Show example",
-              html: jsonExample
-            }) }}
-
-            
-            
-          {% endset %}
-
-          {{ govukTextarea({
-            label: {
-              text: "Option B: JSON value to set",
-              classes: "govuk-label--s",
-              isPageHeading: true
-            },
-            rows: "20",
-            hint: {
-              html: textAreaHintHtml
-            }
-          } | decorateAttributes(data, "data.directSet.valueJson")) }}
-
-          {{ govukCheckboxes({
-            items: [
-              {
-                value: 'true',
-                text: "Merge JSON on to existing data"
-              }
-            ]
-          } | decorateAttributes(data, "data.directSet.mergeJson")) }}
-
-          <input name="successFlash" type="hidden" value="Data set">
-
-
-          {{ govukButton({
-            text: "Update"
+          {{ govukDetails({
+            summaryText: "Show example",
+            html: jsonExample
           }) }}
 
+        {% endset %}
 
-        </form>
+        {{ govukTextarea({
+          label: {
+            text: "Option B: JSON value to set",
+            classes: "govuk-label--s",
+            isPageHeading: true
+          },
+          rows: "20",
+          hint: {
+            html: textAreaHintHtml
+          }
+        } | decorateAttributes(data, "data.directSet.valueJson")) }}
 
-    
+        {{ govukCheckboxes({
+          items: [
+            {
+              value: 'true',
+              text: "Merge JSON on to existing data"
+            }
+          ]
+        } | decorateAttributes(data, "data.directSet.mergeJson")) }}
 
+        <input name="successFlash" type="hidden" value="Data set">
 
+        {{ govukButton({
+          text: "Update"
+        }) }}
+
+      </form>
+    </div>
+  </div>
 
 {% endblock %}


### PR DESCRIPTION
Adds an admin page for directly setting session data on the prototype.

This is useful for where you want to change a value in the *current* session for testing.

Supports passing a string or else Json.

![Screenshot 2021-08-04 at 13 30 58](https://user-images.githubusercontent.com/2204224/128181070-4fe1beb0-27d1-4f8d-bc11-87ea22eda7e7.png)
