### PR TITLE
splits tables by month if there are more than 6 columns

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -226,7 +226,7 @@ span.summary-validation-symbol {
 
 // column widths for tables
 // app-table__column-xx
-$sizes: 40, 35, 20, 15, 10;
+$sizes: 70, 53, 35, 20, 15, 10;
 
 @each $size in $sizes {
   .app-table__column-#{$size} {

--- a/app/data/funding.js
+++ b/app/data/funding.js
@@ -20,9 +20,13 @@ let monthlyFundingScitts = []
 monthlyFundingScittsArray.forEach(row => {
   let description = row[3]
   let monthlyPayments = row.slice(5, 17).map(value => parseInt(value))
+  let cumulativeMonthlyPayments = monthlyPayments.map((payment, index, array) => {
+    return array.slice(0, index + 1).reduce((a, b) => a + b, 0)
+  })
   monthlyFundingScitts.push({
     description,
-    monthlyPayments
+    monthlyPayments,
+    cumulativeMonthlyPayments
   })
 })
 
@@ -176,9 +180,13 @@ let monthlyFundingLeadSchools = []
 monthlyFundingLeadSchoolsArray.forEach(row => {
   let description = row[5]
   let monthlyPayments = row.slice(7, 19).map(value => parseInt(value))
+  let cumulativeMonthlyPayments = monthlyPayments.map((payment, index, array) => {
+    return array.slice(0, index + 1).reduce((a, b) => a + b, 0)
+  })
   monthlyFundingLeadSchools.push({
     description,
-    monthlyPayments
+    monthlyPayments,
+    cumulativeMonthlyPayments
   })
 })
 

--- a/app/views/funding/annual-payments-lead-school.html
+++ b/app/views/funding/annual-payments-lead-school.html
@@ -26,13 +26,11 @@
   {% set dataSource = dataSource | sort(attribute = "subject") %}
 
   {% set salaryHeadRow = [
-    { text: "Subject and route" },
-    { text: "Trainees",
-      classes: "app-table__column-15" },
-    { text: "Amount per trainee",
-      classes: "app-table__column-15" },
-    { text: "Total",
-      classes: "app-table__column-15" }
+    { text: "Subject and route",
+      classes: "app-table__column-53" },
+    { text: "Trainees" },
+    { text: "Amount per trainee" },
+    { text: "Total" }
   ] %}
 
   {% set total = 0 %}

--- a/app/views/funding/annual-payments-scitt.html
+++ b/app/views/funding/annual-payments-scitt.html
@@ -33,15 +33,9 @@
       classes: "app-table__column-35" },
     { text: "Lead school",
       classes: "app-table__column-35" },
-    { text: "Trainees",
-      classes: "app-table__column-10"
-     },
-    { text: "Amount per trainee",
-      classes: "app-table__column-10"
-     },
-    { text: "Total",
-      classes: "app-table__column-10"
-     }
+    { text: "Trainees" },
+    { text: "Amount per trainee" },
+    { text: "Total" }
   ] %}
   {% set ittBursaryTotal = 0 %}
   {% set ittBursaryRows = [] %}
@@ -194,7 +188,9 @@
           caption: "Summary",
           captionClasses: "govuk-table__caption--m",
           head: [
-            { text: "Payment type" },
+            { text: "Payment type",
+              classes: "app-table__column-70"
+             },
             { text: "Total" }
           ],
           rows: annualSummaryRows
