### PR TITLE
Lead school guidance

### DIFF
--- a/app/views/guidance.html
+++ b/app/views/guidance.html
@@ -25,7 +25,7 @@
 
 <p class="govuk-body">In the funding information, you can view a summary of past and predicted payments. There’s a breakdown of monthly payments and a breakdown of bursaries, scholarships and grants.</p>
 
-<p class="govuk-body">The access for lead schools is view only. They cannot:</p>
+<p class="govuk-body">The access for lead schools is view only. As a lead school, you cannot:</p>
 <ul class="govuk-list govuk-list--bullet">
   <li>add trainee records</li>
   <li>change trainee records</li>

--- a/app/views/guidance.html
+++ b/app/views/guidance.html
@@ -19,6 +19,22 @@
 
 <p class="govuk-body">DfE also uses the data for funding, the ITT census and analysis to inform policy development.</p>
 
+<h3 class="govuk-heading-m">Register access for lead schools</h3>
+
+<p class="govuk-body">Lead schools can access Register trainee teachers to view funding information and trainee records.</p>
+
+<p class="govuk-body">In the funding information, you can view a summary of past and predicted payments. There’s a breakdown of monthly payments and a breakdown of bursaries, scholarships and grants.</p>
+
+<p class="govuk-body">The access for lead schools is view only. They cannot:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>add trainee records</li>
+  <li>change trainee records</li>
+  <li>view draft trainee records</li>
+  <li>view a trainee’s diversity information</li>
+  <li>view a trainee’s gender</li>
+  <li>view a trainee’s nationality</li>
+</ul>
+
 <h3 class="govuk-heading-m">Adding trainee records</h3>
 
 <p class="govuk-body">You can add a trainee record manually, which means that you input all of the required data from your own records.</p>


### PR DESCRIPTION
Update guidance for lead school view-only access.

Adds information to the guidance section to inform users about lead school access, what they can and cannot view and that they cannot edit. 