### PR TITLE
Add new admin feature flag, admin styles, filter for all providers

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -29,6 +29,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "utils";
 
 // Components that aren't in Frontend
+@import "components/admin-feature";
 @import "components/application-card";
 @import "components/all-records-header";
 @import "components/all-records-search";

--- a/app/assets/sass/components/_admin-feature.scss
+++ b/app/assets/sass/components/_admin-feature.scss
@@ -1,0 +1,44 @@
+// Mostly copied from https://github.com/DFE-Digital/publish-teacher-training/blob/master/app/webpacker/stylesheets/_status-box.scss
+.app-status-box {
+  @include govuk-responsive-margin(6, "bottom");
+  background-color: govuk-colour("light-grey");
+  padding: govuk-spacing(4);
+
+  > *:last-child {
+    margin-bottom: 0;
+  }
+
+  .autocomplete__input,
+  .govuk-input,
+  .govuk-select {
+    background: govuk-colour("white");
+  }
+
+  // Add a 2px solid border around tags which match colour of the text
+  .govuk-tag--grey {
+    border: 2px solid govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);
+  }
+
+  .govuk-tag--yellow {
+    border: 2px solid govuk-shade(govuk-colour("yellow"), 65);
+  }
+
+  .govuk-tag--red {
+    border: 2px solid govuk-shade(govuk-colour("red"), 30);
+  }
+
+  .govuk-tag--green {
+    border: 2px solid govuk-shade(govuk-colour("green"), 20);
+  }
+}
+
+.app-status-box--admin {
+  border-left: $govuk-border-width solid govuk-colour("purple");
+}
+
+// For use in filter box to outdent to the side margins
+// .moj-filter__options has 20px padding - so this expands to that minus the 1px border
+.app-status-box--filter-outdent {
+  margin-left: -19px;
+  margin-right: -19px;
+}

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -64,6 +64,8 @@ settings.userProviders = [
   // "University of Buckingham"
 ]
 
