### PR TITLE
Update filter to take in to account outstanding actions

### DIFF
--- a/app/views/_includes/trainee-record-card.njk
+++ b/app/views/_includes/trainee-record-card.njk
@@ -23,7 +23,7 @@
         </a>
       </h3>
       <span class="app-application-card_tag-container">
-        {% if record | isDraft and not record | recordIsComplete %}
+        {% if not record | recordIsComplete %}
           {{govukTag({
             text: "Incomplete",
             classes: "app-tag--record-incomplete"


### PR DESCRIPTION
We can now display the `incomplete` badge against registered trainees for any with outstanding actions.

It's a bit fussy that we have both `recordIsComplete` and `hasOutstandingActions` - but I've not touched that for now.
<img width="723" alt="Screenshot 2021-10-22 at 16 09 59" src="https://user-images.githubusercontent.com/2204224/138479814-712d6603-6070-4dbf-88d9-cfcf2e12899a.png">

