### PR TITLE
Fix bug with drafts appearing on registered trainees tab

### DIFF
--- a/app/routes/records-list-routes.js
+++ b/app/routes/records-list-routes.js
@@ -344,7 +344,7 @@ module.exports = router => {
     filteredRecords = filteredRecords.slice(0, 204)
 
     res.render('records', {
-      filteredRecords,
+      filteredRecords: registeredRecords,
       hasFilters,
       selectedFilters,
       draftRecordsCount


### PR DESCRIPTION
This was sending the wrong set of records to the view.