### PR TITLE
Improvements to placements

### DIFF
--- a/app/data/generators/placement.js
+++ b/app/data/generators/placement.js
@@ -46,7 +46,7 @@ module.exports = (params) => {
 
   // Mark section as complete once we have two placements
   if (count == 2){
-    status = 'Complete'
+    status = 'Completed'
   }
 
   if (params?.placement?.hasPlacements == 'Not yet') {

--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -1201,12 +1201,23 @@ module.exports = router => {
       return item
     }
 
+    // Check if the most recent placement already exists in the placement array
+    const placementIsDuplicate = (placement) => {
+      let placements = record?.placement?.items || []
+      if (placements.length){
+        return placements.some(singlePlacement => {
+          return placement?.school?.schoolName == singlePlacement?.school?.schoolName
+        })
+      }
+      else return false
+    }
+
     // Used for no-js results page
     let searchResultRadios = req.body?._searchResultRadios
 
     let searchQuery = req.body?._schoolSearch
 
-    console.log(searchQuery, searchResultRadios)
+    // console.log(searchQuery, searchResultRadios)
 
     // Autocomplete page has two inputs that get submitted - we need to filter out
     // the one we don't need.
@@ -1238,6 +1249,9 @@ module.exports = router => {
       let queryParams = utils.addQueryParam(referrer, `_schoolSearch=${searchQuery}`)
       res.redirect(`${recordPath}/placements/${placementUuid}/details${queryParams}`)
     }
+    // else if (placementsContainDuplicates()){
+    //   res.redirect(`${recordPath}/placements/${placementUuid}/placement-already-added${queryParams}`)
+    // }
     else if (isManualEntry){
       if (placement?.school?.postcode){
         placement.school.postcode = placement.school.postcode.toUpperCase()
@@ -1250,15 +1264,26 @@ module.exports = router => {
       }
       placement.school.isManualEntry = true
 
-      savePlacement(placement)
-      res.redirect(`${recordPath}/placements/confirm${referrer}`)
+      if (placementIsDuplicate(placement)){
+        res.redirect(`${recordPath}/placements/${placementUuid}/placement-already-added${referrer}`)
+      }
+      else {
+        savePlacement(placement)
+        res.redirect(`${recordPath}/placements/confirm${referrer}`)
+      }
     }
     else if (queryIsAUuid || utils.isUuid(searchResultRadios)){
       let schoolUuid = queryIsAUuid ? searchQuery : searchResultRadios
 
       placement = lookUpSchool(placement, schoolUuid)
-      savePlacement(placement)
-      res.redirect(`${recordPath}/placements/confirm${referrer}`)
+
+      if (placementIsDuplicate(placement)){
+        res.redirect(`${recordPath}/placements/${placementUuid}/placement-already-added${referrer}`)
+      }
+      else {
+        savePlacement(placement)
+        res.redirect(`${recordPath}/placements/confirm${referrer}`)
+      }
     }
 
   })

--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -1204,7 +1204,8 @@ module.exports = router => {
     // Check if the most recent placement already exists in the placement array
     const placementIsDuplicate = (placement) => {
       let placements = record?.placement?.items || []
-      if (placements.length){
+      let isExistingPlacement = placements.find(item => placement.id == item.id)
+      if (placements.length && !isExistingPlacement){
         return placements.some(singlePlacement => {
           return placement?.school?.schoolName == singlePlacement?.school?.schoolName
         })

--- a/app/views/_includes/actions-banner.njk
+++ b/app/views/_includes/actions-banner.njk
@@ -8,7 +8,7 @@
       titleText: "You need to provide additional details before recording an outcome",
       itemList: [
         {
-          text: "Confirm training placement details are complete" if placementCount >= minPlacementsRequired else "Add placement details",
+          text: "Complete placement details",
           href: recordPath + "/placements/confirm" | addReferrer(referrer)
         } if record | needsPlacementDetails,
         {

--- a/app/views/_includes/forms/placements/placement-already-added.html
+++ b/app/views/_includes/forms/placements/placement-already-added.html
@@ -1,0 +1,30 @@
+{# Placement data is stored in a temp location before being merged back to array #}
+
+{# Get placement (if it exists) from existing data #}
+{% set placement = {} %}
+
+{% if record.placement.items %}
+  {% set placement = record.placement.items | getRecordById(placementUuid) %}
+{% endif %}
+
+{# Merge with temp store #}
+{% set placementTemp = placement | mergeObjects(data.placementTemp) %}
+
+{% set headingText %}
+  You’ve already added {{placementTemp.school.schoolName | safe}} as a placement
+{% endset %}
+
+<h1 class="govuk-heading-l">{{headingText}}</h1>
+
+<p class="govuk-body">You only need to add each placement {{ record | schoolOrSettingText }} once.</p>
+
+<p class="govuk-body">Next steps</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    <a class="govuk-link" href="./details">go back and edit this placement</a>
+  </li>
+  <li>
+    <a class="govuk-link" href="./../confirm">cancel adding this placement</a>
+  </li>
+</ul>

--- a/app/views/_includes/placement-already-added.njk
+++ b/app/views/_includes/placement-already-added.njk
@@ -1,0 +1,30 @@
+{# Placement data is stored in a temp location before being merged back to array #}
+
+{# Get placement (if it exists) from existing data #}
+{% set placement = {} %}
+
+{% if record.placement.items %}
+  {% set placement = record.placement.items | getRecordById(placementUuid) %}
+{% endif %}
+
+{# Merge with temp store #}
+{% set placementTemp = placement | mergeObjects(data.placementTemp) %}
+
+{% set headingText %}
+  You’ve already added {{placementTemp.school.schoolName | safe}} as a placement
+{% endset %}
+
+<h1 class="govuk-heading-l">{{headingText}}</h1>
+
+<p class="govuk-body">You only need to add each placement {{ record | schoolOrSettingText }} once.</p>
+
+<p class="govuk-body">Next steps</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    <a class="govuk-link" href="./details">go back and edit this placement</a>
+  </li>
+  <li>
+    <a class="govuk-link" href="./../confirm">cancel adding this placement</a>
+  </li>
+</ul>

--- a/app/views/_includes/placement-already-added.njk
+++ b/app/views/_includes/placement-already-added.njk
@@ -1,5 +1,3 @@
-{# Placement data is stored in a temp location before being merged back to array #}
-
 {# Get placement (if it exists) from existing data #}
 {% set placement = {} %}
 

--- a/app/views/_includes/placement-already-added.njk
+++ b/app/views/_includes/placement-already-added.njk
@@ -18,7 +18,7 @@
 
 <p class="govuk-body">You only need to add each placement {{ record | schoolOrSettingText }} once.</p>
 
-<p class="govuk-body">Next steps</p>
+<p class="govuk-body">You can:</p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>

--- a/app/views/_includes/summary-cards/placements/no-placement-details.html
+++ b/app/views/_includes/summary-cards/placements/no-placement-details.html
@@ -8,9 +8,9 @@
   actions: {
     items: [
       {
-        href: recordPath + "/placements/can-add-placement" | addReferrer(referrer),
-        text: "Change",
-        visuallyHiddenText: "placement details"
+        href: recordPath + "/placements/add" | addReferrer(referrer),
+        text: "Add a placement",
+        _visuallyHiddenText: ""
       }
     ]
   } if canAmend

--- a/app/views/_includes/summary-cards/placements/placement-details.html
+++ b/app/views/_includes/summary-cards/placements/placement-details.html
@@ -26,10 +26,8 @@
 
 {% else %}
 
-  {% if record.placement.hasPlacements == "Not yet"%}
+  {% if placementCount == 0 %}
     {% include "_includes/summary-cards/placements/no-placement-details.html" %}
-  {% elseif placementCount == 0 %}
-    <p class="govuk-body">You have not added any placements yet.<p>
   {% else %}
     {% for placement in placements %}
       {% include "_includes/summary-cards/placements/single-placement-details.html" %}

--- a/app/views/_includes/summary-cards/placements/placement-overview.html
+++ b/app/views/_includes/summary-cards/placements/placement-overview.html
@@ -29,7 +29,7 @@
           visuallyHiddenText: (loop.index | getOrdinalName | sentenceCase) + "placement"
         }
       ]
-    } if canAmend and false
+    } if canAmend
   }) %}
 
   {% if placements | length == 1 %}
@@ -38,18 +38,18 @@
       text: "Second placement"
     },
     value: {
-      text: 'Second placement not yet known'
+      text: ''
     },
     actions: {
       items: [
         {
-          href: recordPath + "/placements/" + placement.id + "/details" | addReferrer(referrer),
-          text: "Change",
+          href: recordPath + "/placements/add" | addReferrer(referrer),
+          text: "Add",
           visuallyHiddenText: "second placement"
         }
       ]
-    } if canAmend and false
-  }) %}
+    } if canAmend
+  } if not record | isDraft ) %}
     
   {% endif %}
   
