### PR TITLE
Historic funding

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -226,7 +226,7 @@ span.summary-validation-symbol {
 
 // column widths for tables
 // app-table__column-xx
-$sizes: 70, 53, 33, 25, 20, 16, 15, 10;
+$sizes: 70, 53, 35, 25, 20, 16, 15, 10;
 
 @each $size in $sizes {
   .app-table__column-#{$size} {

--- a/app/data/funding.js
+++ b/app/data/funding.js
@@ -5,10 +5,10 @@ const _ = require('lodash')
 let monthlyFundingScittsCsv = 
 `Academic year,Provider ID,Provider name,Description,Total funding,August,September,October,November,December,January,February,March,April,May,June,July
 2021/22,0,Webury Hill SCITT,Course extension trainee payments for AY 20/21,13000,3250,3250,3250,1625,1625,0,0,0,0,0,0,0
-2021/22,0,Webury Hill SCITT,Training bursary trainees,158750,,27540,27540,27540,1517.5,7937.5,7937.5,11112.5,11112.5,12700,14287.5,9525
+2021/22,0,Webury Hill SCITT,Training bursary trainees,158750,0,27540,27540,27540,1517.5,7937.5,7937.5,11112.5,11112.5,12700,14287.5,9525
 2021/22,0,Webury Hill SCITT,Course extension provider payments for AY 20/21,4000,0,1000,1000,1000,1000,0,0,0,0,0,0,0
-2021/23,0,Webury Hill SCITT,TB 21/22 in-year adjustment for withdrawals,-6300,,,,,-3150,-3150,0,0,0,0,0,0
-2021/22,0,Webury Hill SCITT,Early Years ITT Bursaries & Training Grants,1254001,,52853,62708,57780,278100,112860,112860,163020,112860,112860,112860,75240`
+2021/23,0,Webury Hill SCITT,TB 21/22 in-year adjustment for withdrawals,-6300,0,0,0,0,-3150,-3150,0,0,0,0,0,0
+2021/22,0,Webury Hill SCITT,Early Years ITT Bursaries & Training Grants,1254001,0,52853,62708,57780,278100,112860,112860,163020,112860,112860,112860,75240`
 
 let monthlyFundingScittsArray = CSV.parse(monthlyFundingScittsCsv)
 monthlyFundingScittsArray.shift() // remove header row

--- a/app/views/_includes/funding-header-and-tab-nav.html
+++ b/app/views/_includes/funding-header-and-tab-nav.html
@@ -30,5 +30,5 @@
     text: "Past year’s funding",
     href: '/funding/data',
     active: activeTabFundingData
-  }
+  } if false
 ]}) }}

--- a/app/views/_includes/funding-header-and-tab-nav.html
+++ b/app/views/_includes/funding-header-and-tab-nav.html
@@ -1,3 +1,6 @@
+{% set backText = "Home" %}
+{% set backLink = '/home' %}
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <span class="govuk-caption-xl">{{ data.signedInProviders | andSeparate }}</span>
@@ -9,18 +12,23 @@
   label: 'Sub navigation',
   classes: 'govuk-!-margin-bottom-4',
   items: [{
-    text: 'Monthly payments',
+    text: 'Monthly payments ' + data.years.currentAcademicYear,
     href: "/funding/monthly-payments",
     active: activeTabMonthly
   },
   {
-    text: yearPaymentsTabName,
+    text: yearPaymentsTabName + ' ' + data.years.currentAcademicYear,
     href: '/funding/annual-payments-scitt',
     active: activeTabYearlyScitt
   } if accessLevel == 'accreditingProvider',
   {
-    text: "Salaries and grants",
+    text: 'Salaries and grants ' + data.years.currentAcademicYear,
     href: '/funding/annual-payments-lead-school',
     active: activeTabYearlyLeadSchool
-  } if accessLevel == 'leadSchool'
+  } if accessLevel == 'leadSchool',
+  {
+    text: "Past year’s funding",
+    href: '/funding/data',
+    active: activeTabFundingData
+  }
 ]}) }}

--- a/app/views/funding/annual-payments-lead-school.html
+++ b/app/views/funding/annual-payments-lead-school.html
@@ -1,10 +1,7 @@
 {% extends "_templates/_page.html" %}
 {% set navActive = "funding" %}
 
-{% set backText = "Home" %}
-{% set backLink = '/home' %}
-
-{% set pageHeading = "Funding " + data.years.currentAcademicYear %}
+{% set pageHeading = "Funding" %}
 
 {% block content %}
 
@@ -17,6 +14,7 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <h2 class="govuk-heading-l">
         {{ tabName | sentenceCase }}
+        <span class="app-nowrap">{{ data.years.currentAcademicYear }}</span>
       </h2>
       <p class="govuk-body govuk-!-margin-bottom-1">
         Last updated: {{ "" | yesterdayGovuk }}
@@ -24,7 +22,6 @@
       <p>
         <a href="#" class="govuk-link--no-visited-state">Export {{ tabName | lower }}</a>
       </p>
-
 
   {% set dataSource = data.funding.annualFundingLeadSchools %}
   {% set dataSource = dataSource | sort(attribute = "subject") %}

--- a/app/views/funding/annual-payments-scitt.html
+++ b/app/views/funding/annual-payments-scitt.html
@@ -1,10 +1,7 @@
 {% extends "_templates/_page.html" %}
 {% set navActive = "funding" %}
 
-{% set backText = "Home" %}
-{% set backLink = '/home' %}
-
-{% set pageHeading = "Funding " + data.years.currentAcademicYear %}
+{% set pageHeading = "Funding" %}
 
 {% block content %}
 
@@ -16,13 +13,14 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <h2 class="govuk-heading-l">
-        {{ yearPaymentsTabName | sentenceCase }}
+        {{ yearPaymentsTabName | sentenceCase }} 
+        <span class="app-nowrap">{{ data.years.currentAcademicYear }}</span>
       </h2>
       <p class="govuk-body govuk-!-margin-bottom-1">
         Last updated: {{ "" | yesterdayGovuk }}
       </p>
       <p>
-        <a href="#" class="govuk-link--no-visited-state">Export {{ yearPaymentsTabName | lower }}</a>
+        <a href="#" class="govuk-link--no-visited-state">Export {{ yearPaymentsTabName | lower }} (csv)</a>
       </p>
     </div>
   </div>

--- a/app/views/funding/data.html
+++ b/app/views/funding/data.html
@@ -1,0 +1,126 @@
+{% extends "_templates/_page.html" %}
+{% set navActive = "funding" %}
+
+{% set pageHeading = "Funding" %}
+
+
+{% block content %}
+
+  {% set activeTabFundingData = true %}
+  {% set tabName = "Past year’s funding" %}
+  {% set yearPaymentsTabName = "" | typesOfFunding | joinify  | sentenceCase %}
+
+  {% set months  = [
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July"
+  ]%}
+
+  {% set historicFundingAcademicYears = [
+    2020,
+    2019,
+    2018
+  ] %}
+
+  {% if currentMonth() >= 6 %}
+    {% set thisMonth = -1 + currentMonth() - 6 %}
+  {% else %}
+    {% set thisMonth = -1 + currentMonth() + 6 %}
+  {% endif %}
+  {# {% set thisMonth = 12 %} #}
+
+  {% set accordionItems = [] %}
+
+  {% include "_includes/funding-header-and-tab-nav.html" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <h2 class="govuk-heading-l">
+        {{ tabName | sentenceCase }}
+      </h2>
+
+      {% for academicYear in historicFundingAcademicYears %}
+
+        <h3 class="govuk-heading-m">
+          {{ academicYear  }} to {{ academicYear + 1 }}
+          {# {% if loop.first %}
+            <span class="govuk-body">(current year)</span>
+          {% endif %} #}
+        </h3>
+
+        {# {% if loop.first %}
+
+          <p class="govuk-body">
+            <a href="#" class="govuk-body govuk-link--no-visited-state">
+              Export all monthly payment data ({% if not loop.first %}12{% else %}{{ thisMonth }}{% endif %} csvs)
+            </a>
+          </p>
+          <p class="govuk-body govuk-!-margin-bottom-5">
+            Export monthly funding data as of:
+          </p>
+          <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
+            {% for month in months %}
+              {% if loop.index <= thisMonth %}
+                <li>
+                  <a href="#" class="govuk-body govuk-link--no-visited-state">
+                    {% set day = [1, 2, 3, 4, 5] | random %}
+                    {% set year = academicYear %}
+                    {% if loop.index > 5 %}
+                      {% set year = year + 1 %}
+                    {% endif %}
+                    {{ day }} {{ month | prettyMonthFromAugust }} {{ year }}
+                  </a>
+                </li>
+              {% endif %}
+            {% endfor %}
+          </ul>
+          <p class="govuk-body">
+            <a href="#" class="govuk-link--no-visited-state">
+              Export {{ yearPaymentsTabName | startLowerCase }} data (csv)
+            </a>
+          </p>
+
+        {% else %} #}
+
+          <p class="govuk-body">
+            Export:
+          </p>
+          <ul class="govuk-list govuk-list--bullet govuk-list--spaced govuk-!-margin-top-1">
+            <li>
+              <a href="#" class="govuk-body govuk-link--no-visited-state">
+                  {# final #} monthly payment data (csv)
+              </a>
+            </li>
+            {# <li>
+              <a href="#" class="govuk-body govuk-link--no-visited-state">
+                  all monthly payment data (12 csvs)
+              </a>
+            </li> #}
+            <li>
+              <a href="#" class="govuk-link--no-visited-state">
+                {{ yearPaymentsTabName | startLowerCase }} data (csv)
+              </a>
+            </li>
+          </ul>
+
+        {# {% endif %} #}
+
+        {% if not loop.last %}
+          <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+        {% endif %}
+
+      {% endfor %}
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/funding/index.html
+++ b/app/views/funding/index.html
@@ -1,0 +1,42 @@
+{% extends "_templates/_page.html" %}
+
+{% set backText = "Home" %}
+{% set backLink = '/home' %}
+{% set pageHeading = "Funding" %}
+
+{% block content %}
+
+  {% set historicFundingAcademicYears = [
+    2020,
+    2019,
+    2018
+  ] %}
+
+{% set pageHeading = "Funding " + data.years.currentAcademicYear %}
+
+{% block content %}
+
+  {% set fundingData = true %}
+  {% include "_includes/funding-header-and-tab-nav.html" %}
+
+  <h1 class="govuk-heading-xl">
+    <span class="govuk-caption-l">{{ data.signedInProviders | andSeparate }}</span>
+    {{ pageHeading }}
+  </h1>
+
+  <p class="govuk-body"><a href="annual-payments-scitt">View funding information for 2020 to 2021</a></p>
+
+  <hr class="govuk-section-break govuk-section-break--m">
+
+  <p class="govuk-body">Export funding data (csv) for past years:</p>
+  <ol class="govuk-list govuk-list--bullet govuk-list--spaced">
+  {% for academicYear in historicFundingAcademicYears %}
+    <li>
+      <a href="#" class="govuk-link--no-visited-state">
+        <span class="tabular">{{ academicYear }} to {{ academicYear + 1 }}</span>
+      </a>
+    </li>
+  {% endfor %}
+  </ol>
+
+{% endblock %}

--- a/app/views/funding/monthly-payments.html
+++ b/app/views/funding/monthly-payments.html
@@ -1,14 +1,17 @@
 {% extends "_templates/_page.html" %}
 {% set navActive = "funding" %}
 
-{% set backText = "Home" %}
-{% set backLink = '/home' %}
-
-{% set pageHeading = "Funding " + data.years.currentAcademicYear %}
+{% set pageHeading = "Funding" %}
 
 {% set tablePerMonth = true %}
 
 {% block content %}
+
+
+  {% set yearPaymentsTabName = "" | typesOfFunding | joinify  | sentenceCase %}
+
+  {% set activeTabMonthly = true %}
+  {% include "_includes/funding-header-and-tab-nav.html" %}
 
   {% if currentMonth() >= 6 %}
     {% set thisMonth = -1 + currentMonth() - 6 %}
@@ -17,24 +20,16 @@
   {% endif %}
   {# {% set thisMonth = 12 %} #}
 
-  {% set yearPaymentsTabName = "" | typesOfFunding | joinify  | sentenceCase %}
-
-  {% set activeTabMonthly = true %}
-  {% include "_includes/funding-header-and-tab-nav.html" %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <h2 class="govuk-heading-l">
-        Monthly payments
+        Monthly payments <span class="app-nowrap">{{ data.years.currentAcademicYear }}</span>
       </h2>
       <p class="govuk-body govuk-!-margin-bottom-2">
         Last updated: {{ "" | yesterdayGovuk }}
       </p>
       <p class="govuk-body govuk-!-margin-bottom-2">
         <a href="#" class="govuk-link--no-visited-state">Export lastest monthly payment data (csv)</a><br>
-      </p>
-      <p class="govuk-body">
-        <a href="#">Export all monthly payment data ({{ thisMonth }} csv files)</a>
       </p>
     </div>
   </div>
@@ -49,14 +44,9 @@
 
   {% if not tablePerMonth and dataSource.length > 4 %}
     {% set tableClasses = "govuk-!-font-size-16" %}
-  {% endif %}
-
-  {% if tablePerMonth %}
-    {% set cellClasses = "app-table__column-33" %}
-  {% elseif dataSource.length == 3 %}
-    {% set cellClasses = "app-table__column-20" %}
-  {% elseif dataSource.length == 4 %}
-    {% set cellClasses = "app-table__column-16" %}
+  {% else %}
+    {% set rowHeadingCellClasses = "app-table__column-50" %}
+    {% set dataCellClasses = "app-table__column-25" %}
   {% endif %}
 
   {% set months  = [
@@ -81,15 +71,15 @@
   {% set futureRows   = [] %}
 
 
-  {% set headRow = [{ text: "Month", classes: cellClasses }] %}
+  {% set headRow = [{ text: "Month", classes: rowHeadingCellClasses }] %}
   {% if not tablePerMonth %}
     {% for item in dataSource %}
       {% set headRow = headRow | push({ text: item.descriptions | fixNamesFromFunding | sentenceCase | formatYearRange | safe, classes: cellClasses }) %}
     {% endfor %}
   {% endif %}
-  {% set headRow = headRow | push({ text: "Total", format: "numeric", classes: cellClasses }) %}
+  {% set headRow = headRow | push({ text: "Total", format: "numeric", classes: dataCellClasses }) %}
   {% if tablePerMonth %}
-    {% set headRow = headRow | push({ text: "Running total", format: "numeric", classes: cellClasses }) %}
+    {% set headRow = headRow | push({ text: "Running total", format: "numeric", classes: dataCellClasses }) %}
   {% endif %}
 
   {% for month in months %}
@@ -186,6 +176,7 @@
       <div class="govuk-grid-column-two-thirds-from-desktop">
 
         {% set accordionItems = [] %}
+        {% set runningMonthTotal = 0 %}
 
         {% for month in months %}
         
@@ -195,15 +186,22 @@
           {% set monthTotal = 0 %}
 
           {% for item in dataSource %}
-              {% set row = [
-                { text: item.descriptions | fixNamesFromFunding | sentenceCase | formatYearRange | safe },
-                { text: item.monthlyPayments[monthIndex] | currency, format: "numeric" }
-              ] if item.monthlyPayments[monthIndex] %}
+            {% set row = [
+              { text: item.descriptions | fixNamesFromFunding | sentenceCase | formatYearRange | safe },
+              { text: item.monthlyPayments[monthIndex] | currency, format: "numeric" },
+              { text: item.cumulativeMonthlyPayments[monthIndex] | currency, format: "numeric" }
+            ] if item.monthlyPayments[monthIndex] %}
             {% set monthTotal = monthTotal + item.monthlyPayments[monthIndex] %}
             {% set bodyRows = bodyRows | push(row) %}
           {% endfor %}
+          
+          {% set runningMonthTotal = runningMonthTotal + monthTotal %}
 
-          {% set bodyRows = bodyRows | push([{ text: "Total", classes: "govuk-!-font-weight-bold" }, { text: monthTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }]) %}
+          {% set bodyRows = bodyRows | push([
+            { text: "Total", classes: "govuk-!-font-weight-bold" }, 
+            { text: monthTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" },
+            { text: runningMonthTotal | currency, format: "numeric", classes: "govuk-!-font-weight-bold" }
+          ]) %}
 
           {% set accordionTitle -%}
             {{ month }} {% if loop.index < 6 %}{{ data.years.defaultCourseYear }}{% else %}{{ data.years.defaultCourseYear + 1 }}{% endif %}
@@ -211,19 +209,22 @@
 
           {% set accordionHtml %}
 
-            {% if loop.index <= thisMonth %}
+{#             {% if loop.index <= thisMonth %}
               <p class="govuk-body">
                 <a href="#" class="govuk-link--no-visited-state">Export monthly payment data as it was on {{ [1,2, 3, 4, 5] | random }} {{ month }} {% if loop.index < 6 %}{{ data.years.defaultCourseYear }}{% else %}{{ data.years.defaultCourseYear + 1 }}{% endif %}</a>
               </p>
-            {% endif %}
+            {% endif %} #}
 
 
             {% if monthTotal != 0 %}
               {{ govukTable({
-                classes: "app-table__in-accordion",
+                classes: "app-table__in-accordion govuk-!-margin-bottom-6",
                 caption: month + " payments",
                 captionClasses: "govuk-visually-hidden",
-                head: [{ text: "Payment type" }, { text: "Amount", format: "numeric" }],
+                head: [
+                  { text: "Payment type", classes: rowHeadingCellClasses }, 
+                  { text: "Amount", format: "numeric", classes: dataCellClasses }, 
+                  { text: "Running total", format: "numeric", classes: dataCellClasses }],
                 rows: bodyRows
               }) }}
             {% else %}

--- a/app/views/funding/monthly-payments.html
+++ b/app/views/funding/monthly-payments.html
@@ -31,6 +31,9 @@
       <p class="govuk-body govuk-!-margin-bottom-2">
         <a href="#" class="govuk-link--no-visited-state">Export lastest monthly payment data (csv)</a><br>
       </p>
+      <p class="govuk-body">
+        <a href="#">Export all monthly payment data ({{ thisMonth }} csv files)</a>
+      </p>
     </div>
   </div>
 


### PR DESCRIPTION
This pr adds a page with a list of downloads for previous academic years:

![localhost_3000_funding_data(screenshot) (4)](https://user-images.githubusercontent.com/8417288/154998371-37852edb-a236-428c-a886-175b7b9fa3c8.png)

And after feedback from the funding team, adds a running total to the monthly breakdowns:

![localhost_3000_funding_monthly-payments(screenshot) (13)](https://user-images.githubusercontent.com/8417288/154998650-bd54fb8b-5118-45f3-b3c4-41bdeb926f23.png)
