### PR TITLE
Content update start page

### DIFF
--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -61,7 +61,7 @@
 
     <h2 class="govuk-heading-m">Latest updates</h2>
 
-    <p class="govuk-body">24 September 2021: Apply integration is live. Trainee records that have come through Apply are now imported directly to Regsiter when they have met all conditions and are recruited.</p>
+    <p class="govuk-body">24 September 2021: Apply integration is live. Trainee records that have come through Apply are now imported directly to Register when they have met all conditions and are recruited.</p>
 
     <p class="govuk-body">21 September 2021: You can now record scholarships in the funding section of trainee records.</p>
 

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -32,7 +32,7 @@
         <div class="govuk-grid-column-two-thirds">
 
           <h1 class="start-page-banner__text start-page-banner__heading govuk-heading-xl">{{pageHeading}}</h1>
-          <p class="start-page-banner__text start-page-banner__description govuk-body govuk-!-font-size-27">Register trainees with the Department for Education and record the outcome of their training.</p>
+          <p class="start-page-banner__text start-page-banner__description govuk-body">Register trainees with the Department for Education. Request teacher reference numbers (TRN) for your trainees, update their progress and recommend them for qualified teacher status (QTS) or early years teacher status (EYTS).</p>
           <div class="start-page-banner__actions">
             {{ govukButton({
               text: "Sign in",
@@ -59,13 +59,13 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <p class="govuk-body">Use this service to:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>register trainee data with the Department for Education, and keep it updated</li>
-      <li>request a teacher reference number (TRN) for your trainees</li>
-      <li>share information about a trainee’s progress, such as whether they withdraw or defer</li>
-      <li>recommend your trainees for qualified teacher status (QTS) or early years teacher status (EYTS)</li>
-    </ul>
+    <h2 class="govuk-heading-m">Latest updates</h2>
+
+    <p class="govuk-body">24 September 2021: Apply integration is live. Trainee records that have come through Apply are now imported directly to Regsiter when they have met all conditions and are recruited.</p>
+
+    <p class="govuk-body">21 September 2021: You can now record scholarships in the funding section of trainee records.</p>
+
+
 
   </div>
 </div>


### PR DESCRIPTION
Experimenting with changelog/what's new type content on the start page - borrowed from the design system after Ralph's suggestion.

- Re-written the summary of the service and moved it into the banner
- Removed the service summary below the banner and included 'Latest updates' content.

**Questions**

How do we handle quite a few updates at once?
How do we handle (or do we need to) historical updates?

Spot the typo!!!!!