### PR TITLE
Splits out each funding type into its own table

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -226,7 +226,7 @@ span.summary-validation-symbol {
 
 // column widths for tables
 // app-table__column-xx
-$sizes: 40, 35, 20, 15, 10;
+$sizes: 70, 53, 35, 25, 20, 15, 10;
 
 @each $size in $sizes {
   .app-table__column-#{$size} {

--- a/app/data/funding.js
+++ b/app/data/funding.js
@@ -20,9 +20,13 @@ let monthlyFundingScitts = []
 monthlyFundingScittsArray.forEach(row => {
   let description = row[3]
   let monthlyPayments = row.slice(5, 17).map(value => parseInt(value))
+  let cumulativeMonthlyPayments = monthlyPayments.map((payment, index, array) => {
+    return array.slice(0, index + 1).reduce((a, b) => a + b, 0)
+  })
   monthlyFundingScitts.push({
     description,
-    monthlyPayments
+    monthlyPayments,
+    cumulativeMonthlyPayments
   })
 })
 
@@ -176,9 +180,13 @@ let monthlyFundingLeadSchools = []
 monthlyFundingLeadSchoolsArray.forEach(row => {
   let description = row[5]
   let monthlyPayments = row.slice(7, 19).map(value => parseInt(value))
+  let cumulativeMonthlyPayments = monthlyPayments.map((payment, index, array) => {
+    return array.slice(0, index + 1).reduce((a, b) => a + b, 0)
+  })
   monthlyFundingLeadSchools.push({
     description,
-    monthlyPayments
+    monthlyPayments,
+    cumulativeMonthlyPayments
   })
 })
 

--- a/app/filters/app-misc.js
+++ b/app/filters/app-misc.js
@@ -7,6 +7,7 @@ const trainingRoutes = trainingRouteData.trainingRoutes
 const utils = require('./../lib/utils')
 const arrayFilters = require('./arrays.js').filters
 const funding = require('../data/funding')
+const moment = require("moment")
 
 // Leave this filters line
 var filters = {}
@@ -234,10 +235,31 @@ filters.fixNamesFromFunding = (string) => {
 */
 filters.formatYearRange = (string) => {
   return string
-    .replace(/(\d{4})\/(\d{2})/, '$1&nbsp;to&nbsp;$2')
-    .replace(/(\d{2})\/(\d{2})/, '20$1&nbsp;to&nbsp;$2');
+    .replace(/(\d{4})\/(\d{2})/, '$1&nbsp;to&nbsp;20$2')
+    .replace(/(\d{2})\/(\d{2})/, '20$1&nbsp;to&nbsp;20$2');
 }
 
+/*
+  ====================================================================
+  prettyMonthFromAugust
+  --------------------------------------------------------------------
+  Return month names from numbers, but August is 1
+  ====================================================================
 
+  Usage:
+
+  {{ 1 | prettyMonthFromAugust }}
+
+  = August
+
+*/
+
+filters.prettyMonthFromAugust = (monthNumber) => {
+  if (monthNumber <= 6) {
+    return moment().month(monthNumber - 6).format("MMMM");
+  } else {
+    return moment().month(monthNumber + 6).format("MMMM");
+  }
+}
 
 exports.filters = filters

--- a/app/filters/strings.js
+++ b/app/filters/strings.js
@@ -73,7 +73,7 @@ filters.currency = input => {
 
   // makes negative number positive and puts minus sign in front of £
   else if ( inputAsInt < 0 ) { return `–£${numberWithCommas(inputAsInt * -1 )}` }
-  else return ''
+  else return '–'
 }
 
 // Emulate support for string literals in Nunjucks

--- a/app/views/funding/annual-payments-lead-school.html
+++ b/app/views/funding/annual-payments-lead-school.html
@@ -26,13 +26,11 @@
   {% set dataSource = dataSource | sort(attribute = "subject") %}
 
   {% set salaryHeadRow = [
-    { text: "Subject and route" },
-    { text: "Trainees",
-      classes: "app-table__column-15" },
-    { text: "Amount per trainee",
-      classes: "app-table__column-15" },
-    { text: "Total",
-      classes: "app-table__column-15" }
+    { text: "Subject and route",
+      classes: "app-table__column-53" },
+    { text: "Trainees" },
+    { text: "Amount per trainee" },
+    { text: "Total" }
   ] %}
 
   {% set total = 0 %}

--- a/app/views/funding/annual-payments-scitt.html
+++ b/app/views/funding/annual-payments-scitt.html
@@ -33,15 +33,9 @@
       classes: "app-table__column-35" },
     { text: "Lead school",
       classes: "app-table__column-35" },
-    { text: "Trainees",
-      classes: "app-table__column-10"
-     },
-    { text: "Amount per trainee",
-      classes: "app-table__column-10"
-     },
-    { text: "Total",
-      classes: "app-table__column-10"
-     }
+    { text: "Trainees" },
+    { text: "Amount per trainee" },
+    { text: "Total" }
   ] %}
   {% set ittBursaryTotal = 0 %}
   {% set ittBursaryRows = [] %}
