### PR TITLE
Content change lead and employing schools

### DIFF
--- a/app/views/_includes/forms/schools/employing-school.html
+++ b/app/views/_includes/forms/schools/employing-school.html
@@ -35,7 +35,7 @@
     If the employing school is missing from the list, contact <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>
   </p>
 
-  <p class="govuk-body">You only need to provide an employing school if the trainee is employed or funded by a state school</p>
+  <p class="govuk-body">You do not need to provide an employing school if the trainee is employed or funded privately.</p>
 
   {{ govukCheckboxes({
     items: [
@@ -48,7 +48,7 @@
 {% endset %}
 
 {{ govukDetails({
-  summaryText: "Trainee is not at a state school or employing school is not listed",
+  summaryText: "Employing school is not listed, or the trainee is employed or funded privately",
   html: detailsHtml,
   open: true if record.schools.employingSchool.notApplicable == "true"
 }) }}

--- a/app/views/_includes/forms/schools/lead-school.html
+++ b/app/views/_includes/forms/schools/lead-school.html
@@ -37,7 +37,7 @@
     If the lead school is missing from the list, contact <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>
   </p>
 
-  <p class="govuk-body">You only need to provide a lead school if the trainee is employed or funded by a state school</p>
+  <p class="govuk-body">You do not need to provide a lead school if the trainee is employed or funded privately.</p>
 
   {{ govukCheckboxes({
     items: [
@@ -50,7 +50,7 @@
 {% endset %}
 
 {{ govukDetails({
-  summaryText: "Trainee is not at a state school or lead school is not listed",
+  summaryText: "Lead school is not listed, or the trainee is employed or funded privately",
   html: detailsHtml,
   open: true if record.schools.leadSchool.notApplicable == "true"
 }) }}


### PR DESCRIPTION
Content changes to employing and lead school pages.

What we have in production at the moment isn't quite right - the copy within the details component implies that the funding is coming from the school when it's actually coming from DfE. It should also state that lead/employing school is not applicable for employed trainees.

Also changed the details link copy to match the new copy within the details component. And re-ordered, so the missing school copy comes first which matches how it's presented within the component.

Ideally, details link copy should be short and I considered 'Help with lead school' and 'Lead school guidance' but because there are multiple things we're conveying here, and potentially they need to check the box, I think it needed to be more descriptive.

Does mean that the details link for employing goes to 2 lines!
![Screenshot 2021-11-04 at 14 23 12](https://user-images.githubusercontent.com/54059249/140387255-da9f4ed1-59e2-429a-afdb-1e80cc065a17.png)

