### PR TITLE
Fix for invalid courses being suggested

### DIFF
--- a/app/views/_includes/forms/course-details/pick-course.html
+++ b/app/views/_includes/forms/course-details/pick-course.html
@@ -149,7 +149,7 @@ defer to an id if one exists. #}
   }) }}
 
   {# Always in this route until we design a better journey for many courses #}
-  {% if providerCourses | length < 25 %}
+  {% if providerCourses | length < 100 %}
 
     {{ providerHasFewPublishCourses | safe }}
 


### PR DESCRIPTION
Fixes two bugs:
* Was showing the autocomplete when there were 25 courses or more - this design isn't finished yet so shouldn't have been showing.
* Where a user picks a course from year A, then goes back to change the year to year B, the previous course details were preserved - this crashed as an invalid year would get suggested in the autocomplete. The fix is to check of the *just* chosen year matches the year on the saved course. If they don't match, we wipe the course details.