### PR TITLE
Add badge for incomplete drafts

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -55,6 +55,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "overrides/govuk-panel";
 @import "overrides/govuk-error-summary";
 @import "overrides/govuk-skip-link";
+@import "overrides/govuk-tag";
 @import "overrides/moj-filter";
 @import "overrides/moj-pagination";
 @import "overrides/summary-card";

--- a/app/assets/sass/components/_application-card.scss
+++ b/app/assets/sass/components/_application-card.scss
@@ -2,17 +2,32 @@
   margin-bottom: govuk-spacing(3);
   padding-bottom: govuk-spacing(3);
   border-bottom: 1px solid govuk-colour('mid-grey');
-  
-  @include govuk-media-query($from: 401px) {
-    display: flex;
-    // Ensure columns evenly distributed, with no gap at the start or end
-    justify-content: space-between;
-  }
 }
 
 .app-application-card:first-of-type {
   border-top: 1px solid govuk-colour('mid-grey');
   padding-top: govuk-spacing(3);
+}
+
+.app-application-card_row {
+  min-width: 100%;
+}
+
+.app-application-card_row--header {
+  display: inline-grid;
+  .govuk-tag {
+    margin-left: govuk-spacing(3);
+  }
+}
+
+.app-application-card_row--body {
+    margin-top: govuk-spacing(2);
+    @include govuk-media-query($from: 401px) {
+      display: flex;
+      // Ensure columns evenly distributed, with no gap at the start or end
+      justify-content: space-between;
+    }
+  }
 }
 
 // Checkbox column
@@ -27,10 +42,6 @@
 // Trainee + Course details columns
 .app-application-card_col:nth-last-child(2) {
  
-  .govuk-tag {
-    margin-bottom: govuk-spacing(2);
-  }
-
   div:nth-child(1) {
     margin-bottom: govuk-spacing(2);
   }
@@ -107,11 +118,6 @@
   hyphens: auto;
 }
 
-.app-application-card .govuk-tag {
-  // Stops elements in flex containers to try and fill available space
-  align-self: flex-end;
-}
-
 .app-application-card__provider {
   overflow-wrap: break-word;
 }
@@ -124,5 +130,3 @@
     }
   }
 }
-
-

--- a/app/assets/sass/overrides/_govuk-tag.scss
+++ b/app/assets/sass/overrides/_govuk-tag.scss
@@ -1,0 +1,8 @@
+
+
+.app-tag--record-incomplete {
+  background-color: govuk-colour("white");
+  color:  $govuk-text-colour;
+  outline: 1px solid govuk-colour("black");
+  outline-offset: -1px;
+}

--- a/app/views/_includes/trainee-record-card.njk
+++ b/app/views/_includes/trainee-record-card.njk
@@ -3,24 +3,9 @@
 {% endif %}
 
 <div class="app-application-card {{justNowClass}}">
-  
-  {% if data.settings.showBulkLinks %}
-    <div class="app-application-card_col">
-      <div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox">
-        {% if record.status == 'TRN received' or (record | isDraft and record | recordIsComplete) %}
-          <input type="checkbox" name="[bulk][filteredTrainees]" class="govuk-checkboxes__input" id="checkbox-{{record.id}}" value="{{record.id}}">
-          <label class="govuk-label govuk-checkboxes__label" for="checkbox-{{record.id}}">
-            <span class="govuk-visually-hidden">Select {{record.personalDetails.shortName}}</span>
-          </label>
-        {% endif %}
-      </div>
-    </div>
-  {% endif %}
 
-  <div class="app-application-card_col">
-
-    <div>
-      <h3 class="app-application-card__trainee-name govuk-heading-m govuk-!-margin-bottom-1">
+  <div class="app-application-card_row app-application-card_row--header">
+      <h3 class="app-application-card__trainee-name govuk-heading-m">
         <a href="/record/{{ record.id }}" class="govuk-link govuk-link--no-visited-state">
           {% if record | hasName %}
             {% if query.sortOrder == "lastName" %}
@@ -37,56 +22,75 @@
           {% endif %}
         </a>
       </h3>
-
-      {% if record.trainingDetails.traineeId %}
-        <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-1">Trainee ID: {{record.trainingDetails.traineeId}}</p>
-      {% endif %}
-      {% if record.trn %}
-        <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-0">TRN: {{record.trn}}</p>
-      {% endif %}
-      {% if data.isAdmin or data.signedInProviders | length > 1 %}
-        <p class="govuk-caption-m govuk-!-font-size-16 app-application-card__provider govuk-!-margin-bottom-0 govuk-!-margin-top-2">
-          <span class="govuk-visually-hidden">Provider: </span>{{record.provider}}</p>
-      {% endif %}
-    </div>
-
-    <div>
+      {{govukTag({
+        text: record | getStatusText,
+        classes: record.status | getStatusClass
+      })}}
       {% if record | isDraft and not record | recordIsComplete %}
         {{govukTag({
           text: "Incomplete",
           classes: "app-tag--record-incomplete"
         })}}
       {% endif %}