@@ -101,7 +101,7 @@
     actions: {
       items: [{
         href: recordPath + "/placements/confirm" | addReferrer(referrer),
-        text: "Change" if canAmend else "View"
+        text: "Manage placements" if canAmend else "View"
       }]
     },
     html: placementDetailsHtml

--- a/app/views/_includes/summary-cards/placements/placement-overview.html
+++ b/app/views/_includes/summary-cards/placements/placement-overview.html
@@ -29,7 +29,7 @@
           visuallyHiddenText: (loop.index | getOrdinalName | sentenceCase) + "placement"
         }
       ]
-    } if canAmend
+    } if canAmend and false
   }) %}
 
   {% if placements | length == 1 %}

--- a/app/views/new-record/placements/placement-already-added.html
+++ b/app/views/new-record/placements/placement-already-added.html
@@ -1,0 +1,8 @@
+{% extends "_templates/_new-record.html" %}
+
+{% set pageHeading = "Placement " + ( data.record | schoolOrSettingText ) + " already added" %}
+
+{% block formContent %}
+  {% include "_includes/placement-already-added.njk" %}
+{% endblock %}
+

--- a/app/views/record/placements/confirm.html
+++ b/app/views/record/placements/confirm.html
@@ -6,20 +6,18 @@
 {% set backText = "Back to record" %}
 
 {% set gridColumn = 'govuk-grid-column-full' %}