+settings.viewAsAdmin = 'false'
+
 // The ‘active’ provider for the current user if using hat model
 // Must be one of the ones in settings.userProviders
 settings.userActiveProvider = "Coventry University"

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -1065,8 +1065,11 @@ exports.filterRecords = (records, data, filters = {}) => {
   let filteredRecords = records
   let applyEnabled = data.settings.enableApplyIntegration
 
-  // Only allow records for the signed-in providers
-  filteredRecords = exports.filterBySignedIn(filteredRecords, data)
+  if (data?.settings?.viewAsAdmin != "true"){
+    // Only allow records for the signed-in providers
+    filteredRecords = exports.filterBySignedIn(filteredRecords, data)
+  }
+
 
   // Only show records for training routes that are enabled
   let enabledTrainingRoutes = data.settings.enabledTrainingRoutes
@@ -1112,6 +1115,11 @@ exports.filterRecords = (records, data, filters = {}) => {
   // List of providers if signed in as multiple
   if (filters.providers){
     filteredRecords = filteredRecords.filter(record => filters.providers.includes(record.provider))
+  }
+
+  // Admin only filter for picking from all providers
+  if (filters.allProviders && filters.allProviders != "All providers"){
+    filteredRecords = filteredRecords.filter(record => filters.allProviders.includes(record.provider))
   }
 
   if (filters.trainingRoutes){

--- a/app/routes.js
+++ b/app/routes.js
@@ -29,6 +29,7 @@ router.all('*', function(req, res, next){
   data.isHatModel = (data.settings.providerModel == 'hat-model') ? true : false
   data.isBlendedModel = (data.settings.providerModel == 'blended-model') ? true : false
   data.signedInProviders = (data.isBlendedModel) ? data.settings.userProviders : [data.settings.userActiveProvider]
+  data.isAdmin = (data.settings.viewAsAdmin == "true") ? true : false
 
   // Filter records by provider, enabled routes, apply enabled
   data.filteredRecords = utils.filterRecords(data.records, data)

--- a/app/routes/records-list-routes.js
+++ b/app/routes/records-list-routes.js
@@ -39,6 +39,7 @@ const getFilters = req => {
   'filterStudyMode',
   'filterCycle',
   'filterUserProviders',
+  'filterAllProviders',
   'filterTrainingRoutes']
   filtersToClean.forEach(filter => query[filter] = cleanInputData(query[filter]))
 
@@ -52,6 +53,7 @@ const getFilters = req => {
     phase: query.filterPhase,
     studyMode: query.filterStudyMode,
     providers: query.filterUserProviders,
+    allProviders: query.filterAllProviders,
     trainingRoutes: query.filterTrainingRoutes,
     subject: query.filterSubject
   }
@@ -76,6 +78,7 @@ const getHasFilters = (filters, searchQuery) => {
 
   || !!(filters.trainingRoutes)
   || !!(filters.providers)
+  || !!(filters.allProviders && filters.allProviders != 'All providers')
 }
 
 // Make object to hold details of selected filters with appropriate links to clear each one
@@ -126,6 +129,21 @@ const getSelectedFilters = req => {
   //     })
   //   })
   // }
+
+  if (filters.allProviders && filters.allProviders != 'All providers') {
+    let newQuery = Object.assign({}, query)
+    delete newQuery.filterAllProviders
+    selectedFilters.categories.push({
+      heading: { text: "Provider" },
+      items: [{
+        text: filters.allProviders,
+        href: url.format({
+          pathname,
+          query: newQuery,
+        })
+      }]
+    })
+  }
 
   if (filters.completeStatus) {
     selectedFilters.categories.push({
@@ -217,6 +235,8 @@ const getSelectedFilters = req => {
       })
     })
   }
+
+
 
   if (filters.trainingRoutes) {
     selectedFilters.categories.push({
@@ -312,6 +332,9 @@ module.exports = router => {
 
     // Sort records by sortOrder, defaulting to updatedDate
     filteredRecords = utils.sortRecordsBy(filteredRecords, (req?.query?.sortOrder || 'updatedDate'))
+
+    // Truncate records in case there's lots - and as we don't have working pagination
+    filteredRecords = filteredRecords.slice(0, 204)
 
     res.render('records', {
       filteredRecords,

--- a/app/views/_components/admin-feature/macro.njk
+++ b/app/views/_components/admin-feature/macro.njk
@@ -1,0 +1,3 @@
+{% macro appAdminFeature(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/app/views/_components/admin-feature/template.njk
+++ b/app/views/_components/admin-feature/template.njk
@@ -1,0 +1,8 @@
+<div class="app-status-box app-status-box--admin {{params.classes}}">
+  <p class="govuk-body">
+    <strong class="govuk-tag govuk-tag--purple">Admin feature</strong>
+  </p>
+  <div class="govuk-form-group">
+    {{ params.html | safe}}
+  </div>
+</div>

--- a/app/views/_includes/filter-panel/all-providers.njk
+++ b/app/views/_includes/filter-panel/all-providers.njk
@@ -1,4 +1,4 @@
-{% if data.settings.viewAsAdmin | falsify %}
+{% if data.isAdmin %}
 
   {% set providerItems = [] %}
 

--- a/app/views/_includes/filter-panel/all-providers.njk
+++ b/app/views/_includes/filter-panel/all-providers.njk
@@ -1,0 +1,40 @@
+{% if data.settings.viewAsAdmin | falsify %}
+
+  {% set providerItems = [] %}
+
+  {# Default state - first value is 'all' #}
+  {% set providerItems = providerItems | push({
+    value: "All providers",
+    text: "All providers",
+    selected: true if (not query.filterAllProviders or query.filterAllProviders ==  "All providers")
+  }) %}
+
+  {% set allProviders = data.allProviders %}
+
+  {% for provider in allProviders %}
+    {% set providerItems = providerItems | push({
+      value: provider,
+      text: provider,
+      selected: true if (provider == query.filterAllProviders)
+    }) %}
+  {% endfor %}
+
+  {% set selectHtml %}
+    {{ govukSelect({
+      id: "all-provider-select",
+      name: "filterAllProviders",
+      classes: "js-auto-submit",
+      label: {
+        text: "Provider",
+        classes: "govuk-label--s"
+      },
+      items: providerItems
+    }) }}
+  {% endset %}
+
+  {{ appAdminFeature({
+    classes: "app-status-box--filter-outdent",
+    html: selectHtml
+  }) }}
+
+{% endif %}

--- a/app/views/_includes/summary-cards/trainee-progress.html
+++ b/app/views/_includes/summary-cards/trainee-progress.html
@@ -245,7 +245,7 @@
 } %}
 
 {% set traineeProgressRows = [
-  providerRow if data.settings.userProviders | length > 1,
+  providerRow if data.isAdmin or data.settings.userProviders | length > 1,
   traineeIdRow,
   regionRow if record | requiresField("region"),
   startYearRow,

--- a/app/views/_includes/trainee-record-card.njk
+++ b/app/views/_includes/trainee-record-card.njk
@@ -44,7 +44,7 @@
       {% if record.trn %}
         <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-0">TRN: {{record.trn}}</p>
       {% endif %}
-      {% if data.signedInProviders | length > 1 %}
+      {% if data.isAdmin or data.signedInProviders | length > 1 %}
         <p class="govuk-caption-m govuk-!-font-size-16 app-application-card__provider govuk-!-margin-bottom-0 govuk-!-margin-top-2">
           <span class="govuk-visually-hidden">Provider: </span>{{record.provider}}</p>
       {% endif %}

--- a/app/views/admin.html
+++ b/app/views/admin.html
@@ -30,6 +30,14 @@
         html: insetHtml
       }) }}
 
+      {{ govukCheckboxes({
+        items: [
+          {
+            value: 'true',
+            text: "View as admin"
+          }
+        ]
+      } | decorateAttributes(data, "data.settings.viewAsAdmin")) }}
 
       {{ govukCheckboxes({
         items: [

--- a/app/views/drafts.html
+++ b/app/views/drafts.html
@@ -51,6 +51,7 @@
 
   {# Cycles probably not relevant for drafts? #}
   {# {% include "_includes/filter-panel/cycles.njk" %} #}
+  {% include "_includes/filter-panel/all-providers.njk" %}
 
   {% include "_includes/filter-panel/completeStatus.njk" %}
 

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -32,6 +32,7 @@
 
 {# custom components #}
 {# Most of these copied from the Apply for teacher training prototype #}
+{% from "_components/admin-feature/macro.njk"   import appAdminFeature %}
 {% from "_components/autocomplete/macro.njk"   import appAutocomplete %}
 {% from "_components/banner/macro.njk"         import appBanner %}
 {% from "_components/summary-card/macro.njk"   import appSummaryCard %}

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -52,9 +52,14 @@
 {% set filterOptionsHtml %}
 
   {% set showDefaultVisibleYears = true %}
+
+  {% include "_includes/filter-panel/all-providers.njk" %}
+  
   {% include "_includes/filter-panel/cycles.njk" %}
 
   {% include "_includes/filter-panel/phase.njk" %}
+
+
 
   {% include "_includes/filter-panel/signed-in-providers.njk" %}
 


### PR DESCRIPTION
This adds:

* An admin flag (set in prototype settings) so we can have admin-only features.
* Styles for admin features (stolen from Publish)
* Admin features:
** Records list shows records from all providers rather than 'current' one - though truncated for performance
** Shows provider name on trainee cards
** Adds a new filter to pick from all providers

![Screenshot 2021-09-30 at 11 48 18](https://user-images.githubusercontent.com/2204224/135441805-298df64d-73e7-40f5-8b7d-08d0c77bc240.png)
![Screenshot 2021-09-30 at 11 48 30](https://user-images.githubusercontent.com/2204224/135441810-11cccb34-5b08-441b-8069-db01c24afee1.png)

