### PR TITLE
Removes 'record' and refers to the trainee

### DIFF
--- a/app/views/_components/filter-page/template.njk
+++ b/app/views/_components/filter-page/template.njk
@@ -61,7 +61,7 @@
               {# button code stollen from https://components.publishing.service.gov.uk/component-guide/search #}
               <div class="govuk-form-group">
                 <label class="govuk-label govuk-label--s" for="search">
-                  Search records
+                  Search for a trainee
                 </label>
                 <div class="gem-c-search__item-wrapper gem-c-search--on-white">
                   <input class="govuk-input" id="search" name="searchQuery" type="text" value="{{query.searchQuery}}">

--- a/app/views/admin-providers.html
+++ b/app/views/admin-providers.html
@@ -2,7 +2,7 @@
 {% extends "_templates/_page.html" %}
 
 {% set backLink = '/records' %}
-{% set backText = 'All records' %}
+{% set backText = 'All registered trainees' %}
 {% set pageHeading = 'Provider settings' %}
 
 {% block content %}

--- a/app/views/admin.html
+++ b/app/views/admin.html
@@ -2,7 +2,7 @@
 {% extends "_templates/_page.html" %}
 
 {% set backLink = '/records' %}
-{% set backText = 'All records' %}
+{% set backText = 'All registered trainees' %}
 {% set pageHeading = 'Prototype settings' %}
 {# {% set pageAction = value %} #}
 

--- a/app/views/direct-set-data.html
+++ b/app/views/direct-set-data.html
@@ -1,7 +1,7 @@
 {% extends "_templates/_page.html" %}
 
 {% set navActive = "home" %}
-{% set backText = 'All records' %}
+{% set backText = 'All registered trainees' %}
 {% set pageHeading = 'Direct set prototype data' %}
 
 {% block content %}

--- a/app/views/drafts.html
+++ b/app/views/drafts.html
@@ -1,7 +1,7 @@
 {% extends "_templates/_page.html" %}
 
 {% set pageHeading %}
-  Draft records ({{filteredRecords | length}} {{ "record" | pluralise(filteredRecords | length) }})
+  Drafts ({{filteredRecords | length}} {{ "record" | pluralise(filteredRecords | length) }})
 {% endset %}
 
 {% set backText = "Home" %}
@@ -254,10 +254,10 @@
   <div class="govuk-grid-column-full">
 
     {# This heading set separately than {{pageHeading}} as it is html #}
-    <h1 class="govuk-heading-xl">Draft records ({{filteredRecords | length}}<span class="govuk-visually-hidden"> {{ "record" | pluralise(filteredRecords | length)}}</span>)</h1>
+    <h1 class="govuk-heading-xl">Draft trainees ({{filteredRecords | length}}<span class="govuk-visually-hidden"> {{ "record" | pluralise(filteredRecords | length)}}</span>)</h1>
 
     {{ govukButton({
-      text: "Add a trainee",
+      text: "Create a trainee record",
       href: "./new-record/new",
       isStartButton: true
     }) }}

--- a/app/views/new-record/apply-trainee-application.html
+++ b/app/views/new-record/apply-trainee-application.html
@@ -129,6 +129,6 @@ of the page. #}
   text: "Continue"
 }) }}
 
-<p class="govuk-body"><a href="./save-as-draft" class="govuk-link">Return to this draft record later</a></p>
+<p class="govuk-body"><a href="./save-as-draft" class="govuk-link">Return to this draft later</a></p>
 
 {% endblock %}

--- a/app/views/new-record/check-record-apply-grouped-sections.html
+++ b/app/views/new-record/check-record-apply-grouped-sections.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_new-record.html" %}
 
-{% set pageHeading = "Check draft record" %}
+{% set pageHeading = "Check trainee record" %}
 {% set formAction = "./save" | addReferrer(referrer) %}
 {% set hideReturnLink = true %}
 {% set showIncomplete = true %}
@@ -21,7 +21,7 @@
   {% if not recordIsComplete %}
     {% set insetTextHtml %}
       <p class="govuk-body">
