### PR TITLE
sets summary card heading colour

### DIFF
--- a/app/assets/sass/components/_summary-card.scss
+++ b/app/assets/sass/components/_summary-card.scss
@@ -34,6 +34,7 @@
     align-items: center;
     background-color: govuk-colour("light-grey");
     padding: govuk-spacing(3);
+    color: $govuk-text-colour;
 
     @include govuk-media-query($from: desktop) {
       display: flex;


### PR DESCRIPTION
If you have OSX set to dark mode and Version 98.0.4758.102 (Official Build) (x86_64) of Chrome, summary card headings get set to white:

![Screenshot 2022-02-24 at 13 01 00](https://user-images.githubusercontent.com/8417288/155529189-15da2ed0-6dd3-41e5-884f-df27598fa08f.png)

If we explicitly set the text colour for them, the stay black:

![Screenshot 2022-02-24 at 13 01 38](https://user-images.githubusercontent.com/8417288/155529207-096df4d6-b243-4f72-90df-892621032934.png)