-
 {% set formAction = "./update" | addReferrer(referrer) %}
-
 {% set minPlacementsRequired = data.settings.minPlacementsRequired %}
 {% set canAmend = record.status | canBeAmended %}
 
 {% block formContent %}
-
-  {% set placementCount = record.placement.items | length %}
-  
   {% include "_includes/trainee-name-caption.njk" %}
   <h1 class="govuk-heading-l">
     {{pageHeading}}
   </h1>
+
+  {% set placementCount = record.placement.items | length %}
+
 
   {# Details about how many placements are needed #}
   <div class="govuk-grid-row">

--- a/app/views/record/placements/details-manual.html
+++ b/app/views/record/placements/details-manual.html
@@ -15,7 +15,7 @@
 {# First / Second / Third #}
 {% set ordinalName = ordinalCount | getOrdinalName | sentenceCase %}
 
-{% set pageHeading = ordinalName + " placement " + ( record | schoolOrSettingText ) %}
+{% set pageHeading = ordinalName + " placement " + ( data.record | schoolOrSettingText ) %}
 
 {% set formAction = "./details-answer" | addReferrer(referrer) %}
 

--- a/app/views/record/placements/placement-already-added.html
+++ b/app/views/record/placements/placement-already-added.html
@@ -1,0 +1,8 @@
+{% extends "_templates/_record-form.html" %}
+
+{% set pageHeading = "Placement " + ( data.record | schoolOrSettingText ) + " already added" %}
+
+{% block formContent %}
+  {% include "_includes/placement-already-added.njk" %}
+{% endblock %}
+


### PR DESCRIPTION
A few bits of clean up to placements:

* Bespoke fail page when you add the same placement twice
* Fix bugs
* Show summary card when there are no placements (this happened sometimes before but was not consistent)

## Bespoke fail page
Adds a bespoke fail page where a user attempts to add a placement that matches an existing one.

<img width="1035" alt="Screenshot 2022-01-28 at 11 34 28" src="https://user-images.githubusercontent.com/2204224/151540156-6080ef0e-bdb9-435c-9d12-07a0a9c16482.png">