-        This trainee record is not complete and cannot be submitted for TRN. If you do not have all the required information now, you can <a href="./save-as-draft" class="govuk-link">return to this draft record later</a>.
+        This trainee record is not complete and cannot be submitted for TRN. If you do not have all the required information now, you can <a href="./save-as-draft" class="govuk-link">return to this draft later</a>.
       </p>
     {% endset %}
       {{ govukInsetText({
@@ -111,7 +111,7 @@
 {% include "_includes/summary-cards/funding.html" %}
 
 {{ govukButton({
-  text: "Submit record and request TRN"
+  text: "Submit trainee record and request TRN"
 }) }}
 
 <p class="govuk-body"><a href="./save-as-draft" class="govuk-link">Return to this draft later</a></p>

--- a/app/views/new-record/check-record-apply-grouped-sections.html
+++ b/app/views/new-record/check-record-apply-grouped-sections.html
@@ -20,7 +20,9 @@
   {# Show a warning if the record isn’t ready to be submitted #}
   {% if not recordIsComplete %}
     {% set insetTextHtml %}
-      <p class="govuk-body">This record is not complete and cannot be submitted for TRN. If you do not have all the required information now, you can <a href="./save-as-draft" class="govuk-link">return to this draft record later</a>.</p>
+      <p class="govuk-body">
+        This trainee record is not complete and cannot be submitted for TRN. If you do not have all the required information now, you can <a href="./save-as-draft" class="govuk-link">return to this draft record later</a>.
+      </p>
     {% endset %}
       {{ govukInsetText({
         html: insetTextHtml
@@ -112,6 +114,6 @@
   text: "Submit record and request TRN"
 }) }}
 
-<p class="govuk-body"><a href="./save-as-draft" class="govuk-link">Return to this draft record later</a></p>
+<p class="govuk-body"><a href="./save-as-draft" class="govuk-link">Return to this draft later</a></p>
 
 {% endblock %}

--- a/app/views/new-record/check-record.html
+++ b/app/views/new-record/check-record.html
@@ -21,7 +21,7 @@
   {% if not recordIsComplete %}
     {% set insetTextHtml %}
       <p class="govuk-body">
-        This trainee record is not complete and cannot be submitted for TRN. If you do not have all the required information now, you can <a href="./save-as-draft" class="govuk-link">return to this draft record later</a>.
+        This trainee record is not complete and cannot be submitted for TRN. If you do not have all the required information now, you can <a href="./save-as-draft" class="govuk-link">return to this draft later</a>.
       </p>
     {% endset %}
       {{ govukInsetText({

--- a/app/views/new-record/check-record.html
+++ b/app/views/new-record/check-record.html
@@ -20,7 +20,9 @@
   {# Show a warning if the record isn’t ready to be submitted #}
   {% if not recordIsComplete %}
     {% set insetTextHtml %}
-      <p class="govuk-body">This record is not complete and cannot be submitted for TRN. If you do not have all the required information now, you can <a href="./save-as-draft" class="govuk-link">return to this draft record later</a>.</p>
+      <p class="govuk-body">
+        This trainee record is not complete and cannot be submitted for TRN. If you do not have all the required information now, you can <a href="./save-as-draft" class="govuk-link">return to this draft record later</a>.
+      </p>
     {% endset %}
       {{ govukInsetText({
         html: insetTextHtml
@@ -48,7 +50,7 @@
       {% endif %}
     {% endset %}
 
-    <span class="govuk-caption-l">{{'Draft record' + draftRecordName}}</span>
+    <span class="govuk-caption-l">{{'Draft' + draftRecordName}}</span>
     <h1 class="govuk-heading-l govuk-!-margin-bottom-8">{{pageHeading}}</h1>
 
     {# Show a warning if the record isn’t ready to be submitted #}
@@ -97,6 +99,6 @@
   text: "Register trainee and request TRN"
 }) }}
 
-<p class="govuk-body"><a href="./save-as-draft" class="govuk-link">Return to this draft record later</a></p>
+<p class="govuk-body"><a href="./save-as-draft" class="govuk-link">Return to this draft later</a></p>
 
 {% endblock %}

--- a/app/views/new-record/overview-apply-grouped-sections.html
+++ b/app/views/new-record/overview-apply-grouped-sections.html
@@ -23,7 +23,7 @@
 {% endset %}
 
 {# <span class="govuk-caption-l">{{'Apply draft' + draftRecordName}}</span> #}
-<span class="govuk-caption-l">Draft record</span>
+<span class="govuk-caption-l">Draft</span>
 <h1 class="govuk-heading-l govuk-!-margin-bottom-8">{{pageHeading}}</h1>
 
 {% set insetTextHtml %}
@@ -144,7 +144,7 @@
   href: "check-record"
 }) }}
 
-<p class="govuk-body"><a href="./save-as-draft" class="govuk-link govuk-link--no-visited-state">Return to this draft record later</a></p>
+<p class="govuk-body"><a href="./save-as-draft" class="govuk-link govuk-link--no-visited-state">Return to this draft later</a></p>
 
 <p class="govuk-body govuk-!-margin-top-8"><a href="./delete-draft/confirm" class="govuk-link app-destructive-link">Delete this draft</a></p>
 

--- a/app/views/new-record/overview.html
+++ b/app/views/new-record/overview.html
@@ -22,7 +22,7 @@
   {% endif %}
 {% endset %}
 
-<span class="govuk-caption-l">Draft record</span>
+<span class="govuk-caption-l">Draft</span>
 <h1 class="govuk-heading-l govuk-!-margin-bottom-8">{{pageHeading}}</h1>
 
 {# Inset text about the provider and route #}
@@ -176,7 +176,7 @@
   href: "check-record"
 }) }}
 
-<p class="govuk-body"><a href="./save-as-draft" class="govuk-link govuk-link--no-visited-state">Return to this draft record later</a></p>
+<p class="govuk-body"><a href="./save-as-draft" class="govuk-link govuk-link--no-visited-state">Return to this draft later</a></p>
 
 <p class="govuk-body govuk-!-margin-top-8"><a href="./delete-draft/confirm" class="govuk-link app-destructive-link">Delete this draft</a></p>
 

--- a/app/views/new-record/submitted.html
+++ b/app/views/new-record/submitted.html
@@ -47,7 +47,7 @@
 
 <ul class="govuk-list govuk-list--bullet">
   <li><a class="govuk-link" href="/record/{{data.submittedRecordId}}">{{thisRecordName}}</a></li>
-  <li><a href="/new-record/new" class="govuk-link">add a new trainee</a></li>
+  <li><a href="/new-record/new" class="govuk-link">create a new trainee record</a></li>
   <li><a href="/drafts" class="govuk-link">view your drafts</a></li>
   <li><a href="/records" class="govuk-link">view all your trainees</a></li>
 </ul>

--- a/app/views/record.html
+++ b/app/views/record.html
@@ -25,7 +25,7 @@
         {% if record.status | getCanRecommendForQts %}
           {% if record | hasOutstandingActions %}
             {{ govukInsetText({
-              text: "This record requires additional details",
+              text: "This trainee record requires additional details",
               classes: "govuk-!-margin-0"
             }) }}
           {% else %}
@@ -37,12 +37,12 @@
           {% endif %}
         {% elseif record.status == "Pending TRN" %}
           {{ govukInsetText({
-            text: "This record is pending a TRN",
+            text: "This trainee is pending a TRN",
             classes: "govuk-!-margin-0"
           }) }}
         {% elseif record.status == "Deferred" %}
           {{ govukInsetText({
-            text: "This record is deferred",
+            text: "This trainee is deferred",
             classes: "govuk-!-margin-0"
           }) }}
         {% endif %}

--- a/app/views/record.html
+++ b/app/views/record.html
@@ -2,7 +2,7 @@
 {% extends "_templates/_record.html" %}
 
 {% set backLink = '/records' %}
-{% set backText = 'All records' %}
+{% set backText = 'All registered trainees' %}
 {% set pageHeading = record.personalDetails.shortName %}
 {% set activeTab = 'trainee-details' %}
 

--- a/app/views/record/details-and-education.html
+++ b/app/views/record/details-and-education.html
@@ -1,7 +1,7 @@
 {% extends "_templates/_record.html" %}
 
 {% set backLink = '/records' %}
-{% set backText = 'All records' %}
+{% set backText = 'All registered trainees' %}
 {% set pageHeading = data.record.personalDetails.shortName %}
 {% set activeTab = 'details-education' %}
 

--- a/app/views/record/timeline.html
+++ b/app/views/record/timeline.html
@@ -1,7 +1,7 @@
 {% extends "_templates/_record.html" %}
 
 {% set backLink = '/records' %}
-{% set backText = 'All records' %}
+{% set backText = 'All registered trainees' %}
 {% set pageHeading = data.record.personalDetails.shortName %}
 {% set activeTab = 'timeline' %}
 

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_page.html" %}
 
-{% set pageBaseName = "Registered trainee records" if data.settings.draftsInPrimaryNav | falsify else "Registered trainees" %}
+{% set pageBaseName = "Registered trainees" if data.settings.draftsInPrimaryNav | falsify else "Registered trainees" %}
 
 {% set pageHeading %}
   {{pageBaseName}} ({{filteredRecords | length}} {{ "record" | pluralise(filteredRecords | length) }})
@@ -188,7 +188,7 @@
     <h1 class="govuk-heading-xl">{{pageBaseName}} ({{filteredRecords | length}}<span class="govuk-visually-hidden"> {{ "record" | pluralise(filteredRecords | length)}}</span>)</h1>
 
     {{ govukButton({
-      text: "Add a trainee",
+      text: "Create a trainee record",
       href: "./new-record/new",
       isStartButton: true
     }) }}


### PR DESCRIPTION
We can loose most of the uses of 'record'.

The only places I've kept it is to refer to the record as a separate entity from the trainee themselves. For example if the record is missing information (the trainee isn't missing the information).

