### PR TITLE
Let route be changed on Apply drafts

### DIFF
--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -417,6 +417,10 @@ exports.getProviderCourses = function(courses, provider, route=false, data=false
   if (!provider) {
     console.log('Error: no provider given')
   }
+  if (!data?.courses?.[provider]?.courses){
+    console.log('Error: no courses. The kit has likely been reset.')
+    return false
+  }
   let filteredCourses = data.courses[provider].courses
   if (route) {
     filteredCourses = filteredCourses.filter(course => route == course.route)
@@ -493,7 +497,7 @@ exports.updatePublishCourseDates = (courseDetails, data) => {
 exports.routeHasPublishCourses = function(record){
   if (!record) return false
   const data = Object.assign({}, this.ctx.data)
-  let providerCourses = exports.getProviderCourses(data.courses, record?.provider, record.route, data)
+  let providerCourses = exports.getProviderCourses(data?.courses, record?.provider, record.route, data)
   return (providerCourses.length > 0)
 }
 
@@ -778,7 +782,7 @@ exports.subjectsAreIncomplete = courseDetails => {
 // course
 exports.courseNeedsToBeConfirmed = courseDetails => {
   if (exports.sectionIsComplete(courseDetails)) return false
-  else return (Boolean(courseDetails.needsConfirming))
+  else return (Boolean(courseDetails?.needsConfirming))
 }
 
 // -------------------------------------------------------------------
@@ -894,7 +898,8 @@ exports.recordIsComplete = function(record, data=false ) {
       'Withdrawn'
     ]
     if (statusesThatMustBeComplete.includes(record?.status)) return true
-      else return !exports.hasOutstandingActions(record, data)
+      else
+    return !exports.hasOutstandingActions(record, data)
   }
 
   let requiredSections = _.get(trainingRoutes, `${record.route}.sections`)

--- a/app/views/_includes/forms/course-details/confirm-course.html
+++ b/app/views/_includes/forms/course-details/confirm-course.html
@@ -2,7 +2,7 @@
 
 <h1 class="govuk-heading-l">{{pageHeading}}</h1>
 
-<p class="govuk-body">The trainee is being registered on {{course.courseNameLong}}, {{course.route}}</p>
+<p class="govuk-body">The trainee is being registered on {{course.courseNameLong}}, on the {{record.route}} route.</p>
 
 {% set courseItems = [] %}
 

--- a/app/views/_includes/forms/course-details/pick-course.html
+++ b/app/views/_includes/forms/course-details/pick-course.html
@@ -52,7 +52,7 @@ defer to an id if one exists. #}
   {% set courseItems = courseItems | push({
     value: "Other",
     _text: "Another course not listed",
-    text: "Enter course details",
+    text: "Enter course details manually",
     checked: checked(selectedCourse, "Other")
   }) %}
 

--- a/app/views/_includes/providerAndRouteInsetText.njk
+++ b/app/views/_includes/providerAndRouteInsetText.njk
@@ -5,31 +5,44 @@ Example:
 
 #}
 
+{% set routeSwitchUrl %}
+  <a href="{{ './select-route' | addReferrer(referrer) }}" class="govuk-link">{{ record.route | lower or "route not set" }}</a>
+{%- endset %}
+
 {% set providerText %}
   {# Include a link if using blended model #}
   {% if data.signedInProviders | length > 1 %}
-    Training with <a href="{{'./pick-provider' | addReferrer(referrer) }}" class="govuk-link">{{record.provider}}</a>
+    Training with <a href="{{'./pick-provider' | addReferrer(referrer) }}" class="govuk-link">{{ record.provider }}</a>
   {# Don’t link if using hat model - they need to back out and pick a different provider to work as #}
   {% else %}
-    Training with {{record.provider}}
+    Training with {{ record.provider }}
+  {% endif %}
+{% endset %}
+
+
+{% set applyText %}
+  {% if record.courseDetails %}
+    All conditions met and trainee recruited to {{ record.courseDetails.courseNameLong }},
+  {% else %}
+    All conditions met and trainee 
   {% endif %}
 {% endset %}
 
 {% set routeText %}
-  on the <a href="{{ './select-route' | addReferrer(referrer) }}" class="govuk-link">{{ record.route | lower or "route not set" }}</a> route.
+  on the {{ routeSwitchUrl | safe }} route.
 {% endset %}
 
 {# Don’t show anything if user doesn't have multiple providers #}
-{% if data.settings.userProviders | length > 1  %}
-  {% set insetTextHtml %}
-    {{providerText | safe}} {{routeText | safe}}
-  {% endset %}
+{% set insetTextHtml %}
+  {% if data.settings.userProviders | length > 1  %}
+    {{ providerText | safe }} {{ routeText | safe }}
+  {% elseif record | sourceIsManual %}
+    Trainee {{ routeText | safe}}
+  {% else %}
+    {{ applyText }} {{ routeText | safe }}
+  {% endif %}
+{% endset %}
 
-{% else %}
-  {% set insetTextHtml %}
-    Trainee {{routeText | safe}}
-  {% endset %}
-{% endif %}
 
 {{ govukInsetText({
   html: insetTextHtml

--- a/app/views/new-record/check-record-apply-grouped-sections.html
+++ b/app/views/new-record/check-record-apply-grouped-sections.html
@@ -15,21 +15,6 @@
 {# Add an extra referrer as this is a compound referral path #}
 {% set referrer = referrer | pushReferrer(recordPath + "/check-record") %}
 
-{# Warning if record not complete #}
-{% set recordIncompleteInsetTextWarning %}
-  {# Show a warning if the record isn’t ready to be submitted #}
-  {% if not recordIsComplete %}
-    {% set insetTextHtml %}
-      <p class="govuk-body">
-        This trainee record is not complete and cannot be submitted for TRN. If you do not have all the required information now, you can <a href="./save-as-draft" class="govuk-link">return to this draft later</a>.
-      </p>
-    {% endset %}
-      {{ govukInsetText({
-        html: insetTextHtml
-      }) }}
-  {% endif %}
-{% endset %}
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
@@ -56,9 +41,8 @@
     {# Show a warning if the record isn’t ready to be submitted #}
     {{ recordIncompleteInsetTextWarning | safe }}
 
-    {# Not needed for apply? #}
     {# Inset text about the provider and route #}
-    {# {% include "_includes/providerAndRouteInsetText.njk" %} #}
+    {% include "_includes/providerAndRouteInsetText.njk" %}
 
   </div>
 </div>

--- a/app/views/new-record/course-details/confirm.html
+++ b/app/views/new-record/course-details/confirm.html
@@ -6,6 +6,8 @@
 {% set gridColumn = 'govuk-grid-column-full' %}
 {% set formAction = "./../overview" | orReferrer(referrer) %}
 
+{% set referrer = currentPageUrl %}
+
 {% block formContent %}
   <h1 class="govuk-heading-l">{{pageHeading}}</h1>
   {% include "_includes/summary-cards/course-details.html" %}

--- a/app/views/new-record/overview-apply-grouped-sections.html
+++ b/app/views/new-record/overview-apply-grouped-sections.html
@@ -24,34 +24,27 @@
 <span class="govuk-caption-l">Draft</span>
 <h1 class="govuk-heading-l govuk-!-margin-bottom-8">{{pageHeading}}</h1>
 
-{% set insetTextHtml %}
-  {% if record.courseDetails %}
-    <p class="govuk-body">All conditions met and trainee recruited to {{ record.courseDetails.courseNameLong }}, {{record.route}}</p>
-  {% else %}
-    No data to show
-  {% endif %}
-{% endset %}
-
-{{ govukInsetText({
-  html: insetTextHtml
-}) }}
-
 {# Inset text about the provider and route #}
-{# {% include "_includes/providerAndRouteInsetText.njk" %} #}
+{% include "_includes/providerAndRouteInsetText.njk" %}
 
 <h2 class="govuk-heading-m">Registration data from Apply</h2>
-{# <p class="govuk-body">
-  Application submitted on {{ record.applyData.applicationDate | govukDate }}
-</p> #}
-{#<p class="govuk-body">
-  Met all conditions on {{ record.applyData.recruitedDate | govukDate }}
-</p>#}
 
 {% set courseMissingSpecialisms = record.courseDetails | subjectsAreIncomplete %}
 
 {% set courseNeedsToBeConfirmed = record.courseDetails | courseNeedsToBeConfirmed %}
 
-{% set courseDetailsHref = "course-details/confirm-course" if courseNeedsToBeConfirmed else "course-details/confirm" %}
+{# User has changed route, so course details have been wiped - start as if fresh #}
+{% if not record.courseDetails %}
+  {% set courseDetailsHref = "course-details" %}
+
+{# Fresh Apply draft - course needs confirming, then specialisms / dates, etc #}
+{% elseif courseNeedsToBeConfirmed %}
+  {% set courseDetailsHref = "course-details/confirm-course" %}
+
+{# Returning to existing section #}
+{% else %}
+  {% set courseDetailsHref = "course-details/confirm" %}
+{% endif %}
 
 {{ appTaskList({
   classes: "govuk-!-margin-bottom-8",


### PR DESCRIPTION
Apply drafts don't currently let you freely change the route. They let you change the course and pick other publish courses on other routes, but if the thing you want isn't listed, you're stuck.

This introduces a route selection ui similar to how manual drafts work - as part of the inset text. Similar to manual drafts, changing this clears out course information (I don't necessarily like this, but keeping this change minimal).

Other changes:

* Inset text tweaked
* When the course is deleted, inset text updated so it doesn't refer to the course
* If no course, point the task list section at our standard chooser journey (pick a course if publish courses, else manual)
* Inset text introduced on the check record page
* On the publish chooser page, the manual option has been updated to `Enter course details manually`

Inset text on new Apply draft:

<img width="691" alt="Screenshot 2021-10-26 at 14 19 23" src="https://user-images.githubusercontent.com/2204224/138887164-86b8fab6-84e5-4fd2-b59b-964225127e36.png">

Inset text after changing course (so course info wiped):
<img width="688" alt="Screenshot 2021-10-26 at 14 19 32" src="https://user-images.githubusercontent.com/2204224/138887244-1eee31aa-5c81-4829-bd3d-e864ae76b0bb.png">

New manual radio text:
<img width="700" alt="Screenshot 2021-10-26 at 14 20 21" src="https://user-images.githubusercontent.com/2204224/138887297-e53e73e0-1064-49e2-b24a-56c5d7cf0a68.png">