@@ -194,7 +188,9 @@
           caption: "Summary",
           captionClasses: "govuk-table__caption--m",
           head: [
-            { text: "Payment type" },
+            { text: "Payment type",
+              classes: "app-table__column-70"
+             },
             { text: "Total" }
           ],
           rows: annualSummaryRows
@@ -249,16 +245,14 @@
           caption: "Early years ITT bursaries",
           captionClasses: "govuk-table__caption--m",
           head: [
-            { text: "Tier"
+            { text: "Tier",
+            classes: "app-table__column-53"
             },
-            { text: "Trainees",
-              classes: "app-table__column-15"
+            { text: "Trainees"
             },
-            { text: "Amount per trainee",
-              classes: "app-table__column-15"
+            { text: "Amount per trainee"
             },
-            { text: "Total",
-              classes: "app-table__column-15"
+            { text: "Total"
             }
           ],
           rows: eyIttBursaryRows

--- a/app/views/funding/monthly-payments.html
+++ b/app/views/funding/monthly-payments.html
@@ -16,7 +16,6 @@
   {% endif %}
   {% set dataSource = dataSource | sort(attribute = "description") %}
 
-  {# TODO #}
   {% if dataSource.length > 4 %}
     {% set tableClasses = "govuk-!-font-size-16" %}
   {% endif %}
@@ -100,6 +99,7 @@
     {% set summaryRows = summaryRows | push(summaryRowItems) %}
   {% endif %}
 
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <h2 class="govuk-heading-l">
@@ -135,25 +135,139 @@
     </div>
   </div>
   <hr class="govuk-section-break govuk-section-break--m">
-  {{ govukTable({
-    caption: "Payments to " + currentMonth("nameOfMonth") + " " + currentYear(),
-    captionClasses: "govuk-table__caption--m",
-    classes: tableClasses,
-    head: headRow,
-    rows: rowsPast
-  }) }}
+  <div class="govuk-grid-row">
+    {% if dataSource.length < 6 %}
+      <div class="govuk-grid-column-full">
 
-  {# 11th month = July (12 months of the Academic year 0 indexed) #}
+        {# Single table showing all months #}
+        {{ govukTable({
+          caption: "Payments to " + currentMonth("nameOfMonth") + " " + currentYear(),
+          captionClasses: "govuk-table__caption--m",
+          classes: tableClasses,
+          head: headRow,
+          rows: rowsPast
+        }) }}
 
-  {% if thisMonth != 11 %}
-    <hr class="govuk-section-break govuk-section-break--m">
-    {{ govukTable({
-      caption: "Predicted payments",
-      captionClasses: "govuk-table__caption--m",
-      classes: tableClasses,
-      head: headRow,
-      rows: rowsFuture
-    }) }}
-  {% endif %}
+        {# 11th month = July (12 months of the Academic year 0 indexed) #}
+
+        {% if thisMonth != 11 %}
+          <hr class="govuk-section-break govuk-section-break--m">
+          {{ govukTable({
+            caption: "Predicted payments",
+            captionClasses: "govuk-table__caption--m",
+            classes: tableClasses,
+            head: headRow,
+            rows: rowsFuture
+          }) }}
+        {% endif %}
+      </div>
+    {% else %}
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+        {% set pastTables = [] %}
+        {% set futureTables = [] %}
+
+        {% for item in months %}
+          {% set monthTableRows  = [] %}
+          {% set monthIndex = loop.index0 %}
+          {% set monthTableCaption = months[monthIndex] %}
+          {% set monthTotal = 0 %}
+          {% set cumulativeMonthTotal = 0 %}
+          {% for item in dataSource %}
+            {% set rowIndex = loop.index0 %}
+            {% set paymentDescription = item.description | fixNamesFromFunding | sentenceCase | formatYearRange %}
+            {% set monthTotal = monthTotal + item.monthlyPayments[monthIndex] %}
+            {% set cumulativeMonthTotal = cumulativeMonthTotal + item.cumulativeMonthlyPayments[monthIndex] %}
+            {% if item.monthlyPayments[monthIndex] != "" %}
+              {% set amount = item.monthlyPayments[monthIndex] | currency %}
+            {% else %}
+              {% set amount = "–" %}
+            {% endif %}
+            {% if item.cumulativeMonthlyPayments[monthIndex] != "" %}
+              {% set cumulativeAmount = item.cumulativeMonthlyPayments[monthIndex] | currency %}
+            {% else %}
+              {% set cumulativeAmount = "–" %}
+            {% endif %}
+            {% set row = [
+              { text: paymentDescription | safe },
+              { text: amount, format: "numeric" },
+              { text: cumulativeAmount, format: "numeric" }
+            ] %}
+            {% set monthTableRows = monthTableRows | push(row) %}
+          {% endfor %}
+          {% set monthTableRows = monthTableRows | push([
+            { text: "Total", classes: "govuk-!-font-weight-bold" }, 
+            { text: monthTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" },
+            { text: cumulativeMonthTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
+          ])%}
+          {% if loop.index0 <= thisMonth and cumulativeMonthTotal != 0 %}
+            {% set monthTableHtml %}
+              {{ govukTable({
+                caption: monthTableCaption,
+                captionClasses: "govuk-table__caption--m",
+                classes: tableClasses,
+                head: [
+                  {
+                    text: "Payment type"
+                  },
+                  {
+                    text: "Amount",
+                    format: "numeric",
+                    classes: "app-table__column-15"
+                  },
+                  {
+                    text: "Total for payment type",
+                    format: "numeric",
+                    classes: "app-table__column-15"
+                  }
+                ],
+                rows: monthTableRows
+              }) }}
+            {% endset %}
+            {% set pastTables = pastTables | push(monthTableHtml) %}
+          {% elseif cumulativeMonthTotal != 0 %}
+            {% set monthTableHtml %}
+              {{ govukTable({
+                caption: monthTableCaption,
+                captionClasses: "govuk-table__caption--m",
+                classes: tableClasses,
+                head: [
+                  {
+                    text: "Payment type"
+                  },
+                  {
+                    text: "Amount",
+                    format: "numeric",
+                    classes: "app-table__column-15"
+                  },
+                  {
+                    text: "Total for payment type",
+                    format: "numeric",
+                    classes: "app-table__column-15"
+                  }
+                ],
+                rows: monthTableRows
+              }) }}
+            {% endset %}
+            {% set futureTables = futureTables | push(monthTableHtml) %}
+          {% endif %}
+        {% endfor %}
+
+
+
+        {# Table per month #}
+        <h3 class="govuk-heading-m">Payments to {{ currentMonth("nameOfMonth") }} {{ currentYear() }}</h3>
+        {% for item in pastTables %}
+          {{ item | safe }}
+        {% endfor %}
+        {% if thisMonth != 11 %}
+          <hr class="govuk-section-break govuk-section-break--m">
+          <h3 class="govuk-heading-m">Predicted payments</h3>
+          {% for item in futureTables %}
+            {{ item | safe }}
+          {% endfor %}
+        {% endif %}
+      {% endif %}
+    </div>
+  </div>
 
 {% endblock %}

--- a/app/views/funding/monthly-payments.html
+++ b/app/views/funding/monthly-payments.html
@@ -20,18 +20,6 @@
     {% set tableClasses = "govuk-!-font-size-16" %}
   {% endif %}
 
-  {% set headRow = [{ text: "Month" }] %}
-  {% for item in dataSource %}
-    {% set headRow = headRow | push({ text: item.description | fixNamesFromFunding | sentenceCase | formatYearRange | safe }) %}
-  {% endfor %}
-  {% set headRow = headRow | push({ text: "Total" }) %}
-
-  {% set rowsPast = [] %}
-  {% set pastTotal = 0 %}
-
-  {% set rowsFuture = [] %}
-  {% set futureTotal = 0 %}
-
   {% set months  = [
     "August",
     "September",
@@ -47,58 +35,20 @@
     "July"
   ]%}
 
-  {% if currentMonth() >= 8 %}
-    {% set thisMonth = currentMonth() - 8 %}
+
+  {# Get Month starting from August #}
+  {% if currentMonth() >= 6 %}
+    {% set thisMonth = -1 + currentMonth() - 6 %}
   {% else %}
-    {% set thisMonth = currentMonth() + 4 %}
+    {% set thisMonth = -1 + currentMonth() + 6 %}
   {% endif %}
+  {# {% set thisMonth = 12 %} #}
 
-  {% for item in months %}
-    {% set monthIndex = loop.index0 %}
-    {% set monthTotal = 0 %}
-    {% set row = [{ text: months[monthIndex]}] %}
-    {% for paymentType in dataSource %}
-      {% if paymentType.monthlyPayments[monthIndex] == 0 %}
-        {% set amount = "–" %}
-      {% else %}
-        {% set amount = paymentType.monthlyPayments[monthIndex] | currency %}
-      {% endif %}
-      {% set monthTotal = monthTotal + paymentType.monthlyPayments[monthIndex] %}
-      {% set row = row | push({ text: amount, format: "numeric" }) %}
-    {% endfor %}
-    {% if monthTotal != 0 %}
-      {% set row = row | push({ text: monthTotal | currency, format: "numeric" }) %}
-    {% else %}
-      {% set row = row | push({ text: "–", format: "numeric" }) %}
-    {% endif %}
-    {% if thisMonth >= loop.index0 %}
-      {% set pastTotal = pastTotal + monthTotal %}
-      {% set rowsPast = rowsPast | push(row) %}
-    {% else %}
-      {% set futureTotal = futureTotal + monthTotal %}
-      {% set rowsFuture = rowsFuture | push(row) %}
-    {% endif %}
-  {% endfor %}
-
-  {% set summaryRows = [] %}
-  {% if thisMonth != 11 %}
-    {% set summaryRowItems = [
-      { text: "Payments to " + currentMonth("nameOfMonth") + " " + currentYear() }, 
-      { text: pastTotal | currency, format: "numeric" }] 
-    %}
-    {% set summaryRows = summaryRows | push(summaryRowItems) %}
-    {% set summaryRowItems = [
-      { text: "Predicted payments" }, 
-      { text: futureTotal | currency, format: "numeric" }] 
-    %}
-    {% set summaryRows = summaryRows | push(summaryRowItems) %}
-    {% set summaryRowItems = [{ text: "Predicted total" }, { text: (pastTotal + futureTotal) | currency, format: "numeric" }] %}
-    {% set summaryRows = summaryRows | push(summaryRowItems) %}
+  {% if thisMonth == 12 %}
+    {% set totalRowTitle = "Total" %}
   {% else %}
-    {% set summaryRowItems = [{ text: "Total for year" }, { text: pastTotal | currency, format: "numeric" }] %}
-    {% set summaryRows = summaryRows | push(summaryRowItems) %}
+    {% set totalRowTitle = "Total to " + thisMonth | prettyMonthFromAugust %}
   {% endif %}
-
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
@@ -117,156 +67,183 @@
   <hr class="govuk-section-break govuk-section-break--m">
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half-from-desktop">
-      {{ govukTable({
-        caption: "Summary",
-        captionClasses: "govuk-table__caption--m",
-        head: [
-                {
-                  text: "Payment type"
-                },
-                {
-                  text: "Amount",
-                  classes: "app-table__column-25"
-                }
-              ],
-        rows: summaryRows
-      }) }}
-    </div>
-  </div>
-  <hr class="govuk-section-break govuk-section-break--m">
-  <div class="govuk-grid-row">
-    {% if dataSource.length < 6 %}
-      <div class="govuk-grid-column-full">
-
-        {# Single table showing all months #}
-        {{ govukTable({
-          caption: "Payments to " + currentMonth("nameOfMonth") + " " + currentYear(),
-          captionClasses: "govuk-table__caption--m",
-          classes: tableClasses,
-          head: headRow,
-          rows: rowsPast
-        }) }}
-
-        {# 11th month = July (12 months of the Academic year 0 indexed) #}
-
-        {% if thisMonth != 11 %}
-          <hr class="govuk-section-break govuk-section-break--m">
-          {{ govukTable({
-            caption: "Predicted payments",
-            captionClasses: "govuk-table__caption--m",
-            classes: tableClasses,
-            head: headRow,
-            rows: rowsFuture
-          }) }}
-        {% endif %}
-      </div>
-    {% else %}
       <div class="govuk-grid-column-two-thirds-from-desktop">
-        {% set pastTables = [] %}
-        {% set futureTables = [] %}
 
-        {% for item in months %}
-          {% set monthTableRows  = [] %}
-          {% set monthIndex = loop.index0 %}
-          {% set monthTableCaption = months[monthIndex] %}
-          {% set monthTotal = 0 %}
-          {% set cumulativeMonthTotal = 0 %}
-          {% for item in dataSource %}
-            {% set rowIndex = loop.index0 %}
-            {% set paymentDescription = item.description | fixNamesFromFunding | sentenceCase | formatYearRange %}
-            {% set monthTotal = monthTotal + item.monthlyPayments[monthIndex] %}
-            {% set cumulativeMonthTotal = cumulativeMonthTotal + item.cumulativeMonthlyPayments[monthIndex] %}
-            {% if item.monthlyPayments[monthIndex] != "" %}
-              {% set amount = item.monthlyPayments[monthIndex] | currency %}
-            {% else %}
-              {% set amount = "–" %}
-            {% endif %}
-            {% if item.cumulativeMonthlyPayments[monthIndex] != "" %}
-              {% set cumulativeAmount = item.cumulativeMonthlyPayments[monthIndex] | currency %}
-            {% else %}
-              {% set cumulativeAmount = "–" %}
-            {% endif %}
-            {% set row = [
-              { text: paymentDescription | safe },
-              { text: amount, format: "numeric" },
-              { text: cumulativeAmount, format: "numeric" }
-            ] %}
-            {% set monthTableRows = monthTableRows | push(row) %}
-          {% endfor %}
-          {% set monthTableRows = monthTableRows | push([
-            { text: "Total", classes: "govuk-!-font-weight-bold" }, 
-            { text: monthTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" },
-            { text: cumulativeMonthTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
-          ])%}
-          {% if loop.index0 <= thisMonth and cumulativeMonthTotal != 0 %}
-            {% set monthTableHtml %}
-              {{ govukTable({
-                caption: monthTableCaption,
-                captionClasses: "govuk-table__caption--m",
-                classes: tableClasses,
-                head: [
-                  {
-                    text: "Payment type"
-                  },
-                  {
-                    text: "Amount",
-                    format: "numeric",
-                    classes: "app-table__column-15"
-                  },
-                  {
-                    text: "Total for payment type",
-                    format: "numeric",
-                    classes: "app-table__column-15"
-                  }
-                ],
-                rows: monthTableRows
-              }) }}
-            {% endset %}
-            {% set pastTables = pastTables | push(monthTableHtml) %}
-          {% elseif cumulativeMonthTotal != 0 %}
-            {% set monthTableHtml %}
-              {{ govukTable({
-                caption: monthTableCaption,
-                captionClasses: "govuk-table__caption--m",
-                classes: tableClasses,
-                head: [
-                  {
-                    text: "Payment type"
-                  },
-                  {
-                    text: "Amount",
-                    format: "numeric",
-                    classes: "app-table__column-15"
-                  },
-                  {
-                    text: "Total for payment type",
-                    format: "numeric",
-                    classes: "app-table__column-15"
-                  }
-                ],
-                rows: monthTableRows
-              }) }}
-            {% endset %}
-            {% set futureTables = futureTables | push(monthTableHtml) %}
+      {# Summary to date #}
+      {% set headRow = [
+        { text: "Month", classes: "app-table__column-25" },
+        { text: "Recovery", classes: "app-table__column-25", format: "numeric" },
+        { text: "Payment", classes: "app-table__column-25", format: "numeric" },
+        { text: "Total", classes: "app-table__column-25", format: "numeric" }
+      ] %}
+
+      {% set bodyRowsPast = [] %}
+      {% set bodyRowsFuture = [] %}
+
+
+      {% set pastTotal = 0 %}
+      {% set pastRecoveryTotal = 0 %}
+      {% set pastPaymentTotal = 0 %}
+
+      {% set recoveryTotal = 0 %}
+      {% set paymentTotal = 0 %}
+      {% set total = 0 %}
+
+      {% for month in months %}
+
+        {% set recovery = 0 %}
+        {% set payment = 0 %}
+        {% set monthTotal = 0 %}
+
+        {% set monthIndex = loop.index0 %}
+
+        {% for item in dataSource %}
+
+
+          {% if item.monthlyPayments[monthIndex] < 0 %}
+            {% set recovery = recovery + item.monthlyPayments[monthIndex] %}
+          {% else %}
+            {% set payment = payment + item.monthlyPayments[monthIndex] %}
+          {% endif %}
+          {% set monthTotal = monthTotal + recovery + payment %}
+          {% set total = total + monthTotal %}
+          {% if loop.index0 < thisMonth %}
+            {% set pastRecoveryTotal = pastRecoveryTotal + recovery %}
+            {% set pastPaymentTotal = pastPaymentTotal + payment %}
+            {% set pastTotal = pastPaymentTotal + pastRecoveryTotal %}
+          {% endif %}
+          {% set recoveryTotal = recoveryTotal + recovery %}
+          {% set paymentTotal = paymentTotal + payment %}
+          {% set total = paymentTotal + recoveryTotal %}
+        {% endfor %}
+
+        {% set row = [
+          { text: month },
+          { text: recovery | currency, format: "numeric" },
+          { text: payment | currency, format: "numeric" },
+          { text: monthTotal | currency, format: "numeric" }
+        ] %}
+
+        {% if loop.index0 < thisMonth %}
+          {% set bodyRowsPast = bodyRowsPast | push(row) %}
+        {% else %}
+          {% set bodyRowsFuture = bodyRowsFuture | push(row) %}
+        {% endif %}
+
+      {% endfor %}
+
+      {% set bodyRowsPast = bodyRowsPast | push([
+        { text: totalRowTitle, classes: "govuk-!-font-weight-bold" },
+        { text: pastRecoveryTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" },
+        { text: pastPaymentTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }, 
+        { text: pastTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
+      ])%}
+
+      {% set bodyRowsFuture = bodyRowsFuture | push([
+        { text: "Total", classes: "govuk-!-font-weight-bold" },
+        { text: recoveryTotal  | currency, format: "numeric", classes: "govuk-!-font-weight-bold" },
+        { text: paymentTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" },
+        { text: total | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
+      ])%}
+
+      <h3 class="govuk-heading-m">Summary of payments per month</h3>
+
+      {{ govukTable({
+        caption: "Payments made",
+        captionClasses: "govuk-table__caption--s",
+        head: headRow,
+        rows: bodyRowsPast
+      }) }}
+
+      {{ govukTable({
+        caption: "Predicted payments",
+        captionClasses: "govuk-table__caption--s",
+        head: headRow,
+        rows: bodyRowsFuture
+      }) if thisMonth != 12 }}
+
+      <hr class="govuk-section-break govuk-section-break--l">
+
+      <h2 class="govuk-heading-l">Payments by funding stream</h2>
+
+      {# Payment per month, by payment type tables #}
+      {% for item in dataSource %}
+
+        {% set headRow = [{ text: "Month"}, { text: "Payment" }] %}
+        
+        {% set pastTotal = 0 %}
+        {% set futureTotal = 0 %}
+
+        {% set pastRows = [] %}
+        {% set futureRows = [] %}
+        {% for month in months %}
+          {% set row = [] %}
+          {% if item.monthlyPayments[loop.index0] %}
+            {% set row = [{ text: month }, { text: item.monthlyPayments[loop.index0] | currency, format: "numeric" }] %}
+          {% endif %}
+          {% if loop.index0 < thisMonth %}
+            {% set pastTotal = pastTotal + item.monthlyPayments[loop.index0] %}
+            {% set pastRows = pastRows | push(row) %}
+            {% set futureTotal = pastTotal %}
+          {% else %}
+            {% set futureTotal = futureTotal + item.monthlyPayments[loop.index0] %}
+            {% set futureRows = futureRows | push(row) %}
           {% endif %}
         {% endfor %}
 
+        {% set pastTotalRowHeading %}
+          {% if pastTotal == futureTotal %}
+            Total
+          {% else %}
+            Total to {{ thisMonth | prettyMonthFromAugust }}
+          {% endif %}
+        {% endset %}
+
+        {% set pastRows = pastRows | push([
+          { text: pastTotalRowHeading, classes: "govuk-!-font-weight-bold" },
+          { text: pastTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
+        ]) %}
+
+        {% set futureRows = futureRows | push([
+          { text: "Predicted total", classes: "govuk-!-font-weight-bold" },
+          { text: futureTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
+        ]) %}
 
 
-        {# Table per month #}
-        <h3 class="govuk-heading-m">Payments to {{ currentMonth("nameOfMonth") }} {{ currentYear() }}</h3>
-        {% for item in pastTables %}
-          {{ item | safe }}
-        {% endfor %}
-        {% if thisMonth != 11 %}
-          <hr class="govuk-section-break govuk-section-break--m">
-          <h3 class="govuk-heading-m">Predicted payments</h3>
-          {% for item in futureTables %}
-            {{ item | safe }}
-          {% endfor %}
+        <h3 class="govuk-heading-m">{{ item.description | fixNamesFromFunding | sentenceCase | formatYearRange | safe }}</h3>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+
+        {{ govukTable({
+          caption: "Paymants made",
+          captionClasses: "govuk-table__caption--s",
+          head: headRow,
+          rows: pastRows
+        }) }}
+
+        {% if pastTotal == futureTotal and this != 12 %}
+
+          <p class="govuk-body">No more {{ item.description | fixNamesFromFunding | startLowerCase | formatYearRange | safe }} predicted.</p>
+
+        {% elseif thisMonth != 12 %}
+
+          {{ govukTable({
+            caption: "Remaining payments (predicted)",
+            captionClasses: "govuk-table__caption--s",
+            head: headRow,
+            rows: futureRows
+          }) }}
+
         {% endif %}
-      {% endif %}
+
+        <hr class="govuk-section-break govuk-section-break--l">
+
+        {% endfor %}
+
+
     </div>
   </div>
 

--- a/app/views/funding/monthly-payments.html
+++ b/app/views/funding/monthly-payments.html
@@ -166,6 +166,8 @@
 
       <h2 class="govuk-heading-l">Payments by funding stream</h2>
 
+      {% set accordionItems = [] %}
+
       {# Payment per month, by payment type tables #}
       {% for item in dataSource %}
 
@@ -210,12 +212,7 @@
         ]) %}
 
 
-        <h3 class="govuk-heading-m">{{ item.description | fixNamesFromFunding | sentenceCase | formatYearRange | safe }}</h3>
-      </div>
-    </div>
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
+      {% set accordionHTML %}
 
         {{ govukTable({
           caption: "Paymants made",
@@ -226,11 +223,12 @@
 
         {% if pastTotal == futureTotal and this != 12 %}
 
-          <p class="govuk-body">No more {{ item.description | fixNamesFromFunding | startLowerCase | formatYearRange | safe }} predicted.</p>
+          <p class="govuk-body govuk-!-margin-bottom-7">No more {{ item.description | fixNamesFromFunding | startLowerCase | formatYearRange | safe }} predicted.</p>
 
         {% elseif thisMonth != 12 %}
 
           {{ govukTable({
+            classes: "govuk-!-margin-bottom-7",
             caption: "Remaining payments (predicted)",
             captionClasses: "govuk-table__caption--s",
             head: headRow,
@@ -239,10 +237,20 @@
 
         {% endif %}
 
-        <hr class="govuk-section-break govuk-section-break--l">
+      {% endset %}
+      {% set accordionItems = accordionItems | push(
+        { 
+          heading: { text: item.description | fixNamesFromFunding | sentenceCase | formatYearRange | safe },
+          content: { html: accordionHTML }
+        }
+      ) %}
 
-        {% endfor %}
+    {% endfor %}
 
+    {{ govukAccordion({
+      id: "accordion-default",
+      items: accordionItems
+    }) }}
 
     </div>
   </div>


### PR DESCRIPTION
Also adds a more detailed summary table to make-up for how split-up the data is.

Accordions closed
![localhost_3000_funding_monthly-payments(screenshot) (6)](https://user-images.githubusercontent.com/8417288/152824132-64b395a5-f807-41f2-a52c-2e09da919337.png)


Accordions open
![localhost_3000_funding_monthly-payments(screenshot) (7)](https://user-images.githubusercontent.com/8417288/152824140-c38890cf-1ed8-463c-9d18-d93824309e17.png)
