### PR TITLE
Don’t ask for return date if reinstating trainee before their ITT starts

### DIFF
--- a/app/views/_includes/record-actions.njk
+++ b/app/views/_includes/record-actions.njk
@@ -1,7 +1,7 @@
 <div class="record-actions__links">
   <p class="govuk-body govuk-!-margin-bottom-0">
-    {% if (record | isDeferred) %}
-      <a href="{{referrer}}/reinstate" class="govuk-link--no-visited-state">Reinstate</a> or <a href="{{ referrer + '/withdraw' | addReferrer(referrer) }}" class="govuk-link--no-visited-state"> withdraw</a> this trainee
+    {% if (record | isDeferred ) %}
+      <a {% if (record | ittInTheFuture ) %}href="{{referrer}}/reinstate/confirm" {% else %}href="{{referrer}}/reinstate" {% endif %} class="govuk-link--no-visited-state">Reinstate</a> or <a href="{{ referrer + '/withdraw' | addReferrer(referrer) }}" class="govuk-link--no-visited-state"> withdraw</a> this trainee
     {% elseif (record | ittInTheFuture) %}
       <a href="{{ referrer + '/delete/confirm' | addReferrer(referrer) }}" class="govuk-link--no-visited-state">Delete this record</a>, or <a href="{{ referrer + '/defer/confirm'  | addReferrer(referrer) }}" class="govuk-link--no-visited-state">defer this trainee</a>
     {% elseif (record | ittStartedButNoCommencementDate) %}

--- a/app/views/_includes/summary-cards/reinstate-details.html
+++ b/app/views/_includes/summary-cards/reinstate-details.html
@@ -1,10 +1,20 @@
+{% set reinstateDateText %}
+  {% if record | ittInTheFuture %}
+    Trainee returned before their ITT started
+  {% elseif record | traineeStarted %}
+    {{ record.reinstateDate | govukDate }}
+  {% else %}
+    Not provided
+  {% endif %}
+{% endset %}
+
 {% set reinstateDetailsRows = [
   {
     key: {
       text: "Date of return"
     },
     value: {
-      text: record.reinstateDate | govukDate or 'Not provided'
+      text: reinstateDateText
     },
     actions: {
       items: [
@@ -29,5 +39,3 @@
   titleText: "Reinstatement details",
   html: reinstateDetailsHtml
 }) }}
-  
-


### PR DESCRIPTION
- reinstate skips 'When did the trainee return?' question if ITT in the future
- reinstate summary shows 'Trainee returned before their ITT started' if the trainee returns before the ITT start date