### PR TITLE
Show historic source

### DIFF
--- a/app/data/generators/events.js
+++ b/app/data/generators/events.js
@@ -22,8 +22,8 @@ module.exports = (application) => {
     })
   }
 
-if (application.source == 'Apply'){
-  addEvent("Record imported from Apply")
+if ( application.source !== "Manual" ){
+  addEvent("Record imported from " +  application.source )
 }
 else {
   addEvent("Record created")

--- a/app/data/generators/source.js
+++ b/app/data/generators/source.js
@@ -9,12 +9,13 @@ module.exports = application => {
   else {
     if (trainingRouteData.applyRoutes.includes(application.route)){
       return weighted.select({
-        "Manual": 0.2,
-        "Apply": 0.7
+        "Manual": 0.1,
+        "HESA":   0.3,
+        "DTTP":   0.3,
+        "Apply":  0.3
       })
     }
     else return "Manual"
   }
-
 
 }

--- a/app/views/_includes/filter-panel/all-providers.njk
+++ b/app/views/_includes/filter-panel/all-providers.njk
@@ -1,40 +1,29 @@
-{% if data.isAdmin %}
+{% set providerItems = [] %}
 
-  {% set providerItems = [] %}
+{# Default state - first value is 'all' #}
+{% set providerItems = providerItems | push({
+  value: "All providers",
+  text: "All providers",
+  selected: true if (not query.filterAllProviders or query.filterAllProviders ==  "All providers")
+}) %}
 
-  {# Default state - first value is 'all' #}
+{% set allProviders = data.providers.accreditingProviders.all %}
+
+{% for provider in allProviders %}
   {% set providerItems = providerItems | push({
-    value: "All providers",
-    text: "All providers",
-    selected: true if (not query.filterAllProviders or query.filterAllProviders ==  "All providers")
+    value: provider.name,
+    text: provider.name,
+    selected: true if (provider.name == query.filterAllProviders)
   }) %}
+{% endfor %}
 
-  {% set allProviders = data.providers.accreditingProviders.all %}
-
-  {% for provider in allProviders %}
-    {% set providerItems = providerItems | push({
-      value: provider.name,
-      text: provider.name,
-      selected: true if (provider.name == query.filterAllProviders)
-    }) %}
-  {% endfor %}
-
-  {% set selectHtml %}
-    {{ govukSelect({
-      id: "all-provider-select",
-      name: "filterAllProviders",
-      classes: "js-auto-submit",
-      label: {
-        text: "Provider",
-        classes: "govuk-label--s"
-      },
-      items: providerItems
-    }) }}
-  {% endset %}
-
-  {{ appAdminFeature({
-    classes: "app-status-box--filter-outdent",
-    html: selectHtml
-  }) }}
-
-{% endif %}
+{{ govukSelect({
+  id: "all-provider-select",
+  name: "filterAllProviders",
+  classes: "js-auto-submit",
+  label: {
+    text: "Provider",
+    classes: "govuk-label--s"
+  },
+  items: providerItems
+}) }}

--- a/app/views/_includes/filter-panel/source.njk
+++ b/app/views/_includes/filter-panel/source.njk
@@ -17,6 +17,16 @@
       text: "Added manually",
       value: "Manual",
       checked: checked(query.filterSource, "Manual")
-    }
+    },
+    {
+      text: "Imported from DTTP",
+      value: "DTTP",
+      checked: checked(query.filterSource, "DTTP")
+    } if data.isAdmin and navActive !== "drafts",
+    {
+      text: "Imported from HESA",
+      value: "HESA",
+      checked: checked(query.filterSource, "HESA")
+    } if data.isAdmin and navActive !== "drafts"
   ]
 } | decorateAttributes(data, "data.filterSource"))}}

--- a/app/views/_includes/summary-cards/trainee-progress.html
+++ b/app/views/_includes/summary-cards/trainee-progress.html
@@ -25,6 +25,25 @@
   } if canAmend and false
 } %}
 
