### PR TITLE
adds a button that looks like a link to clear the prototype data

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -202,3 +202,21 @@ span.summary-validation-symbol {
   text-align: right;
   float: right;
 }
+
+.app-link-button {
+  @extend %govuk-body-s;
+  margin: 0;
+  padding: 0;
+  display: inline;
+  background: none;
+  border: none;
+  text-decoration: underline;
+  cursor: pointer;
+}
+.app-link-button:focus {
+  outline: none;
+}
+
+.app-hidden-form {
+  display: inline;
+}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -175,6 +175,11 @@
   </ul>
   {% set guidanceLink = '/guidance' if data.settings.includeGuidance else '#' %}
   <p class="govuk-body govuk-!-font-size-16"><a href="{{guidanceLink}}" class="govuk-link govuk-footer__link">Find out about Register trainee teachers</a></p>
+  <form method="post" action="/admin/clear-data" class="app-hidden-form">
+    <button class="app-link-button">
+      Clear data
+    </button>
+  </form>
 {% endset %}
 
 {% if useAutoStoreData %}
@@ -198,9 +203,6 @@
           href: "/admin",
           text: "Prototype admin"
         }, {
-          href: "/admin/clear-data",
-          text: "Clear data"
-        }, {
           href: "/apply/" + providerCode + "/" + courseCode + "?dualrunning=true&variant=1",
           text: "v1"
         } if providerCode and courseCode, {
@@ -214,6 +216,7 @@
     }) }}
   {% endblock %}
 {% endif %}
+
 
 {% block bodyEnd %}
   {% block scripts %}

--- a/server.js
+++ b/server.js
@@ -222,7 +222,7 @@ if (useAutoStoreData === 'true') {
 // Clear all data in session if you open /prototype-admin/clear-data
 app.post('/admin/clear-data', function (req, res) {
   req.session.data = {}
-  res.render('admin/clear-data-success')
+  res.redirect('/start-page')
 })
 
 // Redirect root to /docs when in promo mode.


### PR DESCRIPTION
Currently if you want to clear the data in the prototype you need to click the link in the footer, press the button, then click to get back to the homepage. This adds a button that does that all in 1 go.