### PR TITLE
Be explicit about provider type

### DIFF
--- a/app/views/_includes/summary-cards/trainee-progress.html
+++ b/app/views/_includes/summary-cards/trainee-progress.html
@@ -9,7 +9,7 @@
 
 {% set providerRow = {
   key: {
-    text: "Provider"
+    text: "Accrediting provider"
   },
   value: {
     text: providerText


### PR DESCRIPTION
Feels better to be explicit about the provider type we're showing.

<img width="1066" alt="Screenshot 2021-11-04 at 11 06 39" src="https://user-images.githubusercontent.com/2204224/140303789-7ef30529-a357-4af6-84d5-97f803084495.png">
