### PR TITLE
Link between draft and registered trainee search results

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -22,6 +22,9 @@ router.all('*', function(req, res, next){
     res.locals.referrer = req.query.referrer.split(',')
   }
   res.locals.query = req.query
+  res.locals.queryString = url.format({
+            query: req.query,
+          })
   res.locals.flash = req.flash('success') // pass through 'success' messages only
   res.locals.currentPageUrl = url.parse(req.url).pathname
 

--- a/app/routes/records-list-routes.js
+++ b/app/routes/records-list-routes.js
@@ -326,14 +326,19 @@ module.exports = router => {
     // console.log(req.query)
     // if (!hasFilters) filteredRecords = filteredRecords.filter(record => record.academicYear == "2021 to 2022")
 
-    // All records except drafts
-    filteredRecords = objectFilters.removeWhere(filteredRecords, 'status', "Draft")
+    // Sort records by sortOrder, defaulting to updatedDate
+    filteredRecords = utils.sortRecordsBy(filteredRecords, (req?.query?.sortOrder || 'updatedDate'))
 
     // Search traineeId and full name
     filteredRecords = utils.filterRecordsBySearchTerm(filteredRecords, searchQuery)
 
-    // Sort records by sortOrder, defaulting to updatedDate
-    filteredRecords = utils.sortRecordsBy(filteredRecords, (req?.query?.sortOrder || 'updatedDate'))
+
+    // All records except drafts
+    let draftRecords = utils.filterRecordsBy(filteredRecords, 'status', "Draft")
+    let registeredRecords = objectFilters.removeWhere(filteredRecords, 'status', "Draft")
+    let draftRecordsCount = draftRecords.length
+
+
 
     // Truncate records in case there's lots - and as we don't have working pagination
     filteredRecords = filteredRecords.slice(0, 204)
@@ -341,7 +346,8 @@ module.exports = router => {
     res.render('records', {
       filteredRecords,
       hasFilters,
-      selectedFilters
+      selectedFilters,
+      draftRecordsCount
     })
   })
 
@@ -365,20 +371,22 @@ module.exports = router => {
     let filteredRecords = utils.filterRecords(data.records, data, filters)
 
     // Only drafts
-    filteredRecords = utils.filterRecordsBy(filteredRecords, 'status', "Draft")
-
-    // Search traineeId and full name
-    filteredRecords = utils.filterRecordsBySearchTerm(filteredRecords, searchQuery)
 
     // Sort records by sortOrder, defaulting to updatedDate
     filteredRecords = utils.sortRecordsBy(filteredRecords, (req?.query?.sortOrder || 'updatedDate'))
 
+    // Search traineeId and full name
+    filteredRecords = utils.filterRecordsBySearchTerm(filteredRecords, searchQuery)
 
+    let draftRecords = utils.filterRecordsBy(filteredRecords, 'status', "Draft")
+    let registeredRecords = objectFilters.removeWhere(filteredRecords, 'status', "Draft")
+    let registeredRecordsCount = registeredRecords.length
 
     res.render('drafts', {
-      filteredRecords,
+      filteredRecords: draftRecords,
       hasFilters,
-      selectedFilters
+      selectedFilters,
+      registeredRecordsCount,
     })
   })
 

--- a/app/views/_components/filter-page/template.njk
+++ b/app/views/_components/filter-page/template.njk
@@ -65,9 +65,9 @@
                 </label>
                 <div class="gem-c-search__item-wrapper gem-c-search--on-white">
                   <input class="govuk-input" id="search" name="searchQuery" type="text" value="{{query.searchQuery}}">
-                  {# <div class="gem-c-search__item gem-c-search__submit-wrapper">
+                  <div class="gem-c-search__item gem-c-search__submit-wrapper">
                     <button type="submit" class="gem-c-search__submit">Search</button>
-                  </div> #}
+                  </div>
                 </div>
               </div>
 

--- a/app/views/drafts.html
+++ b/app/views/drafts.html
@@ -231,8 +231,23 @@
     {% include "_includes/pagination.njk" %}
 
   {% else %}
-    <h2 class="govuk-heading-m">No records found</h2>
+    <h2 class="govuk-heading-m">No draft records found</h2>
     <p class="govuk-body">Try <a href="/records">clearing your search and filters</a>.</p>
+  {% endif %}
+
+  {% if registeredRecordsCount %}
+    {% set insetHtml %}
+      <p class="govuk-body">
+        <a href="/records{{queryString}}">
+          There {{ "are" | pluralise(registeredRecordsCount) }} {{registeredRecordsCount}}{{ " more" if filteredRecords | length}} {{ "result" | pluralise(registeredRecordsCount) }} in your registered trainees.
+        </a>
+      </p>
+    {% endset %}
+
+    {{ govukInsetText({
+      html: insetHtml
+    }) }}
+
   {% endif %}
 {% endset %}
 

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -167,6 +167,21 @@
     <h2 class="govuk-heading-m">No records found</h2>
     <p class="govuk-body">Try <a href="/records">clearing your search and filters</a>.</p>
   {% endif %}
+
+  {% if draftRecordsCount and isAuthorised('viewDrafts') %}
+    {% set insetHtml %}
+      <p class="govuk-body">
+        <a href="/drafts{{queryString}}">
+          There {{ "are" | pluralise(draftRecordsCount) }} {{draftRecordsCount}}{{ " more" if filteredRecords | length}} {{ "result" | pluralise(draftRecordsCount) }} in your registered trainees.
+        </a>
+      </p>
+    {% endset %}
+
+    {{ govukInsetText({
+      html: insetHtml
+    }) }}
+
+  {% endif %}
 {% endset %}
 
 

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -172,7 +172,7 @@
     {% set insetHtml %}
       <p class="govuk-body">
         <a href="/drafts{{queryString}}">
-          There {{ "are" | pluralise(draftRecordsCount) }} {{draftRecordsCount}}{{ " more" if filteredRecords | length}} {{ "result" | pluralise(draftRecordsCount) }} in your registered trainees.
+          There {{ "are" | pluralise(draftRecordsCount) }} {{draftRecordsCount}}{{ " more" if filteredRecords | length}} {{ "result" | pluralise(draftRecordsCount) }} in your draft trainees.
         </a>
       </p>
     {% endset %}


### PR DESCRIPTION
We saw in user research a user search for a user by using the search input for the user's name. However the record they were looking for was for an existing, registered trainee, and they were in the drafts page. As a result they got no results.

The drafts page and registered trainee pages both look similar. A consequence / downside of having scoped pages like this is you might be on the wrong one.

This tries to help a little by adding a link to the other page if there are results there.

<img width="1050" alt="Screenshot 2021-12-02 at 17 54 41" src="https://user-images.githubusercontent.com/2204224/144476967-4be86670-faa5-4df8-b121-73653c1fd2d4.png">

Notes about the language:
* Multiple bits are pluralised depending on if there are 1 result or more.
* If there are results on the current page, then the word `more` is added - `There is 1 result` > `There is 1 more result`

