### PR TITLE
Show start year filter on drafts page

### DIFF
--- a/app/views/drafts.html
+++ b/app/views/drafts.html
@@ -49,11 +49,12 @@
 
 {% set filterOptionsHtml %}
 
-  {# Cycles probably not relevant for drafts? #}
-  {# {% include "_includes/filter-panel/cycles.njk" %} #}
+
   {% include "_includes/filter-panel/all-providers.njk" %}
 
   {% include "_includes/filter-panel/completeStatus.njk" %}
+
+  {% include "_includes/filter-panel/cycles.njk" %}
 
   {% include "_includes/filter-panel/source.njk" %}
 


### PR DESCRIPTION
The drafts page didn't originally have a year filter. At the time I thought it wasn't relevant - but I could see that with Apply applications coming in earlier than anticipated, being able to filter by start year would be helpful.