### PR TITLE
Service news and updates last at least 1 month  -- take 2

### DIFF
--- a/app/data/service-updates.yaml
+++ b/app/data/service-updates.yaml
@@ -2,6 +2,13 @@
 
 items:
 
+  - date: '2021-12-10'
+    title: How Register collects initial teacher training (ITT) start dates has changed
+    content: >-
+      When registering a trainee we were always when the trainee had started their ITT, even if the ITT had not started. Now, we will only ask when the trainee started after their ITT has started.
+
+      You’ll need to provide a start date before you can recommend a trainee for QTS or EYTS.
+
   - date: '2021-12-03'
     title: The Department for Education (DfE) has published the provisional data for the 2021 initial teacher training (ITT) census
     content: >-

--- a/app/views/_includes/app-service-updates.html
+++ b/app/views/_includes/app-service-updates.html
@@ -1,5 +1,5 @@
 <section id="{{ update.title | slugify }}" class="app-markdown">
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
     {{ update.title }}
   </h2>
   <p class="govuk-body govuk-!-margin-bottom-2">

--- a/app/views/start-page.html
+++ b/app/views/start-page.html
@@ -62,7 +62,7 @@
       Latest news and updates
     </h2>
     {% for update in data.serviceUpdates.items -%}
-      {%- if loop.index == 1 -%}
+      {%- if (update.date | isInLast(1, "month")) or (loop.index == 1) -%}
         {% include "_includes/app-service-updates.html" %}
       {%- endif -%}
     {%- endfor %}


### PR DESCRIPTION
- start page stil always show the most recents update
- if an update is less than 1 month old, it will appear on the start page
- placeholder update content