### PR TITLE
Add filters for undergrad / postgrad

### DIFF
--- a/app/data/training-route-data.js
+++ b/app/data/training-route-data.js
@@ -88,6 +88,7 @@ let defaultRouteData = {
 let baseRouteData = {
   "Assessment only": {
     defaultEnabled: true,
+    courseLevel: "Postgraduate",
     sections: [
       // 'trainingDetails',
       'courseDetails',
@@ -101,6 +102,7 @@ let baseRouteData = {
   },
   "Provider-led (undergrad)": {
     defaultEnabled: true,
+    courseLevel: "Undergraduate",
     sections: [
       // 'trainingDetails',
       'courseDetails',
@@ -132,6 +134,7 @@ let baseRouteData = {
   },
   "Provider-led (postgrad)": {
     defaultEnabled: true,
+    courseLevel: "Postgraduate",
     hasAllocatedPlaces: true,
     fields: [
       "studyMode",
@@ -173,6 +176,7 @@ let baseRouteData = {
   },
   "School direct (salaried)": {
     defaultEnabled: true,
+    courseLevel: "Postgraduate",
     sections: [
       // 'trainingDetails',
       'courseDetails',
@@ -225,6 +229,7 @@ let baseRouteData = {
   },
   "School direct (fee funded)": {
     defaultEnabled: true,
+    courseLevel: "Postgraduate",
     hasAllocatedPlaces: true,
     sections: [
       // 'trainingDetails',
@@ -279,6 +284,7 @@ let baseRouteData = {
   "Teach first (postgrad)": {},
   "Teaching apprenticeship (postgrad)": {
     defaultEnabled: true,
+    courseLevel: "Postgraduate",
     sections: [
       // 'trainingDetails',
       'courseDetails',
@@ -325,6 +331,7 @@ let baseRouteData = {
   },
   "Opt-in (undergrad)": {
     defaultEnabled: true,
+    courseLevel: "Undergraduate",
     sections: [
       // 'trainingDetails',
       'courseDetails',
@@ -358,6 +365,7 @@ let baseRouteData = {
   },
   "Early years (salaried)": {
     defaultEnabled: true,
+    courseLevel: "Postgraduate",
     sections: [
       // 'trainingDetails',
       'courseDetails',
@@ -389,6 +397,7 @@ let baseRouteData = {
   },
   "Early years (postgrad)": {
     defaultEnabled: true,
+    courseLevel: "Postgraduate",
     sections: [
       // 'trainingDetails',
       'courseDetails',
@@ -437,6 +446,7 @@ let baseRouteData = {
   },
   "Early years (assessment only)": {
     defaultEnabled: true,
+    courseLevel: "Postgraduate",
     sections: [
       // 'trainingDetails',
       'courseDetails',
@@ -454,6 +464,7 @@ let baseRouteData = {
   },
   "Early years (undergrad)": {
     defaultEnabled: true,
+    courseLevel: "Undergraduate",
     sections: [
       // 'trainingDetails',
       'courseDetails',
@@ -475,6 +486,7 @@ let baseRouteData = {
   },
   "High potential initial teacher training (HPITT)": {
     disableForNewDrafts: true, // we want to show trainees on this route, but not allow new ones
+    courseLevel: "Postgraduate",
     defaultEnabled: false,
     sections: [
       // 'trainingDetails',

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -220,6 +220,11 @@ exports.getCoursePhase = record => {
   return matchedPhase
 }
 
+// Undergraduate / Postgraduate
+exports.getCourseLevel = record => {
+  return trainingRoutes?.[record.route]?.courseLevel || false
+}
+
 // Used to set the right qualification on a record
 exports.setCourseDefaults = record => {
   let route = record?.route
@@ -1149,6 +1154,10 @@ exports.filterRecords = (records, data, filters = {}) => {
       let completeStatus = (exports.recordIsComplete(record, data)) ? 'Complete' : 'Incomplete'
       return filters.completeStatus.includes(completeStatus)
     })
+  }
+
+  if (filters.courseLevel){
+    filteredRecords = filteredRecords.filter(record => filters.courseLevel.includes(exports.getCourseLevel(record)))
   }
 
   // Apply or manual

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -901,6 +901,15 @@ exports.isApprenticeship = record => {
   return record?.route == "Teaching apprenticeship (postgrad)"
 }
 
+// Course levels
+
+exports.isUndergraduate = data => {
+  return exports.getCourseLevel(data) == "Undergraduate"
+}
+
+exports.isPostgraduate= data => {
+  return exports.getCourseLevel(data) == "Postgraduate"
+}
 // Phases
 
 // Unlike the other phases, this is probably reliable - as it checcks the route rather than the age

--- a/app/routes/records-list-routes.js
+++ b/app/routes/records-list-routes.js
@@ -25,22 +25,24 @@ const getFilters = req => {
 
   // Copy the query
   let query = Object.assign({}, req.query)
-  // let searchQuery = query?.searchQuery || ""
-  // let searchQueryLowercase = searchQuery.toLowerCase()
 
+  // Following code is awkward - had some issues with saving objects in query string and then
+  // with _unchecked values appearing. So it's set as top level data, then cleaned and remapped
+  // to an object
 
   // Needed because this is coming via query string and not auto-data store
   // And these values may contain '_unchecked'
   let filtersToClean = [
-  'filterStatus',
-  'filterCompleteStatus',
-  'filterSource',
-  'filterPhase',
-  'filterStudyMode',
-  'filterCycle',
-  'filterUserProviders',
   'filterAllProviders',
-  'filterTrainingRoutes']
+  'filterCompleteStatus',
+  'filterCourseLevel',
+  'filterCycle',
+  'filterPhase',
+  'filterSource',
+  'filterStatus',
+  'filterStudyMode',
+  'filterTrainingRoutes',
+  'filterUserProviders']
   filtersToClean.forEach(filter => query[filter] = cleanInputData(query[filter]))
 
   // Remap to an object so we can pass it to the filterRecords function
@@ -49,6 +51,7 @@ const getFilters = req => {
     status: query.filterStatus,
     source: query.filterSource,
     completeStatus: query.filterCompleteStatus,
+    courseLevel: query.filterCourseLevel,
     cycle: query.filterCycle,
     phase: query.filterPhase,
     studyMode: query.filterStudyMode,
@@ -65,6 +68,7 @@ const getFilters = req => {
 const getHasFilters = (filters, searchQuery) => {
   return !!(filters.status) 
   || !!(filters.completeStatus)
+  || !!(filters.courseLevel)
   || !!(filters.source)
   || !!(filters.phase)
   || !!(filters.studyMode)
@@ -174,6 +178,24 @@ const getSelectedFilters = req => {
         newQuery.filterSource = filters.source.filter(a => a != source)
         return {
           text: source,
+          href: url.format({
+            pathname,
+            query: newQuery,
+          })
+        }
+      })
+    })
+  }
+
+  if (filters.courseLevel) {
+    selectedFilters.categories.push({
+      heading: { text: 'Course level' },
+      items: filters.courseLevel.map((courseLevel) => {
+
+        let newQuery = Object.assign({}, query)
+        newQuery.filtercourseLevel = filters.courseLevel.filter(a => a != courseLevel)
+        return {
+          text: courseLevel,
           href: url.format({
             pathname,
             query: newQuery,

--- a/app/views/_includes/filter-panel/course-level.njk
+++ b/app/views/_includes/filter-panel/course-level.njk
@@ -1,0 +1,20 @@
+{{ govukCheckboxes({
+  classes: "govuk-checkboxes--small js-auto-submit",
+  fieldset: {
+    legend: {
+      text: "Course level",
+      isPageHeading: false,
+      classes: "govuk-fieldset__legend--s"
+    }
+  },
+  items: [
+    {
+      text: "Undergraduate",
+      checked: checked(query.filterCourseLevel, "Undergraduate")
+    },
+    {
+      text: "Postgraduate",
+      checked: checked(query.filterCourseLevel, "Postgraduate")
+    }
+  ]
+} | decorateAttributes(data, "data.filterCourseLevel"))}}

--- a/app/views/drafts.html
+++ b/app/views/drafts.html
@@ -63,6 +63,8 @@
 
   {% include "_includes/filter-panel/phase.njk" %}
 
+  {% include "_includes/filter-panel/course-level.njk" %}
+
   {% include "_includes/filter-panel/subjects.njk" %}
 
 

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -63,6 +63,8 @@
 
   {% include "_includes/filter-panel/phase.njk" %}
 
+  {% include "_includes/filter-panel/course-level.njk" %}
+
   {% include "_includes/filter-panel/signed-in-providers.njk" %}
 
   {% include "_includes/filter-panel/training-routes.njk" %}


### PR DESCRIPTION
Explicitly sets that all routes are either undergraduate or postgraduate.

Adds a filter for undergraduate / postgraduate on the basis of the route set.

Adding this in preparation of doing different flows depending on if the trainee is undergrad or postgrad.

<img width="1086" alt="Screenshot 2021-12-08 at 16 59 41" src="https://user-images.githubusercontent.com/2204224/145250788-7a5a8352-98ab-4731-b8e2-b8be3dcea177.png">


