### PR TITLE
Add complete/incomplete filter to registered records section

### DIFF
--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -3,6 +3,7 @@
 // -------------------------------------------------------------------
 const _ = require('lodash')
 const faker = require('faker')
+const weighted = require('weighted')
 const moment = require('moment')
 const path = require('path')
 const url = require('url')
@@ -877,6 +878,9 @@ exports.sectionIsComplete = section => {
 // Check if all sections are complete
 exports.recordIsComplete = record => {
   if (!record || !_.get(record, "route")) return false
+
+  // Pretend 20% of submitted records are incomplete
+  if (exports.isNonDraft(record)) return weighted.select([true, false], [0.8, 0.2])
 
   let requiredSections = _.get(trainingRoutes, `${record.route}.sections`)
   let applyReviewSections = trainingRouteData.applyReviewSections

--- a/app/routes/records-list-routes.js
+++ b/app/routes/records-list-routes.js
@@ -145,9 +145,11 @@ const getSelectedFilters = req => {
     })
   }
 
+  let completeFilterLabel = (pathname == '/drafts') ? "Draft completion" : "Record completion"
+
   if (filters.completeStatus) {
     selectedFilters.categories.push({
-      heading: { text: 'Draft completion' },
+      heading: { text: completeFilterLabel },
       items: filters.completeStatus.map((completeStatus) => {
 
         let newQuery = Object.assign({}, query)

--- a/app/views/_includes/filter-panel/completeStatus.njk
+++ b/app/views/_includes/filter-panel/completeStatus.njk
@@ -2,7 +2,7 @@
   classes: "govuk-checkboxes--small js-auto-submit",
   fieldset: {
     legend: {
-      text: "Draft completion",
+      text: "Draft completeion" if (navActive == "drafts") else "Record completion",
       isPageHeading: false,
       classes: "govuk-fieldset__legend--s"
     }

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -57,6 +57,9 @@
   
   {% include "_includes/filter-panel/cycles.njk" %}
 
+  {% include "_includes/filter-panel/completeStatus.njk" %}
+
+
   {% include "_includes/filter-panel/phase.njk" %}
 
 


### PR DESCRIPTION
Adds a filter to the registered trainees section to show incomplete records.

The prototype doesn't yet have a way of knowing if a record is incomplete, so for the moment this is randomly chosen - 20% of records are chosen to be incomplete.

<img width="371" alt="Screenshot 2021-10-19 at 13 53 03" src="https://user-images.githubusercontent.com/2204224/137913222-33591326-c737-4a64-a6e5-4bbad58c5de5.png">
 