### PR TITLE
Use provider code in provider row

### DIFF
--- a/app/views/_includes/summary-cards/trainee-progress.html
+++ b/app/views/_includes/summary-cards/trainee-progress.html
@@ -1,9 +1,18 @@
+{% set providerText %}
+  {% if record.provider %}
+    {{record.provider}} (C85)
+  {% else %}
+    Not provided
+  {% endif %}
+{% endset %}
+
+
 {% set providerRow = {
   key: {
     text: "Provider"
   },
   value: {
-    text: record.provider or "Not provided"
+    text: providerText
   },
   actions: {
     items: [


### PR DESCRIPTION
Adds the Publish provider code to the provider row for support. Code is hardcoded for now.

<img width="1067" alt="Screenshot 2021-11-02 at 13 56 25" src="https://user-images.githubusercontent.com/2204224/139910789-474ca6c0-887b-4a0a-8a5a-774f7170e4b8.png">
