### PR TITLE
Rename field to sex to match HESA

### DIFF
--- a/app/views/_includes/forms/personal-details.html
+++ b/app/views/_includes/forms/personal-details.html
@@ -76,10 +76,7 @@
       text: "Male"
     },
     {
-      text: "Other"
-    },
-    {
-      divider: 'or'
+      text: "Prefer not to say"
     },
     {
       text: "Not provided"

--- a/app/views/_includes/forms/personal-details.html
+++ b/app/views/_includes/forms/personal-details.html
@@ -76,6 +76,9 @@
       text: "Male"
     },
     {
+      text: "Other"
+    },
+    {
       text: "Prefer not to say"
     },
     {

--- a/app/views/_includes/forms/personal-details.html
+++ b/app/views/_includes/forms/personal-details.html
@@ -64,7 +64,7 @@
 {{ govukRadios({
   fieldset: {
     legend: {
-      text: "Gender",
+      text: "Sex",
       classes: "govuk-fieldset__legend--s"
     }
   },

--- a/app/views/_includes/summary-cards/personal-details.html
+++ b/app/views/_includes/summary-cards/personal-details.html
@@ -32,7 +32,7 @@
   },
   {
     key: {
-      text: "Gender"
+      text: "Sex"
     },
     value: {
       text: record.personalDetails.sex or 'Not entered'
@@ -42,7 +42,7 @@
         {
           href: recordPath + "/personal-details/edit" | addReferrer(referrer),
           text: "Change",
-          visuallyHiddenText: "gender"
+          visuallyHiddenText: "sex"
         }
       ]
     } if canAmend

--- a/app/views/check-data.html
+++ b/app/views/check-data.html
@@ -27,7 +27,7 @@
         Date of birth
       </li>
       <li>
-        Gender
+        Sex
       </li>
       <li>
         Nationality

--- a/app/views/guidance.html
+++ b/app/views/guidance.html
@@ -31,7 +31,7 @@
   <li>change trainee records</li>
   <li>view draft trainee records</li>
   <li>view a trainee’s diversity information</li>
-  <li>view a trainee’s gender</li>
+  <li>view a trainee’s sex</li>
   <li>view a trainee’s nationality</li>
 </ul>
 


### PR DESCRIPTION
HESA have updated guidance for 22/23 to more clearly indicate the field is about biological sex rather than gender.

This change brings Register in alignment with what Apply and HESA both collect.

![Screenshot 2022-02-24 at 11 32 58](https://user-images.githubusercontent.com/2204224/155516512-4a216bce-335c-47ae-aca0-b9c0e9dd5dc7.png)

![Screenshot 2022-02-24 at 11 33 16](https://user-images.githubusercontent.com/2204224/155516526-0c6fd6b2-f256-47cc-a01a-883374c28a04.png)

