### PR TITLE
Refer to ITT dates rather than course dates

### DIFF
--- a/app/data/training-route-data.js
+++ b/app/data/training-route-data.js
@@ -128,8 +128,7 @@ let baseRouteData = {
           ],
         value: "9000"
       }
-    ],
-    courseDatesAreAmbiguous: true
+    ]
   },
   "Provider-led (postgrad)": {
     defaultEnabled: true,
@@ -300,8 +299,7 @@ let baseRouteData = {
       "Now teach",
       "Transition to teach"
     ],
-    financialSupportAvailable: false,
-    courseDatesAreAmbiguous: true
+    financialSupportAvailable: false
   },
   "Opt-in (undergrad)": {
     defaultEnabled: true,
@@ -334,8 +332,7 @@ let baseRouteData = {
           ],
         value: "9000"
       }
-    ],
-    courseDatesAreAmbiguous: true
+    ]
   },
   "Early years (salaried)": {
     defaultEnabled: true,
@@ -452,8 +449,7 @@ let baseRouteData = {
       "EYTS"
     ],
     qualificationsSummary: "EYTS full time",
-    financialSupportAvailable: false,
-    courseDatesAreAmbiguous: true
+    financialSupportAvailable: false
   },
   "High potential initial teacher training (HPITT)": {
     disableForNewDrafts: true, // we want to show trainees on this route, but not allow new ones

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -829,11 +829,6 @@ exports.isApprenticeship = record => {
   return record?.route == "Teaching apprenticeship (postgrad)"
 }
 
-// For some courses, the the wider course might be longer than the itt bit we’re interested in
-exports.courseDatesAreAmbiguous = record => {
-  return trainingRoutes?.[record?.route]?.courseDatesAreAmbiguous || false
-}
-
 // Phases
 
 // Unlike the other phases, this is probably reliable - as it checcks the route rather than the age

--- a/app/views/_includes/cannot-defer-or-withdraw-content.html
+++ b/app/views/_includes/cannot-defer-or-withdraw-content.html
@@ -7,7 +7,7 @@
 </h1>
 
 <p class="govuk-body">
-  You can only {{ recordTask }} after the trainee has started their {{ "ITT" if record | courseDatesAreAmbiguous else "course" }}.
+  You can only {{ recordTask }} after the trainee has started their ITT.
 </p>
 <p class="govuk-body">
   You can <a href="{{ deletePath }}">delete this trainee record</a>.

--- a/app/views/_includes/forms/course-details/course-dates.html
+++ b/app/views/_includes/forms/course-details/course-dates.html
@@ -28,23 +28,12 @@
 
 {% set startDateHint = "For example, " + "" | today | toDateArray | spaceSeparate %}
 
-{% if record | courseDatesAreAmbiguous %}
-  {% set startDateHint %}
-    <p class="govuk-body govuk-hint">
-      The start date of the Initial Teacher Training part of their course.
-    </p>
-    <p class="govuk-body govuk-hint">
-      {{startDateHint | safe }}
-    </p>
-  {% endset %}
-{% endif %}
-
 {{ govukDateInput({
   id: "start-start-date",
   namePrefix: "record[courseDetails][startDate" + studyModeConcatinated + "]",
   fieldset: {
     legend: {
-      text: "Course start date for all " + (studyMode | lower) + " trainees",
+      text: "ITT start date for all " + (studyMode | lower) + " trainees",
       isPageHeading: false,
       classes: "govuk-fieldset__legend--m"
     }
@@ -74,23 +63,12 @@
 
 {% set endDateHint = "For example, " + "" | today | moment('add', 1, 'years') | toDateArray | spaceSeparate %}
 
-{% if record | courseDatesAreAmbiguous %}
-  {% set endDateHint %}
-    <p class="govuk-body govuk-hint">
-      The start date of the Initial Teacher Training part of their course.
-    </p>
-    <p class="govuk-body govuk-hint">
-      {{endDateHint | safe }}
-    </p>
-  {% endset %}
-{% endif %}
-
 {{ govukDateInput({
   id: "start-start-date",
   namePrefix: "record[courseDetails][endDate" + studyModeConcatinated + "]",
   fieldset: {
     legend: {
-      text: "Course end date for all " + (studyMode | lower) + " trainees",
+      text: "ITT end date for all " + (studyMode | lower) + " trainees",
       isPageHeading: false,
       classes: "govuk-fieldset__legend--m"
     }

--- a/app/views/_includes/forms/course-details/early-years.html
+++ b/app/views/_includes/forms/course-details/early-years.html
@@ -34,22 +34,7 @@
 
 {% set startDateHint = "For example, " + "" | today | toDateArray | spaceSeparate %}
 
-{% if record | courseDatesAreAmbiguous %}
-  {% set startDateLabel = "ITT start date" %}
-{% else %}
-  {% set startDateLabel = "Course start date" %}
-{% endif %}
-
-{% if record | courseDatesAreAmbiguous %}
-  {% set startDateHint %}
-    <p class="govuk-body govuk-hint">
-      The start date of the Initial Teacher Training part of their course.
-    </p>
-    <p class="govuk-body govuk-hint">
-      {{startDateHint | safe }}
-    </p>
-  {% endset %}
-{% endif %}
+{% set startDateLabel = "ITT start date" %}
 
 {{ govukDateInput({
   id: "programme-start-date",
@@ -84,22 +69,7 @@
 
 {% set endDateHint = "For example, " + "" | today | moment('add', 1, 'years') | toDateArray | spaceSeparate %}
 
-{% if record | courseDatesAreAmbiguous %}
-  {% set endDateLabel = "ITT end date" %}
-{% else %}
-  {% set endDateLabel = "Course end date" %}
-{% endif %}
-
-{% if record | courseDatesAreAmbiguous %}
-  {% set endDateHint %}
-    <p class="govuk-body govuk-hint">
-      The end date of the Initial Teacher Training part of their course.
-    </p>
-    <p class="govuk-body govuk-hint">
-      {{ endDateHint | safe }}
-    </p>
-  {% endset %}
-{% endif %}
+{% set endDateLabel = "ITT end date" %}
 
 {% set programmeEndDateArray = record.courseDetails.endDate | toDateArray %}
 {{ govukDateInput({

--- a/app/views/_includes/forms/course-details/index.html
+++ b/app/views/_includes/forms/course-details/index.html
@@ -81,9 +81,6 @@
   },
   {
     text: "Primary with mathematics",
-    hint: {
-      text: "Also called Specialist teaching"
-    },
     checked: true if firstSubject == "Specialist teaching (primary with mathematics)" and not secondSubject and not thirdSubject
   },
   {

--- a/app/views/_includes/forms/course-details/index.html
+++ b/app/views/_includes/forms/course-details/index.html
@@ -81,6 +81,9 @@
   },
   {
     text: "Primary with mathematics",
+    hint: {
+      text: "Also called Specialist teaching"
+    },
     checked: true if firstSubject == "Specialist teaching (primary with mathematics)" and not secondSubject and not thirdSubject
   },
   {
@@ -296,29 +299,12 @@
 
 {% set startDateHint = "For example, " + "" | today | toDateArray | spaceSeparate %}
 
-{% if record | courseDatesAreAmbiguous %}
-  {% set startDateLabel = "ITT start date" %}
-{% else %}
-  {% set startDateLabel = "Course start date" %}
-{% endif %}
-
-{% if record | courseDatesAreAmbiguous %}
-  {% set startDateHint %}
-    <p class="govuk-body govuk-hint">
-      The start date of the Initial Teacher Training part of their course.
-    </p>
-    <p class="govuk-body govuk-hint">
-      {{startDateHint | safe }}
-    </p>
-  {% endset %}
-{% endif %}
-
 {{ govukDateInput({
   id: "programme-start-date",
   namePrefix: "record[courseDetails][startDate]",
   fieldset: {
     legend: {
-      text: startDateLabel,
+      text: "ITT start date",
       classes: "govuk-fieldset__legend--s"
     }
   },
@@ -348,29 +334,12 @@
 
 {% set endDateHint = "For example, " + "" | today | moment('add', 1, 'years') | toDateArray | spaceSeparate %}
 
-{% if record | courseDatesAreAmbiguous %}
-  {% set endDateLabel = "ITT end date" %}
-{% else %}
-  {% set endDateLabel = "Course end date" %}
-{% endif %}
-
-{% if record | courseDatesAreAmbiguous %}
-  {% set endDateHint %}
-    <p class="govuk-body govuk-hint">
-      The end date of the Initial Teacher Training part of their course.
-    </p>
-    <p class="govuk-body govuk-hint">
-      {{ endDateHint | safe }}
-    </p>
-  {% endset %}
-{% endif %}
-
 {{ govukDateInput({
   id: "programme-end-date",
   namePrefix: "record[courseDetails][endDate]",
   fieldset: {
     legend: {
-      text: endDateLabel,
+      text: "ITT end date",
       classes: "govuk-fieldset__legend--s"
     }
   },

--- a/app/views/_includes/forms/course-details/start-date.html
+++ b/app/views/_includes/forms/course-details/start-date.html
@@ -2,16 +2,6 @@
 
 {% set startDateHint = "For example, " + "" | today | toDateArray | spaceSeparate %}
 
-{% if record | courseDatesAreAmbiguous %}
-  {% set startDateHint %}
-    <p class="govuk-body govuk-hint">
-      The start date of the Initial Teacher Training part of their course.
-    </p>
-    <p class="govuk-body govuk-hint">
-      {{startDateHint | safe }}
-    </p>
-  {% endset %}
-{% endif %}
 
 {{ govukDateInput({
   id: "start-start-date",

--- a/app/views/_includes/forms/course-details/trainee-course-dates.html
+++ b/app/views/_includes/forms/course-details/trainee-course-dates.html
@@ -27,23 +27,12 @@
 
 {% set startDateHint = "For example, " + "" | today | toDateArray | spaceSeparate %}
 
-{% if record | courseDatesAreAmbiguous %}
-  {% set startDateHint %}
-    <p class="govuk-body govuk-hint">
-      The start date of the Initial Teacher Training part of their course.
-    </p>
-    <p class="govuk-body govuk-hint">
-      {{startDateHint | safe }}
-    </p>
-  {% endset %}
-{% endif %}
-
 {{ govukDateInput({
   id: "start-start-date",
   namePrefix: "record[courseDetails][startDate]",
   fieldset: {
     legend: {
-      text: "Course start date",
+      text: "ITT start date",
       isPageHeading: false,
       classes: "govuk-fieldset__legend--s"
     }
@@ -73,23 +62,12 @@
 
 {% set endDateHint = "For example, " + "" | today | moment('add', 1, 'years') | toDateArray | spaceSeparate %}
 
-{% if record | courseDatesAreAmbiguous %}
-  {% set endDateHint %}
-    <p class="govuk-body govuk-hint">
-      The start date of the Initial Teacher Training part of their course.
-    </p>
-    <p class="govuk-body govuk-hint">
-      {{endDateHint | safe }}
-    </p>
-  {% endset %}
-{% endif %}
-
 {{ govukDateInput({
   id: "start-start-date",
   namePrefix: "record[courseDetails][endDate]",
   fieldset: {
     legend: {
-      text: "Course end date",
+      text: "ITT end date",
       isPageHeading: false,
       classes: "govuk-fieldset__legend--s"
     }

--- a/app/views/_includes/forms/training-details/trainee-start-date.html
+++ b/app/views/_includes/forms/training-details/trainee-start-date.html
@@ -3,7 +3,7 @@
 {% set traineeStartDate = record.trainingDetails.commencementDate or false %}
 
 {% set commencementDateHint %}
-  Their {{ "ITT" if record | courseDatesAreAmbiguous else "course" }} started on {{ record.courseDetails.startDate | toDateArray | spaceSeparate }}
+  Their ITT started on {{ record.courseDetails.startDate | toDateArray | spaceSeparate }}
 {% endset %}
 
 {% set legendText = "Trainee start date" %}

--- a/app/views/_includes/summary-cards/course-details/early-years-course.html
+++ b/app/views/_includes/summary-cards/course-details/early-years-course.html
@@ -40,7 +40,7 @@
   } if record | requiresField("studyMode"),
   {
     key: {
-      text: "Course start date" if not record | courseDatesAreAmbiguous else "ITT start date"
+      text: "ITT start date"
     },
     value: {
       text: record.courseDetails.startDate | govukDate or 'Not provided'
@@ -50,14 +50,14 @@
         {
           href: recordPath + "/course-details/details" | addReferrer(referrer),
           text: "Change",
-          visuallyHiddenText: "Course start date" if not record | courseDatesAreAmbiguous else "ITT start date"
+          visuallyHiddenText: "ITT start date"
         }
       ]
     } if canAmend
   },
   {
     key: {
-      text: "Course end date" if not record | courseDatesAreAmbiguous else "ITT end date"
+      text: "ITT end date"
     },
     value: {
       text: record.courseDetails.endDate | govukDate or 'Not provided'
@@ -67,7 +67,7 @@
         {
           href: recordPath + "/course-details/details" | addReferrer(referrer),
           text: "Change",
-          visuallyHiddenText: "course end date" if not record | courseDatesAreAmbiguous else "ITT end date"
+          visuallyHiddenText: "ITT end date"
         }
       ]
     } if canAmend

--- a/app/views/_includes/summary-cards/course-details/non-early-years-course.html
+++ b/app/views/_includes/summary-cards/course-details/non-early-years-course.html
@@ -137,7 +137,7 @@
 
 {% set startDateRow = {
   key: {
-    text: "Course start date" if not record | courseDatesAreAmbiguous else "ITT start date"
+    text: "ITT start date"
   },
   value: {
     text: courseDetails.startDate | govukDate or 'Not provided'
@@ -147,7 +147,7 @@
       {
         href: recordPath + "/course-details/details" | addReferrer(referrer),
         text: "Change",
-        visuallyHiddenText: "course start date" if not record | courseDatesAreAmbiguous else "ITT start date"
+        visuallyHiddenText: "ITT start date"
       }
     ]
   } if canAmend
@@ -155,7 +155,7 @@
 
 {% set endDateRow = {
   key: {
-    text: "Course end date" if not record | courseDatesAreAmbiguous else "ITT end date"
+    text: "ITT end date"
   },
   value: {
     text: courseDetails.endDate | govukDate or 'Not provided'
@@ -165,7 +165,7 @@
       {
         href: recordPath + "/course-details/details" | addReferrer(referrer),
         text: "Change",
-        visuallyHiddenText: "course end date" if not record | courseDatesAreAmbiguous else "ITT end date"
+        visuallyHiddenText: "ITT end date"
       }
     ]
   } if canAmend

--- a/app/views/_includes/summary-cards/trainee-progress.html
+++ b/app/views/_includes/summary-cards/trainee-progress.html
@@ -216,7 +216,7 @@
 
 {% set commencementDateLabel %}
   {% if record.courseDetails.startDate | isInFuture %}
-    {{ "ITT has not started" if record | courseDatesAreAmbiguous else "Course has not started" }}
+    {{ "ITT has not started" }}
   {% elseif record.trainingDetails.commencementDate %}
     {{ record.trainingDetails.commencementDate | govukDate }}
   {% elseif record.trainingDetails.traineeStarted == "trainee-not-started" %}

--- a/app/views/new-record/course-details/dates.html
+++ b/app/views/new-record/course-details/dates.html
@@ -1,10 +1,6 @@
 {% extends "_templates/_new-record.html" %}
 
-{% if data.record | courseDatesAreAmbiguous %}
-  {% set pageHeading = "ITT dates" %}
-{% else %}
-  {% set pageHeading = "Course dates" %}
-{% endif %}
+{% set pageHeading = "ITT dates" %}
 
 {% set formAction = "./dates-answer" %}
 

--- a/app/views/new-record/course-details/start-date.html
+++ b/app/views/new-record/course-details/start-date.html
@@ -1,11 +1,6 @@
 {% extends "_templates/_new-record.html" %}
 
-{% if data.record | courseDatesAreAmbiguous %}
-  {% set pageHeading = "ITT start date" %}
-{% else %}
-  {% set pageHeading = "Course start date" %}
-{% endif %}
-
+{% set pageHeading = "ITT start date" %}
 
 {# {% set formAction = "./confirm" %} #}
 

--- a/app/views/new-record/trainee-start-date.html
+++ b/app/views/new-record/trainee-start-date.html
@@ -3,17 +3,9 @@
 {% set traineeStartDate = data.record.trainingDetails.commencementDate or false %}
 
 {% if traineeStartDate %}
-  {% if record | courseDatesAreAmbiguous %}
-    {% set pageHeading = "When did the trainee start their ITT?" %}
-  {% else %}
-    {% set pageHeading = "When did the trainee start their course?" %}
-  {% endif %}
+  {% set pageHeading = "When did the trainee start their ITT?" %}
 {% else %}
-  {% if record | courseDatesAreAmbiguous %}
-    {% set pageHeading = "Did the trainee start their ITT on time?" %}
-  {% else %}
-    {% set pageHeading = "Did the trainee start their course on time?" %}
-  {% endif %}
+  {% set pageHeading = "Did the trainee start their ITT on time?" %}
 {% endif %}
 
 {% set formAction = "./save-with-date" | addReferrer(referrer) %}

--- a/app/views/record.html
+++ b/app/views/record.html
@@ -16,7 +16,7 @@
 {% set recordPath = "/record/" + record.id %}
 
 {% set courseNotStartedMessage %}
-  The trainee’s {{ "ITT" if record | courseDatesAreAmbiguous else "course" }} starts on {{ record.courseDetails.startDate | govukDate }}
+  The trainee’s ITT starts on {{ record.courseDetails.startDate | govukDate }}
 {% endset %}
 
 

--- a/app/views/record/course-details/dates.html
+++ b/app/views/record/course-details/dates.html
@@ -1,10 +1,6 @@
 {% extends "_templates/_record-form.html" %}
 
-{% if data.record | courseDatesAreAmbiguous %}
-  {% set pageHeading = "ITT dates" %}
-{% else %}
-  {% set pageHeading = "Course dates" %}
-{% endif %}
+{% set pageHeading = "ITT dates" %}
 
 {% set formAction = "./dates-answer" %}
 

--- a/app/views/record/course-details/start-date.html
+++ b/app/views/record/course-details/start-date.html
@@ -1,10 +1,6 @@
 {% extends "_templates/_record-form.html" %}
 
-{% if data.record | courseDatesAreAmbiguous %}
-  {% set pageHeading = "ITT start date" %}
-{% else %}
-  {% set pageHeading = "Course start date" %}
-{% endif %}
+{% set pageHeading = "ITT start date" %}
 
 {# {% set formAction = "./confirm" %} #}
 

--- a/app/views/record/defer/did-trainee-start.html
+++ b/app/views/record/defer/did-trainee-start.html
@@ -1,7 +1,7 @@
 {% extends "_templates/_record-form.html" %}
 
 {% set pageHeading %}
-  Did the trainee start their {{ "ITT" if data.record | courseDatesAreAmbiguous else "course" }}?
+  Did the trainee start their ITT?
 {% endset %}
 
 {% set pageHeadingTraineeName = data.record.personalDetails | getShortName %}

--- a/app/views/record/defer/when-did-trainee-start.html
+++ b/app/views/record/defer/when-did-trainee-start.html
@@ -1,7 +1,7 @@
 {% extends "_templates/_record-form.html" %}
 
 {% set pageHeading %}
-  Did the trainee start their {{ "ITT" if data.record | courseDatesAreAmbiguous else "course" }} on time?
+  Did the trainee start their ITT on time?
 {% endset %}
 
 {% set startConfirmed = true %}

--- a/app/views/record/delete/cannot-delete.html
+++ b/app/views/record/delete/cannot-delete.html
@@ -14,7 +14,7 @@
   </h1>
 
   <p class="govuk-body">
-    You can only delete a trainee record before the trainee starts their {{ "ITT" if record | courseDatesAreAmbiguous else "course" }},<br>
+    You can only delete a trainee record before the trainee starts their ITT,<br>
     but you can defer or withdraw the trainee.
   </p>
 

--- a/app/views/record/delete/did-trainee-start.html
+++ b/app/views/record/delete/did-trainee-start.html
@@ -1,7 +1,7 @@
 {% extends "_templates/_record-form.html" %}
 
 {% set pageHeading %}
-  Did the trainee start their {{ "ITT" if data.record | courseDatesAreAmbiguous else "course" }}?
+  Did the trainee start their ITT?
 {% endset %}
 
 {% set pageHeadingTraineeName = data.record.personalDetails | getShortName %}

--- a/app/views/record/delete/when-did-trainee-start.html
+++ b/app/views/record/delete/when-did-trainee-start.html
@@ -1,7 +1,7 @@
 {% extends "_templates/_record-form.html" %}
 
 {% set pageHeading %}
-  Did the trainee start their {{ "ITT" if data.record | courseDatesAreAmbiguous else "course" }} on time?
+  Did the trainee start their ITT on time?
 {% endset %}
 
 {% set startConfirmed = true %}

--- a/app/views/record/did-trainee-start.html
+++ b/app/views/record/did-trainee-start.html
@@ -1,7 +1,7 @@
 {% extends "_templates/_record-form.html" %}
 
 {% set pageHeading %}
-  Did the trainee start their {{ "ITT" if record | courseDatesAreAmbiguous else "course" }}?
+  Did the trainee start their ITT?
 {% endset %}
 
 {% set pageHeadingTraineeName = data.record.personalDetails | getShortName %}

--- a/app/views/record/trainee-start-date/index.html
+++ b/app/views/record/trainee-start-date/index.html
@@ -3,17 +3,9 @@
 {% set traineeStartDate = data.record.trainingDetails.commencementDate or false %}
 
 {% if traineeStartDate %}
-  {% if record | courseDatesAreAmbiguous %}
-    {% set pageHeading = "When did the trainee start their ITT?" %}
-  {% else %}
-    {% set pageHeading = "When did the trainee start their course?" %}
-  {% endif %}
+  {% set pageHeading = "When did the trainee start their ITT?" %}
 {% else %}
-  {% if record | courseDatesAreAmbiguous %}
-    {% set pageHeading = "Did the trainee start their ITT on time?" %}
-  {% else %}
-    {% set pageHeading = "Did the trainee start their course on time?" %}
-  {% endif %}
+  {% set pageHeading = "Did the trainee start their ITT on time?" %}
 {% endif %}
 
 {# {% set formAction = "./trainee-start-date/confirm" | addReferrer(referrer) %} #}

--- a/app/views/record/when-did-trainee-start.html
+++ b/app/views/record/when-did-trainee-start.html
@@ -1,7 +1,7 @@
 {% extends "_templates/_record-form.html" %}
 
 {% set pageHeading %}
-  Did the trainee start their {{ "ITT" if data.record | courseDatesAreAmbiguous else "course" }} on time?
+  Did the trainee start their ITT on time?
 {% endset %}
 
 {% set startConfirmed = true %}

--- a/app/views/record/withdraw/did-trainee-start.html
+++ b/app/views/record/withdraw/did-trainee-start.html
@@ -1,7 +1,7 @@
 {% extends "_templates/_record-form.html" %}
 
 {% set pageHeading %}
-  Did the trainee start their {{ "ITT" if data.record | courseDatesAreAmbiguous else "course" }}?
+  Did the trainee start their ITT?
 {% endset %}
 
 {% set pageHeadingTraineeName = data.record.personalDetails | getShortName %}

--- a/app/views/record/withdraw/when-did-trainee-start.html
+++ b/app/views/record/withdraw/when-did-trainee-start.html
@@ -1,7 +1,7 @@
 {% extends "_templates/_record-form.html" %}
 
 {% set pageHeading %}
-  Did the trainee start their {{ "ITT" if data.record | courseDatesAreAmbiguous else "course" }} on time?
+  Did the trainee start their ITT on time?
 {% endset %}
 
 {% set startConfirmed = true %}


### PR DESCRIPTION
Adopt language around `ITT start date` and `ITT end date` rather than `Course start date` and `Course end date`.

Making this change as although ITT dates and course dates are often the same, for some routes they differ - eg undergrad and teaching apprenticeships. For those routes, asking for `Course start date` was ambiguous - as it could refer to two things - and we're specifically interested in the ITT bit.