### PR TITLE
Change default year

### DIFF
--- a/app/data/years.js
+++ b/app/data/years.js
@@ -14,7 +14,7 @@ let defaultVisibleYears = [
 
 let currentAcademicYear = "2021 to 2022"
 
-let defaultCourseYear = "2022"
+let defaultCourseYear = "2021"
 // defaultCourseYear = null
 
 // The first year in the range


### PR DESCRIPTION
This was accidentally set on next cycle, which is probably premature for November of the current cycle.