### PR TITLE
Fix homepage and footer guidance links

### DIFF
--- a/app/views/home.html
+++ b/app/views/home.html
@@ -83,7 +83,7 @@
       <h2 class="govuk-heading-l">Guidance and feedback</h2>
       {# We need to split these pages #}
       <ul class="govuk-list govuk-list--spaced">
-        <li><a class="govuk-link" href="/about-register">Find out about Register trainee teachers</a></li>
+        <li><a class="govuk-link" href="/guidance">Find out about Register trainee teachers</a></li>
         <li><a class="govuk-link" href="/check-data">Check what data you need to provide</a></li>
         <li><a class="govuk-link" href="#">Give feedback to help us improve Register trainee teachers</a></li>
       </ul>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -174,7 +174,7 @@
     <li>We aim to respond within 5 working days, or one working day for more urgent&nbsp;queries</li>
   </ul>
   {% set guidanceLink = '/guidance' if data.settings.includeGuidance else '#' %}
-  <p class="govuk-body govuk-!-font-size-16"><a href="{{guidanceLink}}" class="govuk-link govuk-footer__link">How to use Register trainee teachers</a></p>
+  <p class="govuk-body govuk-!-font-size-16"><a href="{{guidanceLink}}" class="govuk-link govuk-footer__link">Find out about Register trainee teachers</a></p>
 {% endset %}
 
 {% if useAutoStoreData %}


### PR DESCRIPTION
- Fix the guidance link in the homepage
- rename the guidance link in the footer