### PR TITLE
Support schools being not applicable

### DIFF
--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -96,6 +96,12 @@ module.exports = router => {
     let referrer = utils.getReferrer(req.query.referrer)
     const schools = getSchools()
 
+    // default to applicable unless checkbox set
+    let leadSchoolApplicable = true
+    if (record?.schools?.leadSchool?.notApplicable && record?.schools?.leadSchool?.notApplicable.includes('true') ){
+      leadSchoolApplicable = false
+    }
+
     // Input added with js by the autocomplete
     let autocompleteRawValue = req.body?._autocomplete_raw_value_school_picker
 
@@ -129,25 +135,27 @@ module.exports = router => {
     delete record?.schools?.leadSchoolIsEmployingSchool // Checkbox no longer needed
 
     // Search again
-    if (schoolSearchTerm && !schoolUuid){
+    if (schoolSearchTerm && !schoolUuid && leadSchoolApplicable){
       let queryParams = utils.addQueryParam(referrer, `_schoolSearch=${schoolSearchTerm}`)
       res.redirect(`${recordPath}/schools/lead-school${queryParams}`)
     }
     // No answer given and no search term
-    else if (!schoolUuid){
+    else if (!schoolUuid && leadSchoolApplicable){
       res.redirect(`${recordPath}/schools/lead-school${referrer}`)
     }
     else {
-      let selectedSchool = schools.find(school => school.uuid == schoolUuid)
+      if (leadSchoolApplicable){
+        let selectedSchool = schools.find(school => school.uuid == schoolUuid)
 
-      // Seed records might have schools that aren't in our schools list
-      // This may happen if a user tries to edit an existing seed record
-      if (!selectedSchool) {
-        console.log(`School not found - you probably need to update the seed records`)
-      }
-      else {
-        // Using _.set as lead school might not exist yet
-        _.set(record, 'schools.leadSchool', selectedSchool)
+        // Seed records might have schools that aren't in our schools list
+        // This may happen if a user tries to edit an existing seed record
+        if (!selectedSchool) {
+          console.log(`School not found - you probably need to update the seed records`)
+        }
+        else {
+          // Using _.set as lead school might not exist yet
+          _.set(record, 'schools.leadSchool', selectedSchool)
+        }
       }
 
       // Some routes have a conditional next question
@@ -207,6 +215,12 @@ module.exports = router => {
     let referrer = utils.getReferrer(req.query.referrer)
     const schools = getSchools()
 
+    // default to applicable unless checkbox set
+    let employingSchoolApplicable = true
+    if (record?.schools?.employingSchool?.notApplicable && record?.schools?.employingSchool?.notApplicable.includes('true') ){
+      employingSchoolApplicable = false
+    }
+
     // Input added with js by the autocomplete
     let autocompleteRawValue = req.body?._autocomplete_raw_value_school_picker
 
@@ -238,25 +252,27 @@ module.exports = router => {
     let schoolUuid = autocompleteUuid || schoolResultUuid || false
 
     // Search again
-    if (schoolSearchTerm && !schoolUuid){
+    if (schoolSearchTerm && !schoolUuid && employingSchoolApplicable){
       let queryParams = utils.addQueryParam(referrer, `_schoolSearch=${schoolSearchTerm}`)
       res.redirect(`${recordPath}/schools/employing-school${queryParams}`)
     }
     // No answer given and no search term
-    else if (!schoolUuid){
+    else if (!schoolUuid && employingSchoolApplicable){
       res.redirect(`${recordPath}/schools/employing-school${referrer}`)
     }
     else {
-      let selectedSchool = schools.find(school => school.uuid == schoolUuid)
+      if (employingSchoolApplicable){
+        let selectedSchool = schools.find(school => school.uuid == schoolUuid)
 
-      // Seed records might have schools that aren't in our schools list
-      // This may happen if a user tries to edit an existing seed record
-      if (!selectedSchool) {
-        console.log(`School not found - you probably need to update the seed records`)
-      }
-      else {
-        // Using _.set as lead school might not exist yet
-        _.set(record, 'schools.employingSchool', selectedSchool)
+        // Seed records might have schools that aren't in our schools list
+        // This may happen if a user tries to edit an existing seed record
+        if (!selectedSchool) {
+          console.log(`School not found - you probably need to update the seed records`)
+        }
+        else {
+          // Using _.set as lead school might not exist yet
+          _.set(record, 'schools.employingSchool', selectedSchool)
+        }
       }
 
       res.redirect(`${recordPath}/schools/confirm${referrer}`)

--- a/app/views/_includes/forms/schools/employing-school.html
+++ b/app/views/_includes/forms/schools/employing-school.html
@@ -26,6 +26,30 @@
   }) }}
 </div>
 
+{% set detailsHtml %}
+
+  <p class="govuk-body">
+    If the employing school is missing from the list, contact us at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher<wbr>@digital.education.gov.uk</a>
+  </p>
+
+  <p class="govuk-body">Employing school is not applicable for trainees who are employed and funded by private schools.</p>
+
+  {{ govukCheckboxes({
+    items: [
+      {
+        value: "true",
+        text: "Employing school is not applicable"
+      }
+    ]
+    } | decorateAttributes(record, "record.schools.employingSchool.notApplicable")) }}
+{% endset %}
+
+{{ govukDetails({
+  summaryText: "Employing school is not applicable for this trainee or is not listed",
+  html: detailsHtml,
+  open: true if record.schools.employingSchool.notApplicable == "true"
+}) }}
+
 {{ govukButton({
   text: "Continue"
 }) }}

--- a/app/views/_includes/forms/schools/employing-school.html
+++ b/app/views/_includes/forms/schools/employing-school.html
@@ -29,10 +29,10 @@
 {% set detailsHtml %}
 
   <p class="govuk-body">
-    If the employing school is missing from the list, contact us at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>
+    If the employing school is missing from the list, contact <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>
   </p>
 
-  <p class="govuk-body">Employing school is not applicable for trainees who are employed or funded privately</p>
+  <p class="govuk-body">You only need to provide an employing school if the trainee is employed or funded by a state school</p>
 
   {{ govukCheckboxes({
     items: [
@@ -45,7 +45,7 @@
 {% endset %}
 
 {{ govukDetails({
-  summaryText: "Employing school is not applicable for this trainee or is not listed",
+  summaryText: "Trainee is not at a state school or employing school is not listed",
   html: detailsHtml,
   open: true if record.schools.employingSchool.notApplicable == "true"
 }) }}

--- a/app/views/_includes/forms/schools/employing-school.html
+++ b/app/views/_includes/forms/schools/employing-school.html
@@ -29,10 +29,10 @@
 {% set detailsHtml %}
 
   <p class="govuk-body">
-    If the employing school is missing from the list, contact us at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher<wbr>@digital.education.gov.uk</a>
+    If the employing school is missing from the list, contact us at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>
   </p>
 
-  <p class="govuk-body">Employing school is not applicable for trainees who are employed and funded by private schools.</p>
+  <p class="govuk-body">Employing school is not applicable for trainees who are employed or funded privately</p>
 
   {{ govukCheckboxes({
     items: [

--- a/app/views/_includes/forms/schools/lead-school.html
+++ b/app/views/_includes/forms/schools/lead-school.html
@@ -28,6 +28,34 @@
   }) }}
 </div>
 
+
+  
+
+
+{% set detailsHtml %}
+
+  <p class="govuk-body">
+    If the lead school is missing from the list, contact us at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher<wbr>@digital.education.gov.uk</a>
+  </p>
+
+  <p class="govuk-body">Lead school is not applicable for trainees who are employed and funded by private schools.</p>
+
+  {{ govukCheckboxes({
+    items: [
+      {
+        value: "true",
+        text: "Lead school is not applicable"
+      }
+    ]
+    } | decorateAttributes(record, "record.schools.leadSchool.notApplicable")) }}
+{% endset %}
+
+{{ govukDetails({
+  summaryText: "Lead school is not applicable for this trainee or is not listed",
+  html: detailsHtml,
+  open: true if record.schools.leadSchool.notApplicable == "true"
+}) }}
+
 {# Commented out for now as not sure about this #}
 {# Only show the checkbox where we're using the autocomplete and we've not already got results #}
 {# <div class="app-js-only">

--- a/app/views/_includes/forms/schools/lead-school.html
+++ b/app/views/_includes/forms/schools/lead-school.html
@@ -35,10 +35,10 @@
 {% set detailsHtml %}
 
   <p class="govuk-body">
-    If the lead school is missing from the list, contact us at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher<wbr>@digital.education.gov.uk</a>
+    If the lead school is missing from the list, contact us at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>
   </p>
 
-  <p class="govuk-body">Lead school is not applicable for trainees who are employed and funded by private schools.</p>
+  <p class="govuk-body">Lead school is not applicable for trainees who are employed or funded privately</p>
 
   {{ govukCheckboxes({
     items: [

--- a/app/views/_includes/forms/schools/lead-school.html
+++ b/app/views/_includes/forms/schools/lead-school.html
@@ -28,17 +28,13 @@
   }) }}
 </div>
 
-
-  
-
-
 {% set detailsHtml %}
 
   <p class="govuk-body">
-    If the lead school is missing from the list, contact us at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>
+    If the lead school is missing from the list, contact <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>
   </p>
 
-  <p class="govuk-body">Lead school is not applicable for trainees who are employed or funded privately</p>
+  <p class="govuk-body">You only need to provide a lead school if the trainee is employed or funded by a state school</p>
 
   {{ govukCheckboxes({
     items: [
@@ -51,7 +47,7 @@
 {% endset %}
 
 {{ govukDetails({
-  summaryText: "Lead school is not applicable for this trainee or is not listed",
+  summaryText: "Trainee is not at a state school or lead school is not listed",
   html: detailsHtml,
   open: true if record.schools.leadSchool.notApplicable == "true"
 }) }}

--- a/app/views/_includes/summary-cards/schools.html
+++ b/app/views/_includes/summary-cards/schools.html
@@ -2,8 +2,12 @@
 {# Lead school name #}
 {% if record.schools.leadSchool %}
   {% set leadSchoolHtml %}
-    <p class="govuk-body">{{record.schools.leadSchool.schoolName}}</p>
-    <span class="govuk-hint">{{record.schools.leadSchool | getSchoolHint}}</span>
+    {% if record.schools.leadSchool.notApplicable | falsify %}
+      Not applicable
+    {% else %}
+      <p class="govuk-body">{{record.schools.leadSchool.schoolName}}</p>
+      <span class="govuk-hint">{{record.schools.leadSchool | getSchoolHint}}</span>
+    {% endif %}
   {% endset %}
 {% endif %}
 
@@ -27,8 +31,12 @@
 
 {% if record.schools.employingSchool %}
   {% set employingSchoolHtml %}
+    {% if record.schools.employingSchool.notApplicable | falsify %}
+      Not applicable
+    {% else %}
     <p class="govuk-body">{{record.schools.employingSchool.schoolName}}</p>
     <span class="govuk-hint">{{record.schools.employingSchool | getSchoolHint}}</span>
+    {% endif %}
   {% endset %}
 {% endif %}
 


### PR DESCRIPTION
In some cases, a lead and employing school is not applicable - this happens where the trainee is self funded / at a private school and so DfE does not provide funding to the school.

Adds a checkbox to each of the schools pages. When checked, users do not need to provide a school (and we should prevent them providing both).

Lead school page
<img width="1036" alt="Screenshot 2021-10-15 at 12 24 33" src="https://user-images.githubusercontent.com/2204224/137479731-e2e7d090-b8fe-4825-9aaa-885d101b07c3.png">

Employing school page
<img width="1033" alt="Screenshot 2021-10-15 at 12 24 47" src="https://user-images.githubusercontent.com/2204224/137479733-a2efb88c-3947-403d-af37-2deff3524996.png">

Confirm page
<img width="1047" alt="Screenshot 2021-10-13 at 17 31 13" src="https://user-images.githubusercontent.com/2204224/137175347-f96f0ebf-d06e-4719-aa2e-cc7f4718704b.png">