+  </div>
+  
+  {% if data.settings.showBulkLinks %}
+    <div class="app-application-card_col">
+      <div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox">
+        {% if record.status == 'TRN received' or (record | isDraft and record | recordIsComplete) %}
+          <input type="checkbox" name="[bulk][filteredTrainees]" class="govuk-checkboxes__input" id="checkbox-{{record.id}}" value="{{record.id}}">
+          <label class="govuk-label govuk-checkboxes__label" for="checkbox-{{record.id}}">
+            <span class="govuk-visually-hidden">Select {{record.personalDetails.shortName}}</span>
+          </label>
+        {% endif %}
+      </div>
+    </div>
+  {% endif %}
+  <div class="app-application-card_row app-application-card_row--body">
+    <div class="app-application-card_col">
 
-      <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
-        {# If subject spcialisms are incomplete, prefer course name. Else prefer the specialisms. #}
-        {% set subjects %}
-          {% if record.courseDetails | subjectsAreIncomplete %}
-            {{ record.courseDetails.courseNameShort or record.courseDetails.subjects | prettifySubjects }}
-          {% else %}
-            {{ (record.courseDetails.subjects | prettifySubjects | falsify ) or record.courseDetails.courseNameShort }}
-          {% endif %}
-        {% endset %}
-        
-        <span class="govuk-visually-hidden">Course: </span>{{ subjects }}</p>
-      <p class="govuk-body govuk-!-font-size-16 govuk-hint govuk-!-margin-bottom-0">
-        <span class="govuk-visually-hidden">Route: </span>{{ record.route }}</p>
+      <div>
+
+        {% if record.trainingDetails.traineeId %}
+          <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-1">Trainee ID: {{record.trainingDetails.traineeId}}</p>
+        {% endif %}
+        {% if record.trn %}
+          <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-0">TRN: {{record.trn}}</p>
+        {% endif %}
+        {% if data.isAdmin or data.signedInProviders | length > 1 %}
+          <p class="govuk-caption-m govuk-!-font-size-16 app-application-card__provider govuk-!-margin-bottom-0 govuk-!-margin-top-2">
+            <span class="govuk-visually-hidden">Provider: </span>{{record.provider}}</p>
+        {% endif %}
+      </div>
+
+      <div>
+
+        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
+          {# If subject spcialisms are incomplete, prefer course name. Else prefer the specialisms. #}
+          {% set subjects %}
+            {% if record.courseDetails | subjectsAreIncomplete %}
+              {{ record.courseDetails.courseNameShort or record.courseDetails.subjects | prettifySubjects }}
+            {% else %}
+              {{ (record.courseDetails.subjects | prettifySubjects | falsify ) or record.courseDetails.courseNameShort }}
+            {% endif %}
+          {% endset %}
+          
+          <span class="govuk-visually-hidden">Course: </span>{{ subjects }}</p>
+        <p class="govuk-body govuk-!-font-size-16 govuk-hint govuk-!-margin-bottom-0">
+          <span class="govuk-visually-hidden">Route: </span>{{ record.route }}</p>
+      </div>
+
     </div>
 
-  </div>
-
-  <div class="app-application-card_col">
-    {{govukTag({
-      text: record | getStatusText,
-      classes: record.status | getStatusClass
-    })}}
-    <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-top-2 govuk-!-margin-bottom-0 app-application-card__submitted">
-      {% if query.sortOrder == "dateAdded" %}
-        Added: <span>{{record.submittedDate | govukDate}}
-      {% else %}
-        Updated: <span>{{record.updatedDate | govukDate}}
-      {% endif %}
-      </span></p>
+    <div class="app-application-card_col">
+      <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-0 app-application-card__submitted">
+        {% if query.sortOrder == "dateAdded" %}
+          Added: <span>{{record.submittedDate | govukDate}}
+        {% else %}
+          Updated: <span>{{record.updatedDate | govukDate}}
+        {% endif %}
+        </span></p>
+    </div>
   </div>
 
 </div>

--- a/app/views/_includes/trainee-record-card.njk
+++ b/app/views/_includes/trainee-record-card.njk
@@ -51,6 +51,13 @@
     </div>
 
     <div>
+      {% if record | isDraft and not record | recordIsComplete %}
+        {{govukTag({
+          text: "Incomplete",
+          classes: "app-tag--record-incomplete"
+        })}}
+      {% endif %}
+
       <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
         {# If subject spcialisms are incomplete, prefer course name. Else prefer the specialisms. #}
         {% set subjects %}


### PR DESCRIPTION
Adds a badge to the record card to show when the draft is incomplete.

<img width="652" alt="Screenshot 2021-10-19 at 11 00 23" src="https://user-images.githubusercontent.com/2204224/137888143-babedd64-aa85-48bf-8e25-ef506ccb9582.png">


The intention is this would apply to non drafts too - but for the moment the prototype thinks *all* non drafts are incomplete, so this badge would show everywhere.