### PR TITLE
Funding in monthly tables inside accordions

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -226,7 +226,7 @@ span.summary-validation-symbol {
 
 // column widths for tables
 // app-table__column-xx
-$sizes: 40, 35, 20, 15, 10;
+$sizes: 70, 53, 35, 25, 20, 15, 10;
 
 @each $size in $sizes {
   .app-table__column-#{$size} {

--- a/app/assets/sass/utils.scss
+++ b/app/assets/sass/utils.scss
@@ -10,3 +10,7 @@ p + ul.govuk-list--bullet {
 html {
   scroll-behavior: smooth;
 }
+
+.app-table__in-accordion tr:last-child td {
+  border-bottom: none;
+}

--- a/app/data/funding.js
+++ b/app/data/funding.js
@@ -20,9 +20,13 @@ let monthlyFundingScitts = []
 monthlyFundingScittsArray.forEach(row => {
   let description = row[3]
   let monthlyPayments = row.slice(5, 17).map(value => parseInt(value))
+  let cumulativeMonthlyPayments = monthlyPayments.map((payment, index, array) => {
+    return array.slice(0, index + 1).reduce((a, b) => a + b, 0)
+  })
   monthlyFundingScitts.push({
     description,
-    monthlyPayments
+    monthlyPayments,
+    cumulativeMonthlyPayments
   })
 })
 
@@ -176,9 +180,13 @@ let monthlyFundingLeadSchools = []
 monthlyFundingLeadSchoolsArray.forEach(row => {
   let description = row[5]
   let monthlyPayments = row.slice(7, 19).map(value => parseInt(value))
+  let cumulativeMonthlyPayments = monthlyPayments.map((payment, index, array) => {
+    return array.slice(0, index + 1).reduce((a, b) => a + b, 0)
+  })
   monthlyFundingLeadSchools.push({
     description,
-    monthlyPayments
+    monthlyPayments,
+    cumulativeMonthlyPayments
   })
 })
 

--- a/app/data/funding.js
+++ b/app/data/funding.js
@@ -18,17 +18,18 @@ monthlyFundingScittsArray.shift() // remove header row
 
 let monthlyFundingScitts = []
 monthlyFundingScittsArray.forEach(row => {
-  let description = row[3]
+  let descriptions = row[3]
   let monthlyPayments = row.slice(5, 17).map(value => parseInt(value))
   let cumulativeMonthlyPayments = monthlyPayments.map((payment, index, array) => {
     return array.slice(0, index + 1).reduce((a, b) => a + b, 0)
   })
   monthlyFundingScitts.push({
-    description,
+    descriptions,
     monthlyPayments,
     cumulativeMonthlyPayments
   })
 })
+
 
 // csv training bursaries and scholarships for SCITTS
 let annualFundingScittsCsv =
@@ -178,13 +179,13 @@ monthlyFundingLeadSchoolsArray.shift()
 
 let monthlyFundingLeadSchools = []
 monthlyFundingLeadSchoolsArray.forEach(row => {
-  let description = row[5]
+  let descriptions = row[5]
   let monthlyPayments = row.slice(7, 19).map(value => parseInt(value))
   let cumulativeMonthlyPayments = monthlyPayments.map((payment, index, array) => {
     return array.slice(0, index + 1).reduce((a, b) => a + b, 0)
   })
   monthlyFundingLeadSchools.push({
-    description,
+    descriptions,
     monthlyPayments,
     cumulativeMonthlyPayments
   })

--- a/app/data/years.js
+++ b/app/data/years.js
@@ -11,7 +11,7 @@ let academicYears = [
 
 let currentAcademicYear = "2021 to 2022"
 
-let defaultCourseYear = "2021"
+let defaultCourseYear = 2021
 // defaultCourseYear = null
 
 // The first year in the range

--- a/app/filters/app-misc.js
+++ b/app/filters/app-misc.js
@@ -7,6 +7,7 @@ const trainingRoutes = trainingRouteData.trainingRoutes
 const utils = require('./../lib/utils')
 const arrayFilters = require('./arrays.js').filters
 const funding = require('../data/funding')
+const moment = require("moment")
 
 // Leave this filters line
 var filters = {}
@@ -234,10 +235,31 @@ filters.fixNamesFromFunding = (string) => {
 */
 filters.formatYearRange = (string) => {
   return string
-    .replace(/(\d{4})\/(\d{2})/, '$1&nbsp;to&nbsp;$2')
-    .replace(/(\d{2})\/(\d{2})/, '20$1&nbsp;to&nbsp;$2');
+    .replace(/(\d{4})\/(\d{2})/, '$1&nbsp;to&nbsp;20$2')
+    .replace(/(\d{2})\/(\d{2})/, '20$1&nbsp;to&nbsp;20$2');
 }
 
+/*
+  ====================================================================
+  prettyMonthFromAugust
+  --------------------------------------------------------------------
+  Return month names from numbers, but August is 1
+  ====================================================================
 
+  Usage:
+
+  {{ 1 | prettyMonthFromAugust }}
+
+  = August
+
+*/
+
+filters.prettyMonthFromAugust = (monthNumber) => {
+  if (monthNumber <= 6) {
+    return moment().month(monthNumber - 6).format("MMMM");
+  } else {
+    return moment().month(monthNumber + 6).format("MMMM");
+  }
+}
 
 exports.filters = filters

--- a/app/filters/strings.js
+++ b/app/filters/strings.js
@@ -73,7 +73,7 @@ filters.currency = input => {
 
   // makes negative number positive and puts minus sign in front of £
   else if ( inputAsInt < 0 ) { return `–£${numberWithCommas(inputAsInt * -1 )}` }
-  else return ''
+  else return '–'
 }
 
 // Emulate support for string literals in Nunjucks

--- a/app/views/funding/annual-payments-lead-school.html
+++ b/app/views/funding/annual-payments-lead-school.html
@@ -26,13 +26,11 @@
   {% set dataSource = dataSource | sort(attribute = "subject") %}
 
   {% set salaryHeadRow = [
-    { text: "Subject and route" },
-    { text: "Trainees",
-      classes: "app-table__column-15" },
-    { text: "Amount per trainee",
-      classes: "app-table__column-15" },
-    { text: "Total",
-      classes: "app-table__column-15" }
+    { text: "Subject and route",
+      classes: "app-table__column-53" },
+    { text: "Trainees" },
+    { text: "Amount per trainee" },
+    { text: "Total" }
   ] %}
 
   {% set total = 0 %}

--- a/app/views/funding/annual-payments-lead-school.html
+++ b/app/views/funding/annual-payments-lead-school.html
@@ -1,9 +1,13 @@
-{% extends "layout.html" %}
+{% extends "_templates/_page.html" %}
 {% set navActive = "funding" %}
+
+{% set backText = "Home" %}
+{% set backLink = '/home' %}
+
+{% set pageHeading = "Funding 2021 to 2022" %}
 
 {% block content %}
 
-  {% set pageHeading = "Funding 2021 to 2022" %}
   {% set tabName = "Salaries and grants" %}
 
   {% set activeTabYearlyLeadSchool = true %}

--- a/app/views/funding/annual-payments-lead-school.html
+++ b/app/views/funding/annual-payments-lead-school.html
@@ -4,7 +4,7 @@
 {% set backText = "Home" %}
 {% set backLink = '/home' %}
 
-{% set pageHeading = "Funding 2021 to 2022" %}
+{% set pageHeading = "Funding " + data.years.currentAcademicYear %}
 
 {% block content %}
 

--- a/app/views/funding/annual-payments-scitt.html
+++ b/app/views/funding/annual-payments-scitt.html
@@ -1,11 +1,15 @@
-{% extends "layout.html" %}
+{% extends "_templates/_page.html" %}
 {% set navActive = "funding" %}
+
+{% set backText = "Home" %}
+{% set backLink = '/home' %}
+
+{% set pageHeading = "Funding 2021 to 2022" %}
 
 {% block content %}
 
-  {% set pageHeading = "Funding 2021 to 2022" %}
-
   {% set yearPaymentsTabName = "" | typesOfFunding | joinify  | sentenceCase %}
+
   {% set activeTabYearlyScitt = true %}
   {% include "_includes/funding-header-and-tab-nav.html" %}
 

--- a/app/views/funding/annual-payments-scitt.html
+++ b/app/views/funding/annual-payments-scitt.html
@@ -33,15 +33,9 @@
       classes: "app-table__column-35" },
     { text: "Lead school",
       classes: "app-table__column-35" },
-    { text: "Trainees",
-      classes: "app-table__column-10"
-     },
-    { text: "Amount per trainee",
-      classes: "app-table__column-10"
-     },
-    { text: "Total",
-      classes: "app-table__column-10"
-     }
+    { text: "Trainees" },
+    { text: "Amount per trainee" },
+    { text: "Total" }
   ] %}
   {% set ittBursaryTotal = 0 %}
   {% set ittBursaryRows = [] %}
@@ -194,7 +188,9 @@
           caption: "Summary",
           captionClasses: "govuk-table__caption--m",
           head: [
-            { text: "Payment type" },
+            { text: "Payment type",
+              classes: "app-table__column-70"
+             },
             { text: "Total" }
           ],
           rows: annualSummaryRows
@@ -249,16 +245,14 @@
           caption: "Early years ITT bursaries",
           captionClasses: "govuk-table__caption--m",
           head: [
-            { text: "Tier"
+            { text: "Tier",
+            classes: "app-table__column-53"
             },
-            { text: "Trainees",
-              classes: "app-table__column-15"
+            { text: "Trainees"
             },
-            { text: "Amount per trainee",
-              classes: "app-table__column-15"
+            { text: "Amount per trainee"
             },
-            { text: "Total",
-              classes: "app-table__column-15"
+            { text: "Total"
             }
           ],
           rows: eyIttBursaryRows

--- a/app/views/funding/annual-payments-scitt.html
+++ b/app/views/funding/annual-payments-scitt.html
@@ -4,7 +4,7 @@
 {% set backText = "Home" %}
 {% set backLink = '/home' %}
 
-{% set pageHeading = "Funding 2021 to 2022" %}
+{% set pageHeading = "Funding " + data.years.currentAcademicYear %}
 
 {% block content %}
 

--- a/app/views/funding/monthly-payments.html
+++ b/app/views/funding/monthly-payments.html
@@ -16,7 +16,6 @@
   {% endif %}
   {% set dataSource = dataSource | sort(attribute = "description") %}
 
-  {# TODO #}
   {% if dataSource.length > 4 %}
     {% set tableClasses = "govuk-!-font-size-16" %}
   {% endif %}
@@ -100,6 +99,7 @@
     {% set summaryRows = summaryRows | push(summaryRowItems) %}
   {% endif %}
 
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <h2 class="govuk-heading-l">
@@ -135,25 +135,139 @@
     </div>
   </div>
   <hr class="govuk-section-break govuk-section-break--m">
-  {{ govukTable({
-    caption: "Payments to " + currentMonth("nameOfMonth") + " " + currentYear(),
-    captionClasses: "govuk-table__caption--m",
-    classes: tableClasses,
-    head: headRow,
-    rows: rowsPast
-  }) }}
+  <div class="govuk-grid-row">
+    {% if dataSource.length < 6 %}
+      <div class="govuk-grid-column-full">
 
-  {# 11th month = July (12 months of the Academic year 0 indexed) #}
+        {# Single table showing all months #}
+        {{ govukTable({
+          caption: "Payments to " + currentMonth("nameOfMonth") + " " + currentYear(),
+          captionClasses: "govuk-table__caption--m",
+          classes: tableClasses,
+          head: headRow,
+          rows: rowsPast
+        }) }}
 
-  {% if thisMonth != 11 %}
-    <hr class="govuk-section-break govuk-section-break--m">
-    {{ govukTable({
-      caption: "Predicted payments",
-      captionClasses: "govuk-table__caption--m",
-      classes: tableClasses,
-      head: headRow,
-      rows: rowsFuture
-    }) }}
-  {% endif %}
+        {# 11th month = July (12 months of the Academic year 0 indexed) #}
+
+        {% if thisMonth != 11 %}
+          <hr class="govuk-section-break govuk-section-break--m">
+          {{ govukTable({
+            caption: "Predicted payments",
+            captionClasses: "govuk-table__caption--m",
+            classes: tableClasses,
+            head: headRow,
+            rows: rowsFuture
+          }) }}
+        {% endif %}
+      </div>
+    {% else %}
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+        {% set pastTables = [] %}
+        {% set futureTables = [] %}
+
+        {% for item in months %}
+          {% set monthTableRows  = [] %}
+          {% set monthIndex = loop.index0 %}
+          {% set monthTableCaption = months[monthIndex] %}
+          {% set monthTotal = 0 %}
+          {% set cumulativeMonthTotal = 0 %}
+          {% for item in dataSource %}
+            {% set rowIndex = loop.index0 %}
+            {% set paymentDescription = item.description | fixNamesFromFunding | sentenceCase | formatYearRange %}
+            {% set monthTotal = monthTotal + item.monthlyPayments[monthIndex] %}
+            {% set cumulativeMonthTotal = cumulativeMonthTotal + item.cumulativeMonthlyPayments[monthIndex] %}
+            {% if item.monthlyPayments[monthIndex] != "" %}
+              {% set amount = item.monthlyPayments[monthIndex] | currency %}
+            {% else %}
+              {% set amount = "–" %}
+            {% endif %}
+            {% if item.cumulativeMonthlyPayments[monthIndex] != "" %}
+              {% set cumulativeAmount = item.cumulativeMonthlyPayments[monthIndex] | currency %}
+            {% else %}
+              {% set cumulativeAmount = "–" %}
+            {% endif %}
+            {% set row = [
+              { text: paymentDescription | safe },
+              { text: amount, format: "numeric" },
+              { text: cumulativeAmount, format: "numeric" }
+            ] %}
+            {% set monthTableRows = monthTableRows | push(row) %}
+          {% endfor %}
+          {% set monthTableRows = monthTableRows | push([
+            { text: "Total", classes: "govuk-!-font-weight-bold" }, 
+            { text: monthTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" },
+            { text: cumulativeMonthTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
+          ])%}
+          {% if loop.index0 <= thisMonth and cumulativeMonthTotal != 0 %}
+            {% set monthTableHtml %}
+              {{ govukTable({
+                caption: monthTableCaption,
+                captionClasses: "govuk-table__caption--m",
+                classes: tableClasses,
+                head: [
+                  {
+                    text: "Payment type"
+                  },
+                  {
+                    text: "Amount",
+                    format: "numeric",
+                    classes: "app-table__column-15"
+                  },
+                  {
+                    text: "Total for payment type",
+                    format: "numeric",
+                    classes: "app-table__column-15"
+                  }
+                ],
+                rows: monthTableRows
+              }) }}
+            {% endset %}
+            {% set pastTables = pastTables | push(monthTableHtml) %}
+          {% elseif cumulativeMonthTotal != 0 %}
+            {% set monthTableHtml %}
+              {{ govukTable({
+                caption: monthTableCaption,
+                captionClasses: "govuk-table__caption--m",
+                classes: tableClasses,
+                head: [
+                  {
+                    text: "Payment type"
+                  },
+                  {
+                    text: "Amount",
+                    format: "numeric",
+                    classes: "app-table__column-15"
+                  },
+                  {
+                    text: "Total for payment type",
+                    format: "numeric",
+                    classes: "app-table__column-15"
+                  }
+                ],
+                rows: monthTableRows
+              }) }}
+            {% endset %}
+            {% set futureTables = futureTables | push(monthTableHtml) %}
+          {% endif %}
+        {% endfor %}
+
+
+
+        {# Table per month #}
+        <h3 class="govuk-heading-m">Payments to {{ currentMonth("nameOfMonth") }} {{ currentYear() }}</h3>
+        {% for item in pastTables %}
+          {{ item | safe }}
+        {% endfor %}
+        {% if thisMonth != 11 %}
+          <hr class="govuk-section-break govuk-section-break--m">
+          <h3 class="govuk-heading-m">Predicted payments</h3>
+          {% for item in futureTables %}
+            {{ item | safe }}
+          {% endfor %}
+        {% endif %}
+      {% endif %}
+    </div>
+  </div>
 
 {% endblock %}

--- a/app/views/funding/monthly-payments.html
+++ b/app/views/funding/monthly-payments.html
@@ -4,7 +4,7 @@
 {% set backText = "Home" %}
 {% set backLink = '/home' %}
 
-{% set pageHeading = "Funding 2021 to 2022" %}
+{% set pageHeading = "Funding " + data.years.currentAcademicYear %}
 
 {% set tablePerMonth = true %}
 
@@ -114,7 +114,9 @@
   {% endfor %}
 
   {% if thisMonth != 12 %}
-    {% set tableCaption = 'Payments to ' + thisMonth | prettyMonthFromAugust %}
+    {% set tableCaption %}
+      Payments to {{ thisMonth | prettyMonthFromAugust }} {% if thisMonth < 6 %}{{ data.years.defaultCourseYear }}{% else %}{{ data.years.defaultCourseYear + 1 }}{% endif %}
+    {% endset %}
     {% set totalPerStreamRowPast = [{ text: "Total to " + thisMonth | prettyMonthFromAugust, classes: "govuk-!-font-weight-bold" }] if not tablePerMonth %}
   {% else %}
     {% set tableCaption = 'Monthl payments' %}
@@ -192,14 +194,24 @@
 
           {% set bodyRows = bodyRows | push([{ text: "Total", classes: "govuk-!-font-weight-bold" }, { text: monthTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }]) %}
 
+          {% set accordionTitle -%}
+            {{ month }} {% if loop.index < 6 %}{{ data.years.defaultCourseYear }}{% else %}{{ data.years.defaultCourseYear + 1 }}{% endif %}
+          {%- endset %}
+
           {% set accordionHtml %}
-            {{ govukTable({
-              classes: "app-table__in-accordion",
-              caption: month + " payments",
-              captionClasses: "govuk-visually-hidden",
-              head: [{ text: "Payment type" }, { text: "Amount", format: "numeric" }],
-              rows: bodyRows
-            }) }}
+            {% if monthTotal != 0 %}
+              {{ govukTable({
+                classes: "app-table__in-accordion",
+                caption: month + " payments",
+                captionClasses: "govuk-visually-hidden",
+                head: [{ text: "Payment type" }, { text: "Amount", format: "numeric" }],
+                rows: bodyRows
+              }) }}
+            {% else %}
+              <p class="govuk-body">
+                No payments for {{ accordionTitle }}.
+              </p>
+            {% endif %}
           {% endset %}
 
           {% if loop.index0 == thisMonth -1 %}
@@ -208,11 +220,11 @@
 
           {% set accordionItems = accordionItems | push(
             { 
-              heading: { text: month },
+              heading: { text: accordionTitle },
               content: { html: accordionHtml },
               expanded: expandedState
             }
-          ) if monthTotal != 0 %}
+          )%}
         {% endfor %}
 
         <h2 class="govuk-heading-m">Payment breakdown</h2>

--- a/app/views/funding/monthly-payments.html
+++ b/app/views/funding/monthly-payments.html
@@ -6,6 +6,8 @@
 
 {% set pageHeading = "Funding 2021 to 2022" %}
 
+{% set tablePerMonth = true %}
+
 {% block content %}
 
   {% set yearPaymentsTabName = "" | typesOfFunding | joinify  | sentenceCase %}
@@ -13,14 +15,31 @@
   {% set activeTabMonthly = true %}
   {% include "_includes/funding-header-and-tab-nav.html" %}
 
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <h2 class="govuk-heading-l">
+        Monthly payments
+      </h2>
+      <p class="govuk-body govuk-!-margin-bottom-2">
+        Last updated: {{ "" | yesterdayGovuk }}
+      </p>
+      <p class="govuk-body">
+        <a href="#" class="govuk-link--no-visited-state">Export monthly payments</a>
+      </p>
+    </div>
+  </div>
+
+  {# Set which data the user sees #}
   {% if accessLevel == 'accreditingProvider' %}
     {% set dataSource = data.funding.monthlyFundingScitts %}
   {% else %}
     {% set dataSource = data.funding.monthlyFundingLeadSchools %}
   {% endif %}
-  {% set dataSource = dataSource | sort(attribute = "description") %}
+  {% set dataSource = dataSource | sort(attribute = "descriptions") %}
 
-  {% if dataSource.length > 4 %}
+
+  {# Makes the type size smaller if the table is has more than 4 columns #}
+  {% if not tablePerMonth %}
     {% set tableClasses = "govuk-!-font-size-16" %}
   {% endif %}
 
@@ -39,8 +58,6 @@
     "July"
   ]%}
 
-
-  {# Get Month starting from August #}
   {% if currentMonth() >= 6 %}
     {% set thisMonth = -1 + currentMonth() - 6 %}
   {% else %}
@@ -48,215 +65,167 @@
   {% endif %}
   {# {% set thisMonth = 12 %} #}
 
-  {% if thisMonth == 12 %}
-    {% set totalRowTitle = "Total" %}
-  {% else %}
-    {% set totalRowTitle = "Total to " + thisMonth | prettyMonthFromAugust %}
+  {% set pastTotal     = 0 %}
+  {% set total         = 0 %}
+
+  {% set pastRows     = [] %}
+  {% set futureRows   = [] %}
+
+
+  {% set headRow = [{ text: "Month" }] %}
+  {% if not tablePerMonth %}
+    {% for item in dataSource %}
+      {% set headRow = headRow | push({ text: item.descriptions | fixNamesFromFunding | sentenceCase | formatYearRange | safe }) %}
+    {% endfor %}
+  {% endif %}
+  {% set headRow = headRow | push({ text: "Total", format: "numeric" }) %}
+  {% if tablePerMonth %}
+    {% set headRow = headRow | push({ text: "Running total", format: "numeric" }) %}
   {% endif %}
 
+  {% for month in months %}
+    
+    {% set monthTotal = 0 %}
+    {% set row = [{ text: month }] %}
+
+    {% set monthIndex = loop.index0 %}
+    {% for item in dataSource %}
+      {% if not tablePerMonth %}
+        {% set row = row | push({text: item.monthlyPayments[monthIndex] | currency, format: "numeric" }) %}
+      {% endif %}
+      {% set monthTotal = monthTotal + item.monthlyPayments[monthIndex] %}
+    {% endfor %}
+
+    {% set row = row | push({ text: monthTotal | currency, format: "numeric" }) %}
+
+    {% if monthIndex < thisMonth %}
+      {% set pastTotal = pastTotal + monthTotal %}
+      {% set total = total + monthTotal %}
+      {% if tablePerMonth %}
+        {% set row = row | push({ text: total | currency, format: "numeric" }) %}
+      {% endif %}
+      {% set pastRows = pastRows | push(row) %}
+    {% else %}
+      {% set total = total + monthTotal %}
+      {% if tablePerMonth %}
+        {% set row = row | push({ text: total | currency, format: "numeric" }) if tablePerMonth %}
+      {% endif %}
+      {% set futureRows = futureRows | push(row) %}
+    {% endif %}
+
+  {% endfor %}
+
+  {% if thisMonth != 12 %}
+    {% set tableCaption = 'Payments to ' + thisMonth | prettyMonthFromAugust %}
+    {% set totalPerStreamRowPast = [{ text: "Total to " + thisMonth | prettyMonthFromAugust, classes: "govuk-!-font-weight-bold" }] if not tablePerMonth %}
+  {% else %}
+    {% set tableCaption = 'Monthl payments' %}
+    {% set totalPerStreamRowPast = [{ text: "Total", classes: "govuk-!-font-weight-bold" }] %}
+  {% endif %}
+  {% set totalPerStreamRow = [{ text: "Predicted total", classes: "govuk-!-font-weight-bold" }] if not tablePerMonth %}
+
+  {% if not tablePerMonth %}
+    {% for item in dataSource %}
+      {% set totalPerStreamRowPast = totalPerStreamRowPast | push(
+        {text: item.cumulativeMonthlyPayments[thisMonth - 1] | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
+      ) %}
+      {% set totalPerStreamRow = totalPerStreamRow | push(
+        {text: item.cumulativeMonthlyPayments[11] | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
+      ) %}
+    {% endfor %}
+  {% endif %}
+
+  {% set totalPerStreamRowPast = totalPerStreamRowPast | push({text: pastTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }) if not tablePerMonth %}
+  {% set totalPerStreamRow = totalPerStreamRow | push({text: total | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }) if not tablePerMonth %}
+
+  {% set pastRows = pastRows | push(totalPerStreamRowPast) %}
+  {% set futureRows = futureRows | push(totalPerStreamRow) %}
+
+
   <div class="govuk-grid-row">
+  {% if not tablePerMonth %}
+    <div class="govuk-grid-column-full">
+  {% else %}
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <h2 class="govuk-heading-l">
-        Monthly payments
-      </h2>
-      <p class="govuk-body govuk-!-margin-bottom-1">
-        Last updated: {{ "" | yesterdayGovuk }}
-      </p>
-      <p>
-        <a href="#" class="govuk-link--no-visited-state">Export monthly payments</a>
-      </p>
-    </div>
-  </div>
+  {% endif %}
 
-  <hr class="govuk-section-break govuk-section-break--m">
+        <hr class="govuk-section-break govuk-section-break--m">
 
-  <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds-from-desktop">
-
-      {# Summary to date #}
-      {% set headRow = [
-        { text: "Month", classes: "app-table__column-25" },
-        { text: "Recovery", classes: "app-table__column-25", format: "numeric" },
-        { text: "Payment", classes: "app-table__column-25", format: "numeric" },
-        { text: "Total", classes: "app-table__column-25", format: "numeric" }
-      ] %}
-
-      {% set bodyRowsPast = [] %}
-      {% set bodyRowsFuture = [] %}
-
-
-      {% set pastTotal = 0 %}
-      {% set pastRecoveryTotal = 0 %}
-      {% set pastPaymentTotal = 0 %}
-
-      {% set recoveryTotal = 0 %}
-      {% set paymentTotal = 0 %}
-      {% set total = 0 %}
-
-      {% for month in months %}
-
-        {% set recovery = 0 %}
-        {% set payment = 0 %}
-        {% set monthTotal = 0 %}
-
-        {% set monthIndex = loop.index0 %}
-
-        {% for item in dataSource %}
-
-
-          {% if item.monthlyPayments[monthIndex] < 0 %}
-            {% set recovery = recovery + item.monthlyPayments[monthIndex] %}
-          {% else %}
-            {% set payment = payment + item.monthlyPayments[monthIndex] %}
-          {% endif %}
-          {% set monthTotal = monthTotal + recovery + payment %}
-          {% set total = total + monthTotal %}
-          {% if loop.index0 < thisMonth %}
-            {% set pastRecoveryTotal = pastRecoveryTotal + recovery %}
-            {% set pastPaymentTotal = pastPaymentTotal + payment %}
-            {% set pastTotal = pastPaymentTotal + pastRecoveryTotal %}
-          {% endif %}
-          {% set recoveryTotal = recoveryTotal + recovery %}
-          {% set paymentTotal = paymentTotal + payment %}
-          {% set total = paymentTotal + recoveryTotal %}
-        {% endfor %}
-
-        {% set row = [
-          { text: month },
-          { text: recovery | currency, format: "numeric" },
-          { text: payment | currency, format: "numeric" },
-          { text: monthTotal | currency, format: "numeric" }
-        ] %}
-
-        {% if loop.index0 < thisMonth %}
-          {% set bodyRowsPast = bodyRowsPast | push(row) %}
-        {% else %}
-          {% set bodyRowsFuture = bodyRowsFuture | push(row) %}
-        {% endif %}
-
-      {% endfor %}
-
-      {% set bodyRowsPast = bodyRowsPast | push([
-        { text: totalRowTitle, classes: "govuk-!-font-weight-bold" },
-        { text: pastRecoveryTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" },
-        { text: pastPaymentTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }, 
-        { text: pastTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
-      ])%}
-
-      {% set bodyRowsFuture = bodyRowsFuture | push([
-        { text: "Total", classes: "govuk-!-font-weight-bold" },
-        { text: recoveryTotal  | currency, format: "numeric", classes: "govuk-!-font-weight-bold" },
-        { text: paymentTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" },
-        { text: total | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
-      ])%}
-
-      <h3 class="govuk-heading-m">Summary of payments per month</h3>
-
-      {{ govukTable({
-        caption: "Payments made",
-        captionClasses: "govuk-table__caption--s",
-        head: headRow,
-        rows: bodyRowsPast
-      }) }}
-
-      {{ govukTable({
-        caption: "Predicted payments",
-        captionClasses: "govuk-table__caption--s",
-        head: headRow,
-        rows: bodyRowsFuture
-      }) if thisMonth != 12 }}
-
-      <hr class="govuk-section-break govuk-section-break--l">
-
-      <h2 class="govuk-heading-l">Payments by funding stream</h2>
-
-      {% set accordionItems = [] %}
-
-      {# Payment per month, by payment type tables #}
-      {% for item in dataSource %}
-
-        {% set headRow = [{ text: "Month"}, { text: "Payment" }] %}
-        
-        {% set pastTotal = 0 %}
-        {% set futureTotal = 0 %}
-
-        {% set pastRows = [] %}
-        {% set futureRows = [] %}
-        {% for month in months %}
-          {% set row = [] %}
-          {% if item.monthlyPayments[loop.index0] %}
-            {% set row = [{ text: month }, { text: item.monthlyPayments[loop.index0] | currency, format: "numeric" }] %}
-          {% endif %}
-          {% if loop.index0 < thisMonth %}
-            {% set pastTotal = pastTotal + item.monthlyPayments[loop.index0] %}
-            {% set pastRows = pastRows | push(row) %}
-            {% set futureTotal = pastTotal %}
-          {% else %}
-            {% set futureTotal = futureTotal + item.monthlyPayments[loop.index0] %}
-            {% set futureRows = futureRows | push(row) %}
-          {% endif %}
-        {% endfor %}
-
-        {% set pastTotalRowHeading %}
-          {% if pastTotal == futureTotal %}
-            Total
-          {% else %}
-            Total to {{ thisMonth | prettyMonthFromAugust }}
-          {% endif %}
-        {% endset %}
-
-        {% set pastRows = pastRows | push([
-          { text: pastTotalRowHeading, classes: "govuk-!-font-weight-bold" },
-          { text: pastTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
-        ]) %}
-
-        {% set futureRows = futureRows | push([
-          { text: "Predicted total", classes: "govuk-!-font-weight-bold" },
-          { text: futureTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
-        ]) %}
-
-
-      {% set accordionHTML %}
-
+        <!-- Everything in one table -->
         {{ govukTable({
-          caption: "Paymants made",
-          captionClasses: "govuk-table__caption--s",
+          classes: tableClasses,
+          caption: tableCaption,
+          captionClasses: "govuk-table__caption--m govuk-!-margin-bottom-3",
           head: headRow,
           rows: pastRows
         }) }}
 
-        {% if pastTotal == futureTotal and this != 12 %}
-
-          <p class="govuk-body govuk-!-margin-bottom-7">No more {{ item.description | fixNamesFromFunding | startLowerCase | formatYearRange | safe }} predicted.</p>
-
-        {% elseif thisMonth != 12 %}
-
-          {{ govukTable({
-            classes: "govuk-!-margin-bottom-7",
-            caption: "Remaining payments (predicted)",
-            captionClasses: "govuk-table__caption--s",
-            head: headRow,
-            rows: futureRows
-          }) }}
-
-        {% endif %}
-
-      {% endset %}
-      {% set accordionItems = accordionItems | push(
-        { 
-          heading: { text: item.description | fixNamesFromFunding | sentenceCase | formatYearRange | safe },
-          content: { html: accordionHTML }
-        }
-      ) %}
-
-    {% endfor %}
-
-    {{ govukAccordion({
-      id: "accordion-default",
-      items: accordionItems
-    }) }}
-
+        {{ govukTable({
+          classes: tableClasses,
+          caption: "Predicted payments",
+          captionClasses: "govuk-table__caption--m govuk-!-margin-bottom-3",
+          head: headRow,
+          rows: futureRows
+        }) if thisMonth != 12 }}
     </div>
   </div>
+  {% if tablePerMonth %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+
+        {% set accordionItems = [] %}
+
+        {% for month in months %}
+        
+          {% set bodyRows = [] %}
+          {% set monthIndex = loop.index0 %}
+          {% set expandedState = false %}
+          {% set monthTotal = 0 %}
+
+          {% for item in dataSource %}
+              {% set row = [
+                { text: item.descriptions | fixNamesFromFunding | sentenceCase | formatYearRange | safe },
+                { text: item.monthlyPayments[monthIndex] | currency, format: "numeric" }
+              ] if item.monthlyPayments[monthIndex] %}
+            {% set monthTotal = monthTotal + item.monthlyPayments[monthIndex] %}
+            {% set bodyRows = bodyRows | push(row) %}
+          {% endfor %}
+
+          {% set bodyRows = bodyRows | push([{ text: "Total", classes: "govuk-!-font-weight-bold" }, { text: monthTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }]) %}
+
+          {% set accordionHtml %}
+            {{ govukTable({
+              classes: "app-table__in-accordion",
+              caption: month + " payments",
+              captionClasses: "govuk-visually-hidden",
+              head: [{ text: "Payment type" }, { text: "Amount", format: "numeric" }],
+              rows: bodyRows
+            }) }}
+          {% endset %}
+
+          {% if loop.index0 == thisMonth %}
+            {% set expandedState = true %}
+          {% endif %}
+
+          {% set accordionItems = accordionItems | push(
+            { 
+              heading: { text: month },
+              content: { html: accordionHtml },
+              expanded: expandedState
+            }
+          ) if monthTotal != 0 %}
+        {% endfor %}
+
+        <h2 class="govuk-heading-m">Payment breakdown</h2>
+
+        {{ govukAccordion({
+          id: "accordion-default",
+          items: accordionItems
+        })}}
+
+    </div>
+  {% endif %}
+</div>
+
 
 {% endblock %}

--- a/app/views/funding/monthly-payments.html
+++ b/app/views/funding/monthly-payments.html
@@ -1,11 +1,15 @@
-{% extends "layout.html" %}
+{% extends "_templates/_page.html" %}
 {% set navActive = "funding" %}
+
+{% set backText = "Home" %}
+{% set backLink = '/home' %}
+
+{% set pageHeading = "Funding 2021 to 2022" %}
 
 {% block content %}
 
-  {% set pageHeading = "Funding 2021 to 2022" %}
-
   {% set yearPaymentsTabName = "" | typesOfFunding | joinify  | sentenceCase %}
+
   {% set activeTabMonthly = true %}
   {% include "_includes/funding-header-and-tab-nav.html" %}
 

--- a/app/views/funding/monthly-payments.html
+++ b/app/views/funding/monthly-payments.html
@@ -202,7 +202,7 @@
             }) }}
           {% endset %}
 
-          {% if loop.index0 == thisMonth %}
+          {% if loop.index0 == thisMonth -1 %}
             {% set expandedState = true %}
           {% endif %}
 

--- a/app/views/funding/monthly-payments.html
+++ b/app/views/funding/monthly-payments.html
@@ -20,18 +20,6 @@
     {% set tableClasses = "govuk-!-font-size-16" %}
   {% endif %}
 
-  {% set headRow = [{ text: "Month" }] %}
-  {% for item in dataSource %}
-    {% set headRow = headRow | push({ text: item.description | fixNamesFromFunding | sentenceCase | formatYearRange | safe }) %}
-  {% endfor %}
-  {% set headRow = headRow | push({ text: "Total" }) %}
-
-  {% set rowsPast = [] %}
-  {% set pastTotal = 0 %}
-
-  {% set rowsFuture = [] %}
-  {% set futureTotal = 0 %}
-
   {% set months  = [
     "August",
     "September",
@@ -47,58 +35,20 @@
     "July"
   ]%}
 
-  {% if currentMonth() >= 8 %}
-    {% set thisMonth = currentMonth() - 8 %}
+
+  {# Get Month starting from August #}
+  {% if currentMonth() >= 6 %}
+    {% set thisMonth = -1 + currentMonth() - 6 %}
   {% else %}
-    {% set thisMonth = currentMonth() + 4 %}
+    {% set thisMonth = -1 + currentMonth() + 6 %}
   {% endif %}
+  {# {% set thisMonth = 12 %} #}
 
-  {% for item in months %}
-    {% set monthIndex = loop.index0 %}
-    {% set monthTotal = 0 %}
-    {% set row = [{ text: months[monthIndex]}] %}
-    {% for paymentType in dataSource %}
-      {% if paymentType.monthlyPayments[monthIndex] == 0 %}
-        {% set amount = "–" %}
-      {% else %}
-        {% set amount = paymentType.monthlyPayments[monthIndex] | currency %}
-      {% endif %}
-      {% set monthTotal = monthTotal + paymentType.monthlyPayments[monthIndex] %}
-      {% set row = row | push({ text: amount, format: "numeric" }) %}
-    {% endfor %}
-    {% if monthTotal != 0 %}
-      {% set row = row | push({ text: monthTotal | currency, format: "numeric" }) %}
-    {% else %}
-      {% set row = row | push({ text: "–", format: "numeric" }) %}
-    {% endif %}
-    {% if thisMonth >= loop.index0 %}
-      {% set pastTotal = pastTotal + monthTotal %}
-      {% set rowsPast = rowsPast | push(row) %}
-    {% else %}
-      {% set futureTotal = futureTotal + monthTotal %}
-      {% set rowsFuture = rowsFuture | push(row) %}
-    {% endif %}
-  {% endfor %}
-
-  {% set summaryRows = [] %}
-  {% if thisMonth != 11 %}
-    {% set summaryRowItems = [
-      { text: "Payments to " + currentMonth("nameOfMonth") + " " + currentYear() }, 
-      { text: pastTotal | currency, format: "numeric" }] 
-    %}
-    {% set summaryRows = summaryRows | push(summaryRowItems) %}
-    {% set summaryRowItems = [
-      { text: "Predicted payments" }, 
-      { text: futureTotal | currency, format: "numeric" }] 
-    %}
-    {% set summaryRows = summaryRows | push(summaryRowItems) %}
-    {% set summaryRowItems = [{ text: "Predicted total" }, { text: (pastTotal + futureTotal) | currency, format: "numeric" }] %}
-    {% set summaryRows = summaryRows | push(summaryRowItems) %}
+  {% if thisMonth == 12 %}
+    {% set totalRowTitle = "Total" %}
   {% else %}
-    {% set summaryRowItems = [{ text: "Total for year" }, { text: pastTotal | currency, format: "numeric" }] %}
-    {% set summaryRows = summaryRows | push(summaryRowItems) %}
+    {% set totalRowTitle = "Total to " + thisMonth | prettyMonthFromAugust %}
   {% endif %}
-
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
@@ -117,156 +67,183 @@
   <hr class="govuk-section-break govuk-section-break--m">
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half-from-desktop">
-      {{ govukTable({
-        caption: "Summary",
-        captionClasses: "govuk-table__caption--m",
-        head: [
-                {
-                  text: "Payment type"
-                },
-                {
-                  text: "Amount",
-                  classes: "app-table__column-25"
-                }
-              ],
-        rows: summaryRows
-      }) }}
-    </div>
-  </div>
-  <hr class="govuk-section-break govuk-section-break--m">
-  <div class="govuk-grid-row">
-    {% if dataSource.length < 6 %}
-      <div class="govuk-grid-column-full">
-
-        {# Single table showing all months #}
-        {{ govukTable({
-          caption: "Payments to " + currentMonth("nameOfMonth") + " " + currentYear(),
-          captionClasses: "govuk-table__caption--m",
-          classes: tableClasses,
-          head: headRow,
-          rows: rowsPast
-        }) }}
-
-        {# 11th month = July (12 months of the Academic year 0 indexed) #}
-
-        {% if thisMonth != 11 %}
-          <hr class="govuk-section-break govuk-section-break--m">
-          {{ govukTable({
-            caption: "Predicted payments",
-            captionClasses: "govuk-table__caption--m",
-            classes: tableClasses,
-            head: headRow,
-            rows: rowsFuture
-          }) }}
-        {% endif %}
-      </div>
-    {% else %}
       <div class="govuk-grid-column-two-thirds-from-desktop">
-        {% set pastTables = [] %}
-        {% set futureTables = [] %}
 
-        {% for item in months %}
-          {% set monthTableRows  = [] %}
-          {% set monthIndex = loop.index0 %}
-          {% set monthTableCaption = months[monthIndex] %}
-          {% set monthTotal = 0 %}
-          {% set cumulativeMonthTotal = 0 %}
-          {% for item in dataSource %}
-            {% set rowIndex = loop.index0 %}
-            {% set paymentDescription = item.description | fixNamesFromFunding | sentenceCase | formatYearRange %}
-            {% set monthTotal = monthTotal + item.monthlyPayments[monthIndex] %}
-            {% set cumulativeMonthTotal = cumulativeMonthTotal + item.cumulativeMonthlyPayments[monthIndex] %}
-            {% if item.monthlyPayments[monthIndex] != "" %}
-              {% set amount = item.monthlyPayments[monthIndex] | currency %}
-            {% else %}
-              {% set amount = "–" %}
-            {% endif %}
-            {% if item.cumulativeMonthlyPayments[monthIndex] != "" %}
-              {% set cumulativeAmount = item.cumulativeMonthlyPayments[monthIndex] | currency %}
-            {% else %}
-              {% set cumulativeAmount = "–" %}
-            {% endif %}
-            {% set row = [
-              { text: paymentDescription | safe },
-              { text: amount, format: "numeric" },
-              { text: cumulativeAmount, format: "numeric" }
-            ] %}
-            {% set monthTableRows = monthTableRows | push(row) %}
-          {% endfor %}
-          {% set monthTableRows = monthTableRows | push([
-            { text: "Total", classes: "govuk-!-font-weight-bold" }, 
-            { text: monthTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" },
-            { text: cumulativeMonthTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
-          ])%}
-          {% if loop.index0 <= thisMonth and cumulativeMonthTotal != 0 %}
-            {% set monthTableHtml %}
-              {{ govukTable({
-                caption: monthTableCaption,
-                captionClasses: "govuk-table__caption--m",
-                classes: tableClasses,
-                head: [
-                  {
-                    text: "Payment type"
-                  },
-                  {
-                    text: "Amount",
-                    format: "numeric",
-                    classes: "app-table__column-15"
-                  },
-                  {
-                    text: "Total for payment type",
-                    format: "numeric",
-                    classes: "app-table__column-15"
-                  }
-                ],
-                rows: monthTableRows
-              }) }}
-            {% endset %}
-            {% set pastTables = pastTables | push(monthTableHtml) %}
-          {% elseif cumulativeMonthTotal != 0 %}
-            {% set monthTableHtml %}
-              {{ govukTable({
-                caption: monthTableCaption,
-                captionClasses: "govuk-table__caption--m",
-                classes: tableClasses,
-                head: [
-                  {
-                    text: "Payment type"
-                  },
-                  {
-                    text: "Amount",
-                    format: "numeric",
-                    classes: "app-table__column-15"
-                  },
-                  {
-                    text: "Total for payment type",
-                    format: "numeric",
-                    classes: "app-table__column-15"
-                  }
-                ],
-                rows: monthTableRows
-              }) }}
-            {% endset %}
-            {% set futureTables = futureTables | push(monthTableHtml) %}
+      {# Summary to date #}
+      {% set headRow = [
+        { text: "Month", classes: "app-table__column-25" },
+        { text: "Recovery", classes: "app-table__column-25", format: "numeric" },
+        { text: "Payment", classes: "app-table__column-25", format: "numeric" },
+        { text: "Total", classes: "app-table__column-25", format: "numeric" }
+      ] %}
+
+      {% set bodyRowsPast = [] %}
+      {% set bodyRowsFuture = [] %}
+
+
+      {% set pastTotal = 0 %}
+      {% set pastRecoveryTotal = 0 %}
+      {% set pastPaymentTotal = 0 %}
+
+      {% set recoveryTotal = 0 %}
+      {% set paymentTotal = 0 %}
+      {% set total = 0 %}
+
+      {% for month in months %}
+
+        {% set recovery = 0 %}
+        {% set payment = 0 %}
+        {% set monthTotal = 0 %}
+
+        {% set monthIndex = loop.index0 %}
+
+        {% for item in dataSource %}
+
+
+          {% if item.monthlyPayments[monthIndex] < 0 %}
+            {% set recovery = recovery + item.monthlyPayments[monthIndex] %}
+          {% else %}
+            {% set payment = payment + item.monthlyPayments[monthIndex] %}
+          {% endif %}
+          {% set monthTotal = monthTotal + recovery + payment %}
+          {% set total = total + monthTotal %}
+          {% if loop.index0 < thisMonth %}
+            {% set pastRecoveryTotal = pastRecoveryTotal + recovery %}
+            {% set pastPaymentTotal = pastPaymentTotal + payment %}
+            {% set pastTotal = pastPaymentTotal + pastRecoveryTotal %}
+          {% endif %}
+          {% set recoveryTotal = recoveryTotal + recovery %}
+          {% set paymentTotal = paymentTotal + payment %}
+          {% set total = paymentTotal + recoveryTotal %}
+        {% endfor %}
+
+        {% set row = [
+          { text: month },
+          { text: recovery | currency, format: "numeric" },
+          { text: payment | currency, format: "numeric" },
+          { text: monthTotal | currency, format: "numeric" }
+        ] %}
+
+        {% if loop.index0 < thisMonth %}
+          {% set bodyRowsPast = bodyRowsPast | push(row) %}
+        {% else %}
+          {% set bodyRowsFuture = bodyRowsFuture | push(row) %}
+        {% endif %}
+
+      {% endfor %}
+
+      {% set bodyRowsPast = bodyRowsPast | push([
+        { text: totalRowTitle, classes: "govuk-!-font-weight-bold" },
+        { text: pastRecoveryTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" },
+        { text: pastPaymentTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }, 
+        { text: pastTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
+      ])%}
+
+      {% set bodyRowsFuture = bodyRowsFuture | push([
+        { text: "Total", classes: "govuk-!-font-weight-bold" },
+        { text: recoveryTotal  | currency, format: "numeric", classes: "govuk-!-font-weight-bold" },
+        { text: paymentTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" },
+        { text: total | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
+      ])%}
+
+      <h3 class="govuk-heading-m">Summary of payments per month</h3>
+
+      {{ govukTable({
+        caption: "Payments made",
+        captionClasses: "govuk-table__caption--s",
+        head: headRow,
+        rows: bodyRowsPast
+      }) }}
+
+      {{ govukTable({
+        caption: "Predicted payments",
+        captionClasses: "govuk-table__caption--s",
+        head: headRow,
+        rows: bodyRowsFuture
+      }) if thisMonth != 12 }}
+
+      <hr class="govuk-section-break govuk-section-break--l">
+
+      <h2 class="govuk-heading-l">Payments by funding stream</h2>
+
+      {# Payment per month, by payment type tables #}
+      {% for item in dataSource %}
+
+        {% set headRow = [{ text: "Month"}, { text: "Payment" }] %}
+        
+        {% set pastTotal = 0 %}
+        {% set futureTotal = 0 %}
+
+        {% set pastRows = [] %}
+        {% set futureRows = [] %}
+        {% for month in months %}
+          {% set row = [] %}
+          {% if item.monthlyPayments[loop.index0] %}
+            {% set row = [{ text: month }, { text: item.monthlyPayments[loop.index0] | currency, format: "numeric" }] %}
+          {% endif %}
+          {% if loop.index0 < thisMonth %}
+            {% set pastTotal = pastTotal + item.monthlyPayments[loop.index0] %}
+            {% set pastRows = pastRows | push(row) %}
+            {% set futureTotal = pastTotal %}
+          {% else %}
+            {% set futureTotal = futureTotal + item.monthlyPayments[loop.index0] %}
+            {% set futureRows = futureRows | push(row) %}
           {% endif %}
         {% endfor %}
 
+        {% set pastTotalRowHeading %}
+          {% if pastTotal == futureTotal %}
+            Total
+          {% else %}
+            Total to {{ thisMonth | prettyMonthFromAugust }}
+          {% endif %}
+        {% endset %}
+
+        {% set pastRows = pastRows | push([
+          { text: pastTotalRowHeading, classes: "govuk-!-font-weight-bold" },
+          { text: pastTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
+        ]) %}
+
+        {% set futureRows = futureRows | push([
+          { text: "Predicted total", classes: "govuk-!-font-weight-bold" },
+          { text: futureTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
+        ]) %}
 
 
-        {# Table per month #}
-        <h3 class="govuk-heading-m">Payments to {{ currentMonth("nameOfMonth") }} {{ currentYear() }}</h3>
-        {% for item in pastTables %}
-          {{ item | safe }}
-        {% endfor %}
-        {% if thisMonth != 11 %}
-          <hr class="govuk-section-break govuk-section-break--m">
-          <h3 class="govuk-heading-m">Predicted payments</h3>
-          {% for item in futureTables %}
-            {{ item | safe }}
-          {% endfor %}
+        <h3 class="govuk-heading-m">{{ item.description | fixNamesFromFunding | sentenceCase | formatYearRange | safe }}</h3>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+
+        {{ govukTable({
+          caption: "Paymants made",
+          captionClasses: "govuk-table__caption--s",
+          head: headRow,
+          rows: pastRows
+        }) }}
+
+        {% if pastTotal == futureTotal and this != 12 %}
+
+          <p class="govuk-body">No more {{ item.description | fixNamesFromFunding | startLowerCase | formatYearRange | safe }} predicted.</p>
+
+        {% elseif thisMonth != 12 %}
+
+          {{ govukTable({
+            caption: "Remaining payments (predicted)",
+            captionClasses: "govuk-table__caption--s",
+            head: headRow,
+            rows: futureRows
+          }) }}
+
         {% endif %}
-      {% endif %}
+
+        <hr class="govuk-section-break govuk-section-break--l">
+
+        {% endfor %}
+
+
     </div>
   </div>
 

--- a/app/views/funding/monthly-payments.html
+++ b/app/views/funding/monthly-payments.html
@@ -166,6 +166,8 @@
 
       <h2 class="govuk-heading-l">Payments by funding stream</h2>
 
+      {% set accordionItems = [] %}
+
       {# Payment per month, by payment type tables #}
       {% for item in dataSource %}
 
@@ -210,12 +212,7 @@
         ]) %}
 
 
-        <h3 class="govuk-heading-m">{{ item.description | fixNamesFromFunding | sentenceCase | formatYearRange | safe }}</h3>
-      </div>
-    </div>
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
+      {% set accordionHTML %}
 
         {{ govukTable({
           caption: "Paymants made",
@@ -226,11 +223,12 @@
 
         {% if pastTotal == futureTotal and this != 12 %}
 
-          <p class="govuk-body">No more {{ item.description | fixNamesFromFunding | startLowerCase | formatYearRange | safe }} predicted.</p>
+          <p class="govuk-body govuk-!-margin-bottom-7">No more {{ item.description | fixNamesFromFunding | startLowerCase | formatYearRange | safe }} predicted.</p>
 
         {% elseif thisMonth != 12 %}
 
           {{ govukTable({
+            classes: "govuk-!-margin-bottom-7",
             caption: "Remaining payments (predicted)",
             captionClasses: "govuk-table__caption--s",
             head: headRow,
@@ -239,10 +237,20 @@
 
         {% endif %}
 
-        <hr class="govuk-section-break govuk-section-break--l">
+      {% endset %}
+      {% set accordionItems = accordionItems | push(
+        { 
+          heading: { text: item.description | fixNamesFromFunding | sentenceCase | formatYearRange | safe },
+          content: { html: accordionHTML }
+        }
+      ) %}
 
-        {% endfor %}
+    {% endfor %}
 
+    {{ govukAccordion({
+      id: "accordion-default",
+      items: accordionItems
+    }) }}
 
     </div>
   </div>

--- a/app/views/funding/monthly-payments.html
+++ b/app/views/funding/monthly-payments.html
@@ -37,8 +37,6 @@
   {% endif %}
   {% set dataSource = dataSource | sort(attribute = "descriptions") %}
 
-
-  {# Makes the type size smaller if the table is has more than 4 columns #}
   {% if not tablePerMonth %}
     {% set tableClasses = "govuk-!-font-size-16" %}
   {% endif %}
@@ -84,7 +82,7 @@
   {% endif %}
 
   {% for month in months %}
-    
+
     {% set monthTotal = 0 %}
     {% set row = [{ text: month }] %}
 
@@ -141,7 +139,6 @@
   {% set pastRows = pastRows | push(totalPerStreamRowPast) %}
   {% set futureRows = futureRows | push(totalPerStreamRow) %}
 
-
   <div class="govuk-grid-row">
   {% if not tablePerMonth %}
     <div class="govuk-grid-column-full">
@@ -167,8 +164,10 @@
           head: headRow,
           rows: futureRows
         }) if thisMonth != 12 }}
+
     </div>
   </div>
+
   {% if tablePerMonth %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
@@ -223,9 +222,7 @@
           items: accordionItems
         })}}
 
+      </div>
     </div>
   {% endif %}
-</div>
-
-
 {% endblock %}


### PR DESCRIPTION
We have an unknown data set coming from the funding team, so I wanted to make sure we could handle any complexity of data.

To do this we've decided to show a simple breakdown (payment and running total per month) and then show a detailed breakdown for each month. 

![localhost_3000_funding_monthly-payments(screenshot) (9)](https://user-images.githubusercontent.com/8417288/153394618-c2261b17-0301-4a3a-8ecf-caf04429c32e.png)
