### PR TITLE
Prevent HPITT from appearing as an option for new drafts

### DIFF
--- a/app/data/training-route-data.js
+++ b/app/data/training-route-data.js
@@ -418,6 +418,7 @@ let baseRouteData = {
     courseDatesAreAmgiguous: true
   },
   "High potential initial teacher training (HPITT)": {
+    disableForNewDrafts: true, // we want to show trainees on this route, but not allow new ones
     defaultEnabled: false,
     sections: [
       'trainingDetails',

--- a/app/views/_includes/forms/select-route.html
+++ b/app/views/_includes/forms/select-route.html
@@ -1,7 +1,9 @@
 
 {% set enabledTrainingRoutes = [] %}
 {% for route in data.settings.enabledTrainingRoutes %}
-  {% set enabledTrainingRoutes = enabledTrainingRoutes | push({text: route}) %}
+  {% if not data.trainingRoutes[route].disableForNewDrafts %}
+    {% set enabledTrainingRoutes = enabledTrainingRoutes | push({text: route}) %}
+  {% endif %}
 {% endfor %}
 
 {% set enabledTrainingRoutes = enabledTrainingRoutes | push({divider: "or"}) %}


### PR DESCRIPTION
HPITT will only come in via csv, so we want to prevent empty drafts being created with this route.