### PR TITLE
Defer withdraw check new start date

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -106,8 +106,8 @@ settings.viewAsAdmin = 'false'
 
 // The ‘active’ provider for the current user if using hat model
 // Must be one of the ones in settings.userProviders
-// settings.userActiveProvider = "Coventry University"
-settings.userActiveProvider = "Beam Primary School"
+settings.userActiveProvider = "Coventry University"
+// settings.userActiveProvider = "Beam Primary School"
 
 settings.providerType = "accrediting-provider"
 

--- a/app/filters/dates.js
+++ b/app/filters/dates.js
@@ -170,6 +170,31 @@ filters.toDateArray = (date) => {
 
 /*
   ====================================================================
+  toDateObject
+  --------------------------------------------------------------------
+  Convert an array to date
+  ====================================================================
+
+  Usage:
+
+  {{ "[05, 06, 2021]" | toDateObject }}
+  = Sat Jun 05 2021 00:00:00 GMT+0100 (British Summer Time)
+
+  {{ "2021-06-05T19:21:48.168Z" | toDateObject }}
+  = Sat Jun 05 2021 20:21:48 GMT+0100 (British Summer Time)
+
+*/
+
+filters.toDateObject = (date) => {
+  if (!date) return false
+  if (_.isArray(date)) return filters.arrayToDateObject(date)
+  else {
+    return moment(date).toDate()
+  }
+}
+
+/*
+  ====================================================================
   prettyMonth
   --------------------------------------------------------------------
   Return month names from numbers.

--- a/app/views/_includes/summary-cards/trainee-progress.html
+++ b/app/views/_includes/summary-cards/trainee-progress.html
@@ -251,7 +251,7 @@
 
 {% set traineeStartDateRow = {
   key: {
-    text: "Trainee’s start date"
+    text: "Trainee start date"
   },
   value: {
     text: commencementDateLabel
@@ -261,7 +261,7 @@
       {
         href: recordPath + "/trainee-start-date" | addReferrer(referrer),
         text: "Change",
-        visuallyHiddenText: "trainee’s start date"
+        visuallyHiddenText: "trainee start date"
       }
     ]
   } if canAmend and record.courseDetails.startDate | isInPast and not record | isDeferred

--- a/app/views/_includes/summary-cards/training-details/trainee-start-date.html
+++ b/app/views/_includes/summary-cards/training-details/trainee-start-date.html
@@ -13,7 +13,7 @@
 {% set recordBaseRows = [
   {
     key: {
-      text: "Trainee’s start date"
+      text: "Trainee start date"
     },
     value: {
       text: traineeStartDate
@@ -23,7 +23,7 @@
         {
           href: recordPath + "/trainee-start-date" | addReferrer(referrer),
           text: "Change",
-          visuallyHiddenText: "trainee’s start date"
+          visuallyHiddenText: "trainee start date"
         }
       ]
     } if canAmend

--- a/app/views/_includes/summary-cards/training-details/training-details.html
+++ b/app/views/_includes/summary-cards/training-details/training-details.html
@@ -52,7 +52,7 @@
 
 {% set traineeStartDateRow = {
     key: {
-      text: "Trainee’s start date"
+      text: "Trainee start date"
     },
     value: {
       text: commencementDateLabel
@@ -62,7 +62,7 @@
         {
           href: recordPath + "/training-details" | addReferrer(referrer),
           text: "Change",
-          visuallyHiddenText: "trainee’s start date"
+          visuallyHiddenText: "trainee start date"
         }
       ]
     } if canAmend

--- a/app/views/_includes/summary-cards/withdraw-details.html
+++ b/app/views/_includes/summary-cards/withdraw-details.html
@@ -20,6 +20,23 @@
 {% set withdrawDetailsRows = [
   {
     key: {
+      text: "Trainee start date"
+    },
+    value: {
+      text: record.trainingDetails.commencementDate | govukDate
+    },
+    actions: {
+      items: [
+        {
+          href: recordPath + "/withdraw/did-trainee-start" | addReferrer(referrer),
+          text: "Change",
+          visuallyHiddenText: "trainee start date"
+        }
+      ]
+    }
+  },
+  {
+    key: {
       text: "Date of withdrawal"
     },
     value: {

--- a/app/views/record/defer/when-did-trainee-start.html
+++ b/app/views/record/defer/when-did-trainee-start.html
@@ -1,5 +1,7 @@
 {% extends "_templates/_record-form.html" %}
 
+{% set traineeStartDate = data.record.trainingDetails.commencementDate or false %}
+
 {% if traineeStartDate %}
   {% set pageHeading = "When did the trainee start their ITT?" %}
 {% else %}

--- a/app/views/record/delete/when-did-trainee-start.html
+++ b/app/views/record/delete/when-did-trainee-start.html
@@ -1,5 +1,7 @@
 {% extends "_templates/_record-form.html" %}
 
+{% set traineeStartDate = data.record.trainingDetails.commencementDate or false %}
+
 {% if traineeStartDate %}
   {% set pageHeading = "When did the trainee start their ITT?" %}
 {% else %}

--- a/app/views/record/withdraw/when-did-trainee-start.html
+++ b/app/views/record/withdraw/when-did-trainee-start.html
@@ -1,8 +1,12 @@
 {% extends "_templates/_record-form.html" %}
 
-{% set pageHeading %}
-  Did the trainee start their ITT on time?
-{% endset %}
+{% set traineeStartDate = data.record.trainingDetails.commencementDate or false %}
+
+{% if traineeStartDate %}
+  {% set pageHeading = "When did the trainee start their ITT?" %}
+{% else %}
+  {% set pageHeading = "Did the trainee start their ITT on time?" %}
+{% endif %}
 
 {% set startConfirmed = true %}
 


### PR DESCRIPTION
this pr contains some stuff from that got reverted:
- using 'trainee start date' not 'trainee’s start date'
- bug that meant heading for when did the trainee start didn't change with context

adds
- update to change flow for defer/withdraw — if the user sets a new trainee start date that is after the deferral/withdrawal date then they will be asked for the deferral/withdrawal date again