+{% set sourceText %}
+  {% if record.source == "Manual" %}
+    Added manually
+  {% elseif record.source %}
+    {{ record.source }}
+  {% else %}
+    Not provided
+  {% endif %}
+{% endset %}
+
+{% set recordSourceRow = {
+  key: {
+    text: "Source"
+  },
+  value: {
+    text: sourceText
+  }
+} %}
+
 {% set trnRow = {
   key: {
     text: "TRN"
@@ -278,6 +297,7 @@
 
 {% set traineeProgressRows = [
   providerRow if data.isAdmin or data.settings.userProviders | length > 1,
+  recordSourceRow if data.isAdmin,
   trnRow if record.trn,
   referenceRow,
   traineeIdRow,

--- a/app/views/_includes/summary-cards/trainee-progress.html
+++ b/app/views/_includes/summary-cards/trainee-progress.html
@@ -37,7 +37,7 @@
 
 {% set recordSourceRow = {
   key: {
-    text: "Source"
+    text: "Record source"
   },
   value: {
     text: sourceText

--- a/app/views/_includes/trainee-record-card.njk
+++ b/app/views/_includes/trainee-record-card.njk
@@ -77,7 +77,13 @@
 
         {% if data.isAdmin or (data.signedInProviders | length > 1) or (accessLevel == 'leadSchool') %}
           <p class="govuk-caption-m govuk-!-font-size-16 app-application-card__provider govuk-!-margin-bottom-0 govuk-!-margin-top-2">
-            <span class="govuk-visually-hidden">Provider: </span>{{record.provider}}</p>
+            <span class="govuk-visually-hidden">Provider: </span>{{record.provider}}
+          </p>
+        {% endif %}
+        {% if data.isAdmin %}
+          <p class="govuk-caption-m govuk-!-font-size-16 app-application-card__provider govuk-!-margin-bottom-0 govuk-!-margin-top-1">
+              Source: {{ record.source }}
+          </p>
         {% endif %}
       </div>
 

--- a/app/views/_includes/trainee-record-card.njk
+++ b/app/views/_includes/trainee-record-card.njk
@@ -81,7 +81,7 @@
         {% endif %}
         {% if data.isAdmin %}
           <p class="govuk-caption-m govuk-!-font-size-16 app-application-card__provider govuk-!-margin-bottom-0 govuk-!-margin-top-1">
-              Source: {{ record.source }}
+              Record source: {{ record.source }}
           </p>
         {% endif %}
       </div>

--- a/app/views/_includes/trainee-record-card.njk
+++ b/app/views/_includes/trainee-record-card.njk
@@ -77,8 +77,7 @@
 
         {% if data.isAdmin or (data.signedInProviders | length > 1) or (accessLevel == 'leadSchool') %}
           <p class="govuk-caption-m govuk-!-font-size-16 app-application-card__provider govuk-!-margin-bottom-0 govuk-!-margin-top-2">
-            <span class="govuk-visually-hidden">Provider: </span>{{record.provider}}
-          </p>
+            <span class="govuk-visually-hidden">Provider: </span>{{record.provider}}</p>
         {% endif %}
         {% if data.isAdmin %}
           <p class="govuk-caption-m govuk-!-font-size-16 app-application-card__provider govuk-!-margin-bottom-0 govuk-!-margin-top-1">

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -53,7 +53,6 @@
 
   {% if data.isAdmin %}
 
-
     {% set adminOnlyFilters %}
       {% include "_includes/filter-panel/all-providers.njk" %}
       {% include "_includes/filter-panel/source.njk" %}
@@ -66,7 +65,6 @@
 
   {% endif %}
 
-  
   {% include "_includes/filter-panel/cohort-filter.njk" %}
 
   {% include "_includes/filter-panel/cycles.njk" %}

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -51,7 +51,21 @@
 
 {% set filterOptionsHtml %}
 
-  {% include "_includes/filter-panel/all-providers.njk" %}
+  {% if data.isAdmin %}
+
+
+    {% set adminOnlyFilters %}
+      {% include "_includes/filter-panel/all-providers.njk" %}
+      {% include "_includes/filter-panel/source.njk" %}
+    {% endset %}
+
+    {{ appAdminFeature({
+      classes: "app-status-box--filter-outdent",
+      html: adminOnlyFilters
+    }) }}
+
+  {% endif %}
+
   
   {% include "_includes/filter-panel/cohort-filter.njk" %}
 

--- a/scripts/generate-records.js
+++ b/scripts/generate-records.js
@@ -108,7 +108,7 @@ const generateFakeApplication = (params = {}) => {
   application.trn              = (params.trn === null) ? undefined : (params.trn || generateTrn(application))
 
   application.source          = (params.source) ? params.source : generateSource(application)
-  if (application.source == "Apply" || application.source == "HESA" || application.source == "DTTP" ){
+  if (application.source == "Apply" ){
     application.applyData = { ...generateApplyData(application), ...params.applyData}
     // if (params.applyData) application.applyData = params.applyData
   }

--- a/scripts/generate-records.js
+++ b/scripts/generate-records.js
@@ -108,7 +108,7 @@ const generateFakeApplication = (params = {}) => {
   application.trn              = (params.trn === null) ? undefined : (params.trn || generateTrn(application))
 
   application.source          = (params.source) ? params.source : generateSource(application)
-  if (application.source == "Apply"){
+  if (application.source == "Apply" || application.source == "HESA" || application.source == "DTTP" ){
     application.applyData = { ...generateApplyData(application), ...params.applyData}
     // if (params.applyData) application.applyData = params.applyData
   }


### PR DESCRIPTION
We're importing records from DTTP and HESA into Register.

To help devs/admins we're showing the original source on the trainee record card and trainee record.

![localhost_3000_record_57231a63-013b-4729-9d15-b5c9ce4f0e60(screenshot)](https://user-images.githubusercontent.com/8417288/151383426-0c5f3cc6-dfb8-4a85-973e-6d9daf4e4435.png)

![localhost_3000_records(screenshot) (3)](https://user-images.githubusercontent.com/8417288/151383432-1dc36778-375c-4117-b5fc-7ad872353cb6.png)

It will also show in the record timeline to all users.

![localhost_3000_record_9bfc3333-a9bd-468d-9577-19a4f09b2148_timeline(screenshot)](https://user-images.githubusercontent.com/8417288/150973099-2506ec53-dc10-4ef6-bca7-4e684f89a3ee.png)