@@ -249,16 +245,14 @@
           caption: "Early years ITT bursaries",
           captionClasses: "govuk-table__caption--m",
           head: [
-            { text: "Tier"
+            { text: "Tier",
+            classes: "app-table__column-53"
             },
-            { text: "Trainees",
-              classes: "app-table__column-15"
+            { text: "Trainees"
             },
-            { text: "Amount per trainee",
-              classes: "app-table__column-15"
+            { text: "Amount per trainee"
             },
-            { text: "Total",
-              classes: "app-table__column-15"
+            { text: "Total"
             }
           ],
           rows: eyIttBursaryRows

--- a/app/views/funding/monthly-payments.html
+++ b/app/views/funding/monthly-payments.html
@@ -16,7 +16,6 @@
   {% endif %}
   {% set dataSource = dataSource | sort(attribute = "description") %}
 
-  {# TODO #}
   {% if dataSource.length > 4 %}
     {% set tableClasses = "govuk-!-font-size-16" %}
   {% endif %}
@@ -53,6 +52,7 @@
   {% else %}
     {% set thisMonth = currentMonth() + 4 %}
   {% endif %}
+  {# {% set thisMonth = 11 %} #}
 
   {% for item in months %}
     {% set monthIndex = loop.index0 %}
@@ -100,6 +100,7 @@
     {% set summaryRows = summaryRows | push(summaryRowItems) %}
   {% endif %}
 
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <h2 class="govuk-heading-l">
@@ -123,11 +124,11 @@
         captionClasses: "govuk-table__caption--m",
         head: [
                 {
-                  text: "Payment type"
+                  text: "Payment type",
+                  classes: "app-table__column-70"
                 },
                 {
-                  text: "Amount",
-                  classes: "app-table__column-25"
+                  text: "Amount"
                 }
               ],
         rows: summaryRows
@@ -135,25 +136,139 @@
     </div>
   </div>
   <hr class="govuk-section-break govuk-section-break--m">
-  {{ govukTable({
-    caption: "Payments to " + currentMonth("nameOfMonth") + " " + currentYear(),
-    captionClasses: "govuk-table__caption--m",
-    classes: tableClasses,
-    head: headRow,
-    rows: rowsPast
-  }) }}
+  <div class="govuk-grid-row">
+    {% if dataSource.length < 6 %}
+      <div class="govuk-grid-column-full">
 
-  {# 11th month = July (12 months of the Academic year 0 indexed) #}
+        {# Single table showing all months #}
+        {{ govukTable({
+          caption: "Payments to " + currentMonth("nameOfMonth") + " " + currentYear(),
+          captionClasses: "govuk-table__caption--m",
+          classes: tableClasses,
+          head: headRow,
+          rows: rowsPast
+        }) }}
 
-  {% if thisMonth != 11 %}
-    <hr class="govuk-section-break govuk-section-break--m">
-    {{ govukTable({
-      caption: "Predicted payments",
-      captionClasses: "govuk-table__caption--m",
-      classes: tableClasses,
-      head: headRow,
-      rows: rowsFuture
-    }) }}
-  {% endif %}
+        {# 11th month = July (12 months of the Academic year 0 indexed) #}
+
+        {% if thisMonth != 11 %}
+          <hr class="govuk-section-break govuk-section-break--m">
+          {{ govukTable({
+            caption: "Predicted payments",
+            captionClasses: "govuk-table__caption--m",
+            classes: tableClasses,
+            head: headRow,
+            rows: rowsFuture
+          }) }}
+        {% endif %}
+      </div>
+    {% else %}
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+        {% set pastTables = [] %}
+        {% set futureTables = [] %}
+
+        {% for item in months %}
+          {% set monthTableRows  = [] %}
+          {% set monthIndex = loop.index0 %}
+          {% set monthTableCaption = months[monthIndex] %}
+          {% set monthTotal = 0 %}
+          {% set cumulativeMonthTotal = 0 %}
+          {% for item in dataSource %}
+            {% set rowIndex = loop.index0 %}
+            {% set paymentDescription = item.description | fixNamesFromFunding | sentenceCase | formatYearRange %}
+            {% set monthTotal = monthTotal + item.monthlyPayments[monthIndex] %}
+            {% set cumulativeMonthTotal = cumulativeMonthTotal + item.cumulativeMonthlyPayments[monthIndex] %}
+            {% if item.monthlyPayments[monthIndex] != "" %}
+              {% set amount = item.monthlyPayments[monthIndex] | currency %}
+            {% else %}
+              {% set amount = "–" %}
+            {% endif %}
+            {% if item.cumulativeMonthlyPayments[monthIndex] != "" %}
+              {% set cumulativeAmount = item.cumulativeMonthlyPayments[monthIndex] | currency %}
+            {% else %}
+              {% set cumulativeAmount = "–" %}
+            {% endif %}
+            {% set row = [
+              { text: paymentDescription | safe },
+              { text: amount, format: "numeric" },
+              { text: cumulativeAmount, format: "numeric" }
+            ] %}
+            {% set monthTableRows = monthTableRows | push(row) %}
+          {% endfor %}
+          {% set monthTableRows = monthTableRows | push([
+            { text: "Total", classes: "govuk-!-font-weight-bold" }, 
+            { text: monthTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" },
+            { text: cumulativeMonthTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
+          ])%}
+          {% if loop.index0 <= thisMonth and cumulativeMonthTotal != 0 %}
+            {% set monthTableHtml %}
+              {{ govukTable({
+                caption: monthTableCaption,
+                captionClasses: "govuk-table__caption--m",
+                classes: tableClasses,
+                head: [
+                  {
+                    text: "Payment type"
+                  },
+                  {
+                    text: "Amount",
+                    format: "numeric",
+                    classes: "app-table__column-15"
+                  },
+                  {
+                    text: "Total for payment type",
+                    format: "numeric",
+                    classes: "app-table__column-15"
+                  }
+                ],
+                rows: monthTableRows
+              }) }}
+            {% endset %}
+            {% set pastTables = pastTables | push(monthTableHtml) %}
+          {% elseif cumulativeMonthTotal != 0 %}
+            {% set monthTableHtml %}
+              {{ govukTable({
+                caption: monthTableCaption,
+                captionClasses: "govuk-table__caption--m",
+                classes: tableClasses,
+                head: [
+                  {
+                    text: "Payment type"
+                  },
+                  {
+                    text: "Amount",
+                    format: "numeric",
+                    classes: "app-table__column-15"
+                  },
+                  {
+                    text: "Total for payment type",
+                    format: "numeric",
+                    classes: "app-table__column-15"
+                  }
+                ],
+                rows: monthTableRows
+              }) }}
+            {% endset %}
+            {% set futureTables = futureTables | push(monthTableHtml) %}
+          {% endif %}
+        {% endfor %}
+
+
+
+        {# Table per month #}
+        <h3 class="govuk-heading-m">Payments to {{ currentMonth("nameOfMonth") }} {{ currentYear() }}</h3>
+        {% for item in pastTables %}
+          {{ item | safe }}
+        {% endfor %}
+        {% if thisMonth != 11 %}
+          <hr class="govuk-section-break govuk-section-break--m">
+          <h3 class="govuk-heading-m">Predicted payments</h3>
+          {% for item in futureTables %}
+            {{ item | safe }}
+          {% endfor %}
+        {% endif %}
+      {% endif %}
+    </div>
+  </div>
 
 {% endblock %}


### PR DESCRIPTION
Bit of a spike into how we could present funding data, if there is too many types of payment:

![localhost_3000_funding_monthly-payments(screenshot) (5)](https://user-images.githubusercontent.com/8417288/146576575-0b73576e-8d48-413f-bd8d-b503a753cd97.png)

Things to consider:
- its likely this would change mid-year (funding types get added throughout the year, is the disruption worth it?)
- the page is really long, we could use accordions?
- maybe this should be a table per funding stream (not per month)