### PR TITLE
Capture dates of significant course changes

### DIFF
--- a/app/data/direct-add-draft-record.json
+++ b/app/data/direct-add-draft-record.json
@@ -1,0 +1,100 @@
+{
+  "status": "Draft",
+  "events": {
+    "items": []
+  },
+  "reference": "KN5837",
+  "provider": "Coventry University",
+  "route": "Provider-led (postgrad)",
+  "personalDetails": {
+    "nationality": [
+      "Irish",
+      "American"
+    ],
+    "givenName": "Sarah Lilia",
+    "middleNames": "",
+    "familyName": "Jones",
+    "dateOfBirth": [
+      "3",
+      "12",
+      "1987"
+    ],
+    "sex": "Female",
+    "status": [
+      "Completed"
+    ]
+  },
+  "contactDetails": {
+    "internationalAddress": "",
+    "addressType": "domestic",
+    "address": {
+      "line1": "260 Bradford Street",
+      "line2": "Deritend",
+      "level2": "Birmingham",
+      "postcode": "B12 0QY"
+    },
+    "phoneNumber": "07700 900941",
+    "email": "s.jones@example.com",
+    "status": [
+      "Completed"
+    ]
+  },
+  "diversity": {
+    "diversityDisclosed": "false",
+    "status": [
+      "Completed"
+    ]
+  },
+  "degree": {
+    "items": [
+      {
+        "isInternational": "true",
+        "subject": "Biology",
+        "country": "United States",
+        "endDate": "2013",
+        "type": "Bachelor degree",
+        "id": "31dc5e93-b521-425c-98d8-dec96eb2388c"
+      },
+      {
+        "isInternational": "false",
+        "subject": "Sport and exercise sciences",
+        "org": "The University of Manchester",
+        "endDate": "2016",
+        "type": "BSc - Bachelor of Science",
+        "grade": "First-class honours",
+        "id": "1faf0ae6-4c01-4224-9e49-06beffc0c5d0"
+      }
+    ],
+    "status": [
+      "Completed"
+    ]
+  },
+  "courseDetails": {
+    "subjects": ["Physics"],
+    "ageRange": "3 to 11 programme",
+    "startDate": [
+      "1",
+      "2",
+      "2021"
+    ],
+    "endDate": [
+      "1",
+      "6",
+      "2021"
+    ],
+    "status": [
+      "Completed"
+    ]
+  },
+  "trainingDetails": {
+    "commencementDate": [
+      "1",
+      "2",
+      "2021"
+    ],
+    "traineeId": "AO/03/21",
+    "status": [
+      "Completed"
+    ]
+  }
+}

--- a/app/data/direct-add-record.json
+++ b/app/data/direct-add-record.json
@@ -2,31 +2,37 @@
     "academicYear": "2021 to 2022",
     "diversity": {
         "diversityDisclosed": "true",
-        "ethnicGroup": "Black, African, Black British or Caribbean",
-        "ethnicGroupSpecific": "Another Black background",
-        "disabledAnswer": "Not provided"
+        "ethnicGroup": "Prefer not to say",
+        "disabledAnswer": "Yes",
+        "disabilities": [
+            "Other"
+        ]
     },
     "id": "directly-added",
     "personalDetails": {
-        "givenName": "Dale",
-        "familyName": "Schowalter",
-        "middleNames": "Preston",
+        "givenName": "Carl",
+        "familyName": "Berge",
+        "middleNames": "Clayton Clifton",
         "nationality": [
             "British"
         ],
         "sex": "Male",
-        "dateOfBirth": "1991-11-09T01:07:28.399Z",
-        "fullName": "Dale Preston Schowalter",
-        "shortName": "Dale Schowalter"
+        "dateOfBirth": "1972-08-25T12:58:09.016Z",
+        "fullName": "Carl Clayton Clifton Berge",
+        "shortName": "Carl Berge"
     },
     "provider": "Webury Hill SCITT",
     "accreditingProviderType": "SCITT",
     "route": "Provider-led (postgrad)",
     "status": "Pending TRN",
-    "updatedDate": "2022-03-29T15:44:11.189Z",
-    "submittedDate": "2022-03-21T04:10:33.875Z",
-    "reference": "EN5769",
-    "source": "Manual",
+    "updatedDate": "2022-03-29T16:30:31.436Z",
+    "submittedDate": "2022-03-21T19:29:36.093Z",
+    "reference": "KL9720",
+    "source": "Apply",
+    "applyData": {
+        "recruitedDate": "2022-03-21T19:29:36.093Z",
+        "applicationDate": "2022-03-08T14:30:12.527Z"
+    },
     "courseDetails": {
         "ageRange": "11 to 18",
         "code": "F974",
@@ -57,56 +63,56 @@
     "events": {
         "items": [
             {
-                "title": "Record created",
+                "title": "Record imported from Apply",
                 "user": "Provider",
-                "date": "2021-12-15T18:07:01.968Z"
+                "date": "2021-11-09T02:17:34.321Z"
             },
             {
                 "title": "Trainee submitted for TRN",
                 "user": "Provider",
-                "date": "2021-12-15T18:07:01.968Z"
+                "date": "2021-11-09T02:17:34.321Z"
             },
             {
                 "title": "Record updated",
                 "user": "Provider",
-                "date": "2022-03-29T15:43:03.830Z"
+                "date": "2022-03-29T16:29:45.723Z"
             },
             {
                 "title": "Record updated",
                 "user": "Provider",
-                "date": "2022-03-29T15:44:11.189Z"
+                "date": "2022-03-29T16:30:31.436Z"
             }
         ]
     },
     "trainingDetails": {
         "traineeStarted": "true",
-        "commencementDate": "2022-03-21T04:10:33.875Z"
+        "commencementDate": "2022-03-21T19:29:36.093Z"
     },
     "isInternationalTrainee": false,
     "contactDetails": {
-        "phoneNumber": "056 9614 9105",
-        "email": "allison31@hotmail.com",
+        "phoneNumber": "0967 519 7344",
+        "email": "nadia.will2@yahoo.com",
         "address": {
-            "line1": "1004 Kiley Street",
+            "line1": "780 Blick Run",
             "line2": "",
-            "level2": "West Lesliebury",
-            "postcode": "BP6 6LO"
+            "level2": "North Richmond",
+            "postcode": "CN57 0IV"
         },
         "addressType": "domestic"
     },
     "gcse": {
         "maths": {
-            "type": "Scottish National 5",
+            "type": "GCSE",
             "subject": "Maths",
             "gradeBoundary": "4 and above"
         },
         "english": {
-            "type": "Scottish National 5",
+            "type": "GCSE",
             "subject": "English",
             "gradeBoundary": "4 and above"
         },
         "science": {
-            "type": "Scottish National 5",
+            "type": "GCSE",
             "subject": "Science",
             "gradeBoundary": "4 and above"
         }
@@ -114,15 +120,15 @@
     "degree": {
         "items": [
             {
-                "type": "BSc Education",
-                "subject": "Fashion",
+                "type": "Bachelor of Accountancy",
+                "subject": "French language",
                 "isInternational": "false",
-                "institution": "Backstage Academy (Training)",
-                "grade": "Pass",
-                "predicted": false,
-                "startDate": "2015",
-                "endDate": "2019",
-                "id": "cb7e588f-a59f-44a0-9e2a-bda871cefe5f"
+                "institution": "Plymouth College of Art",
+                "grade": "First-class honours",
+                "predicted": true,
+                "startDate": "2016",
+                "endDate": "2020",
+                "id": "4486cc10-3621-4e0f-8542-e375057535a1"
             }
         ]
     },
@@ -133,37 +139,20 @@
         "items": [
             {
                 "school": {
-                    "urn": "110257",
-                    "localAuthority": "Milton Keynes",
-                    "schoolName": "Wyvern School",
-                    "type": "Foundation school",
+                    "urn": "138050",
+                    "localAuthority": "West Sussex",
+                    "schoolName": "The Bewbush Academy",
+                    "type": "Academy sponsor led",
                     "status": "Open",
                     "phase": "Primary",
-                    "ukprn": "10080374",
-                    "addressLine1": "Aylesbury Street",
-                    "addressLine2": "Wolverton",
-                    "town": "Milton Keynes",
-                    "postcode": "MK12 5HU",
-                    "uuid": "85e899c9-d81c-404b-aa63-7c163875c1d3"
+                    "ukprn": "10037078",
+                    "addressLine1": "Dorsten Place",
+                    "addressLine2": "Bewbush",
+                    "town": "Crawley",
+                    "postcode": "RH11 8XW",
+                    "uuid": "7807a60c-30d3-4ea2-a29d-923c14bcdca7"
                 },
-                "id": "678834bf-79a3-4f8f-bcf8-02bad6426b6e"
-            },
-            {
-                "school": {
-                    "urn": "140696",
-                    "localAuthority": "Leicestershire",
-                    "schoolName": "Ab Kettleby School",
-                    "type": "Academy converter",
-                    "status": "Open",
-                    "phase": "Primary",
-                    "ukprn": "10045668",
-                    "addressLine1": "Wartnaby Road",
-                    "addressLine2": "Ab Kettleby",
-                    "town": "Melton Mowbray",
-                    "postcode": "LE14 3JJ",
-                    "uuid": "0d37f6f8-0a96-4189-a749-8d996cf1c86e"
-                },
-                "id": "ed78efdc-cf09-4704-8de1-ddeb5044f169"
+                "id": "49da554b-6c92-4d55-bde7-c8739e6fc533"
             }
         ]
     },
@@ -171,70 +160,368 @@
     "selectedCourseTemp": "d8a7c5d5-441d-41d3-8889-05036d9c4df3",
     "historicCourseDetails": [
         {
-            "courseDetails": {
-                "ageRange": "11 to 18",
-                "code": "G640",
-                "duration": 1,
-                "id": "eedb5a80-431d-4e4c-9c8b-a6de5631120a",
-                "isPublishCourse": true,
-                "phase": "Secondary",
-                "qualifications": [
-                    "QTS",
-                    "PGCE"
-                ],
-                "qualificationsSummary": "PGCE with QTS full time",
-                "route": "Teaching apprenticeship (postgrad)",
-                "startDateVague": "2021-08-31T23:00:00.000Z",
+            "recordData": {
                 "academicYear": "2021 to 2022",
-                "studyMode": "Full time",
-                "publishSubjects": {
-                    "first": "Physics"
+                "diversity": {
+                    "diversityDisclosed": "true",
+                    "ethnicGroup": "Prefer not to say",
+                    "disabledAnswer": "Yes",
+                    "disabilities": [
+                        "Other"
+                    ]
                 },
-                "courseNameShort": "Physics",
-                "courseNameLong": "Physics (G640)",
-                "subjects": {
-                    "first": "Physics"
+                "id": "9fcd2373-0254-468f-8252-6d4f151c9c19",
+                "personalDetails": {
+                    "givenName": "Carl",
+                    "familyName": "Berge",
+                    "middleNames": "Clayton Clifton",
+                    "nationality": [
+                        "British"
+                    ],
+                    "sex": "Male",
+                    "dateOfBirth": "1972-08-25T12:58:09.016Z",
+                    "fullName": "Carl Clayton Clifton Berge",
+                    "shortName": "Carl Berge"
                 },
-                "startDate": "2021-09-02T23:00:00.000Z",
-                "endDate": "2022-06-02T23:00:00.000Z"
-            },
-            "schools": {
-                "leadSchool": {
-                    "urn": "137628",
-                    "localAuthority": "Nottinghamshire",
-                    "schoolName": "The Joseph Whitaker School",
-                    "type": "Academy converter",
-                    "status": "Open",
+                "provider": "Webury Hill SCITT",
+                "accreditingProviderType": "SCITT",
+                "route": "School direct (salaried)",
+                "status": "Pending TRN",
+                "updatedDate": "2022-03-21T19:29:36.093Z",
+                "submittedDate": "2022-03-21T19:29:36.093Z",
+                "reference": "KL9720",
+                "source": "Apply",
+                "applyData": {
+                    "recruitedDate": "2022-03-21T19:29:36.093Z",
+                    "applicationDate": "2022-03-08T14:30:12.527Z"
+                },
+                "courseDetails": {
+                    "ageRange": "11 to 16",
+                    "code": "P910",
+                    "duration": 1,
+                    "id": "ed142d73-0374-4c23-8420-67d963ab19bb",
+                    "isPublishCourse": true,
                     "phase": "Secondary",
-                    "ukprn": "10035689",
-                    "addressLine1": "Warsop Lane",
-                    "addressLine2": "Rainworth",
-                    "town": "Mansfield",
-                    "postcode": "NG21 0AG",
-                    "uuid": "c3d5b7f8-f53a-45a9-bb3e-ba0f72338b1a"
+                    "qualifications": [
+                        "QTS",
+                        "PGCE"
+                    ],
+                    "qualificationsSummary": "PGCE with QTS full time",
+                    "route": "School direct (salaried)",
+                    "startDateVague": "2021-08-31T23:00:00.000Z",
+                    "academicYear": "2021 to 2022",
+                    "studyMode": "Full time",
+                    "publishSubjects": {
+                        "first": "German"
+                    },
+                    "courseNameShort": "German",
+                    "courseNameLong": "German (P910)",
+                    "subjects": {
+                        "first": "German language"
+                    },
+                    "startDate": "2021-09-17T23:00:00.000Z",
+                    "endDate": "2022-06-17T23:00:00.000Z"
                 },
-                "employingSchool": {
-                    "urn": "122762",
-                    "localAuthority": "Nottinghamshire",
-                    "schoolName": "Kneesall CofE Primary School",
-                    "type": "Voluntary controlled school",
-                    "status": "Open",
-                    "phase": "Primary",
-                    "ukprn": "10077939",
-                    "addressLine1": "School Lane",
-                    "addressLine2": "Kneesall",
-                    "town": "Newark",
-                    "postcode": "NG22 0AB",
-                    "uuid": "315867fe-1897-4503-90e5-01c4feb4ae0e"
-                }
-            },
-            "funding": {
-                "initiative": "Not on a training initiative",
-                "source": "grant"
+                "events": {
+                    "items": [
+                        {
+                            "title": "Record imported from Apply",
+                            "user": "Provider",
+                            "date": "2021-11-09T02:17:34.321Z"
+                        },
+                        {
+                            "title": "Trainee submitted for TRN",
+                            "user": "Provider",
+                            "date": "2021-11-09T02:17:34.321Z"
+                        }
+                    ]
+                },
+                "trainingDetails": {
+                    "traineeStarted": "true",
+                    "commencementDate": "2022-03-21T19:29:36.093Z"
+                },
+                "isInternationalTrainee": false,
+                "contactDetails": {
+                    "phoneNumber": "0967 519 7344",
+                    "email": "nadia.will2@yahoo.com",
+                    "address": {
+                        "line1": "780 Blick Run",
+                        "line2": "",
+                        "level2": "North Richmond",
+                        "postcode": "CN57 0IV"
+                    },
+                    "addressType": "domestic"
+                },
+                "gcse": {
+                    "maths": {
+                        "type": "GCSE",
+                        "subject": "Maths",
+                        "gradeBoundary": "4 and above"
+                    },
+                    "english": {
+                        "type": "GCSE",
+                        "subject": "English",
+                        "gradeBoundary": "4 and above"
+                    },
+                    "science": {
+                        "type": "GCSE",
+                        "subject": "Science",
+                        "gradeBoundary": "4 and above"
+                    }
+                },
+                "schools": {
+                    "leadSchool": {
+                        "urn": "137628",
+                        "localAuthority": "Nottinghamshire",
+                        "schoolName": "The Joseph Whitaker School",
+                        "type": "Academy converter",
+                        "status": "Open",
+                        "phase": "Secondary",
+                        "ukprn": "10035689",
+                        "addressLine1": "Warsop Lane",
+                        "addressLine2": "Rainworth",
+                        "town": "Mansfield",
+                        "postcode": "NG21 0AG",
+                        "uuid": "c3d5b7f8-f53a-45a9-bb3e-ba0f72338b1a"
+                    },
+                    "employingSchool": {
+                        "urn": "146331",
+                        "localAuthority": "Nottingham",
+                        "schoolName": "Djanogly Sherwood Academy",
+                        "type": "Academy sponsor led",
+                        "status": "Open",
+                        "phase": "Primary",
+                        "ukprn": "10081109",
+                        "addressLine1": "Sherwood Rise",
+                        "addressLine2": "Sherwood",
+                        "town": "Nottingham",
+                        "postcode": "NG7 7AR",
+                        "uuid": "1e456ad9-b353-4be5-b25d-cddd23799bf2"
+                    }
+                },
+                "degree": {
+                    "items": [
+                        {
+                            "type": "Bachelor of Accountancy",
+                            "subject": "French language",
+                            "isInternational": "false",
+                            "institution": "Plymouth College of Art",
+                            "grade": "First-class honours",
+                            "predicted": true,
+                            "startDate": "2016",
+                            "endDate": "2020",
+                            "id": "4486cc10-3621-4e0f-8542-e375057535a1"
+                        }
+                    ]
+                },
+                "funding": {
+                    "initiative": "Not on a training initiative",
+                    "source": "bursary"
+                },
+                "placement": {
+                    "items": [
+                        {
+                            "school": {
+                                "urn": "138050",
+                                "localAuthority": "West Sussex",
+                                "schoolName": "The Bewbush Academy",
+                                "type": "Academy sponsor led",
+                                "status": "Open",
+                                "phase": "Primary",
+                                "ukprn": "10037078",
+                                "addressLine1": "Dorsten Place",
+                                "addressLine2": "Bewbush",
+                                "town": "Crawley",
+                                "postcode": "RH11 8XW",
+                                "uuid": "7807a60c-30d3-4ea2-a29d-923c14bcdca7"
+                            },
+                            "id": "49da554b-6c92-4d55-bde7-c8739e6fc533"
+                        }
+                    ]
+                },
+                "outcome": {}
             },
             "dateFinished": [
                 "1",
                 "2",
+                "2022"
+            ]
+        },
+        {
+            "recordData": {
+                "academicYear": "2021 to 2022",
+                "diversity": {
+                    "diversityDisclosed": "true",
+                    "ethnicGroup": "Prefer not to say",
+                    "disabledAnswer": "Yes",
+                    "disabilities": [
+                        "Other"
+                    ]
+                },
+                "id": "9fcd2373-0254-468f-8252-6d4f151c9c19",
+                "personalDetails": {
+                    "givenName": "Carl",
+                    "familyName": "Berge",
+                    "middleNames": "Clayton Clifton",
+                    "nationality": [
+                        "British"
+                    ],
+                    "sex": "Male",
+                    "dateOfBirth": "1972-08-25T12:58:09.016Z",
+                    "fullName": "Carl Clayton Clifton Berge",
+                    "shortName": "Carl Berge"
+                },
+                "provider": "Webury Hill SCITT",
+                "accreditingProviderType": "SCITT",
+                "route": "School direct (fee funded)",
+                "status": "Pending TRN",
+                "updatedDate": "2022-03-29T16:29:45.723Z",
+                "submittedDate": "2022-03-21T19:29:36.093Z",
+                "reference": "KL9720",
+                "source": "Apply",
+                "applyData": {
+                    "recruitedDate": "2022-03-21T19:29:36.093Z",
+                    "applicationDate": "2022-03-08T14:30:12.527Z"
+                },
+                "courseDetails": {
+                    "ageRange": "11 to 18",
+                    "code": "H617",
+                    "duration": 1,
+                    "id": "847df604-d0f5-4464-a229-3494593353a7",
+                    "isPublishCourse": true,
+                    "phase": "Secondary",
+                    "qualifications": [
+                        "QTS",
+                        "PGCE"
+                    ],
+                    "qualificationsSummary": "PGCE with QTS full time",
+                    "route": "School direct (fee funded)",
+                    "startDateVague": "2021-11-01T00:00:00.000Z",
+                    "academicYear": "2021 to 2022",
+                    "studyMode": "Full time",
+                    "publishSubjects": {
+                        "first": "Latin"
+                    },
+                    "courseNameShort": "Latin",
+                    "courseNameLong": "Latin (H617)",
+                    "subjects": {
+                        "first": "Latin"
+                    }
+                },
+                "events": {
+                    "items": [
+                        {
+                            "title": "Record imported from Apply",
+                            "user": "Provider",
+                            "date": "2021-11-09T02:17:34.321Z"
+                        },
+                        {
+                            "title": "Trainee submitted for TRN",
+                            "user": "Provider",
+                            "date": "2021-11-09T02:17:34.321Z"
+                        },
+                        {
+                            "title": "Record updated",
+                            "user": "Provider",
+                            "date": "2022-03-29T16:29:45.723Z"
+                        }
+                    ]
+                },
+                "trainingDetails": {
+                    "traineeStarted": "true",
+                    "commencementDate": "2022-03-21T19:29:36.093Z"
+                },
+                "isInternationalTrainee": false,
+                "contactDetails": {
+                    "phoneNumber": "0967 519 7344",
+                    "email": "nadia.will2@yahoo.com",
+                    "address": {
+                        "line1": "780 Blick Run",
+                        "line2": "",
+                        "level2": "North Richmond",
+                        "postcode": "CN57 0IV"
+                    },
+                    "addressType": "domestic"
+                },
+                "gcse": {
+                    "maths": {
+                        "type": "GCSE",
+                        "subject": "Maths",
+                        "gradeBoundary": "4 and above"
+                    },
+                    "english": {
+                        "type": "GCSE",
+                        "subject": "English",
+                        "gradeBoundary": "4 and above"
+                    },
+                    "science": {
+                        "type": "GCSE",
+                        "subject": "Science",
+                        "gradeBoundary": "4 and above"
+                    }
+                },
+                "schools": {
+                    "leadSchool": {
+                        "urn": "137628",
+                        "localAuthority": "Nottinghamshire",
+                        "schoolName": "The Joseph Whitaker School",
+                        "type": "Academy converter",
+                        "status": "Open",
+                        "phase": "Secondary",
+                        "ukprn": "10035689",
+                        "addressLine1": "Warsop Lane",
+                        "addressLine2": "Rainworth",
+                        "town": "Mansfield",
+                        "postcode": "NG21 0AG",
+                        "uuid": "c3d5b7f8-f53a-45a9-bb3e-ba0f72338b1a"
+                    }
+                },
+                "degree": {
+                    "items": [
+                        {
+                            "type": "Bachelor of Accountancy",
+                            "subject": "French language",
+                            "isInternational": "false",
+                            "institution": "Plymouth College of Art",
+                            "grade": "First-class honours",
+                            "predicted": true,
+                            "startDate": "2016",
+                            "endDate": "2020",
+                            "id": "4486cc10-3621-4e0f-8542-e375057535a1"
+                        }
+                    ]
+                },
+                "funding": {
+                    "initiative": "Not on a training initiative",
+                    "source": "bursary"
+                },
+                "placement": {
+                    "items": [
+                        {
+                            "school": {
+                                "urn": "138050",
+                                "localAuthority": "West Sussex",
+                                "schoolName": "The Bewbush Academy",
+                                "type": "Academy sponsor led",
+                                "status": "Open",
+                                "phase": "Primary",
+                                "ukprn": "10037078",
+                                "addressLine1": "Dorsten Place",
+                                "addressLine2": "Bewbush",
+                                "town": "Crawley",
+                                "postcode": "RH11 8XW",
+                                "uuid": "7807a60c-30d3-4ea2-a29d-923c14bcdca7"
+                            },
+                            "id": "49da554b-6c92-4d55-bde7-c8739e6fc533"
+                        }
+                    ]
+                },
+                "outcome": {},
+                "selectedCourseTemp": "847df604-d0f5-4464-a229-3494593353a7"
+            },
+            "dateFinished": [
+                "1",
+                "5",
                 "2022"
             ]
         }

--- a/app/data/direct-add-record.json
+++ b/app/data/direct-add-record.json
@@ -1,100 +1,242 @@
 {
-  "status": "Draft",
-  "events": {
-    "items": []
-  },
-  "reference": "KN5837",
-  "provider": "Coventry University",
-  "route": "Provider-led (postgrad)",
-  "personalDetails": {
-    "nationality": [
-      "Irish",
-      "American"
-    ],
-    "givenName": "Sarah Lilia",
-    "middleNames": "",
-    "familyName": "Jones",
-    "dateOfBirth": [
-      "3",
-      "12",
-      "1987"
-    ],
-    "sex": "Female",
-    "status": [
-      "Completed"
-    ]
-  },
-  "contactDetails": {
-    "internationalAddress": "",
-    "addressType": "domestic",
-    "address": {
-      "line1": "260 Bradford Street",
-      "line2": "Deritend",
-      "level2": "Birmingham",
-      "postcode": "B12 0QY"
+    "academicYear": "2021 to 2022",
+    "diversity": {
+        "diversityDisclosed": "true",
+        "ethnicGroup": "Black, African, Black British or Caribbean",
+        "ethnicGroupSpecific": "Another Black background",
+        "disabledAnswer": "Not provided"
     },
-    "phoneNumber": "07700 900941",
-    "email": "s.jones@example.com",
-    "status": [
-      "Completed"
+    "id": "directly-added",
+    "personalDetails": {
+        "givenName": "Dale",
+        "familyName": "Schowalter",
+        "middleNames": "Preston",
+        "nationality": [
+            "British"
+        ],
+        "sex": "Male",
+        "dateOfBirth": "1991-11-09T01:07:28.399Z",
+        "fullName": "Dale Preston Schowalter",
+        "shortName": "Dale Schowalter"
+    },
+    "provider": "Webury Hill SCITT",
+    "accreditingProviderType": "SCITT",
+    "route": "Provider-led (postgrad)",
+    "status": "Pending TRN",
+    "updatedDate": "2022-03-29T15:44:11.189Z",
+    "submittedDate": "2022-03-21T04:10:33.875Z",
+    "reference": "EN5769",
+    "source": "Manual",
+    "courseDetails": {
+        "ageRange": "11 to 18",
+        "code": "F974",
+        "duration": 1,
+        "id": "d8a7c5d5-441d-41d3-8889-05036d9c4df3",
+        "isPublishCourse": true,
+        "phase": "Secondary",
+        "qualifications": [
+            "QTS",
+            "PGCE"
+        ],
+        "qualificationsSummary": "PGCE with QTS full time",
+        "route": "Provider-led (postgrad)",
+        "startDateVague": "2021-08-31T23:00:00.000Z",
+        "academicYear": "2021 to 2022",
+        "studyMode": "Full time",
+        "publishSubjects": {
+            "first": "Physical education",
+            "second": "Chemistry"
+        },
+        "courseNameShort": "Physical education with chemistry",
+        "courseNameLong": "Physical education with chemistry (F974)",
+        "subjects": {
+            "first": "Physical education",
+            "second": "Chemistry"
+        }
+    },
+    "events": {
+        "items": [
+            {
+                "title": "Record created",
+                "user": "Provider",
+                "date": "2021-12-15T18:07:01.968Z"
+            },
+            {
+                "title": "Trainee submitted for TRN",
+                "user": "Provider",
+                "date": "2021-12-15T18:07:01.968Z"
+            },
+            {
+                "title": "Record updated",
+                "user": "Provider",
+                "date": "2022-03-29T15:43:03.830Z"
+            },
+            {
+                "title": "Record updated",
+                "user": "Provider",
+                "date": "2022-03-29T15:44:11.189Z"
+            }
+        ]
+    },
+    "trainingDetails": {
+        "traineeStarted": "true",
+        "commencementDate": "2022-03-21T04:10:33.875Z"
+    },
+    "isInternationalTrainee": false,
+    "contactDetails": {
+        "phoneNumber": "056 9614 9105",
+        "email": "allison31@hotmail.com",
+        "address": {
+            "line1": "1004 Kiley Street",
+            "line2": "",
+            "level2": "West Lesliebury",
+            "postcode": "BP6 6LO"
+        },
+        "addressType": "domestic"
+    },
+    "gcse": {
+        "maths": {
+            "type": "Scottish National 5",
+            "subject": "Maths",
+            "gradeBoundary": "4 and above"
+        },
+        "english": {
+            "type": "Scottish National 5",
+            "subject": "English",
+            "gradeBoundary": "4 and above"
+        },
+        "science": {
+            "type": "Scottish National 5",
+            "subject": "Science",
+            "gradeBoundary": "4 and above"
+        }
+    },
+    "degree": {
+        "items": [
+            {
+                "type": "BSc Education",
+                "subject": "Fashion",
+                "isInternational": "false",
+                "institution": "Backstage Academy (Training)",
+                "grade": "Pass",
+                "predicted": false,
+                "startDate": "2015",
+                "endDate": "2019",
+                "id": "cb7e588f-a59f-44a0-9e2a-bda871cefe5f"
+            }
+        ]
+    },
+    "funding": {
+        "initiative": "Not on a training initiative"
+    },
+    "placement": {
+        "items": [
+            {
+                "school": {
+                    "urn": "110257",
+                    "localAuthority": "Milton Keynes",
+                    "schoolName": "Wyvern School",
+                    "type": "Foundation school",
+                    "status": "Open",
+                    "phase": "Primary",
+                    "ukprn": "10080374",
+                    "addressLine1": "Aylesbury Street",
+                    "addressLine2": "Wolverton",
+                    "town": "Milton Keynes",
+                    "postcode": "MK12 5HU",
+                    "uuid": "85e899c9-d81c-404b-aa63-7c163875c1d3"
+                },
+                "id": "678834bf-79a3-4f8f-bcf8-02bad6426b6e"
+            },
+            {
+                "school": {
+                    "urn": "140696",
+                    "localAuthority": "Leicestershire",
+                    "schoolName": "Ab Kettleby School",
+                    "type": "Academy converter",
+                    "status": "Open",
+                    "phase": "Primary",
+                    "ukprn": "10045668",
+                    "addressLine1": "Wartnaby Road",
+                    "addressLine2": "Ab Kettleby",
+                    "town": "Melton Mowbray",
+                    "postcode": "LE14 3JJ",
+                    "uuid": "0d37f6f8-0a96-4189-a749-8d996cf1c86e"
+                },
+                "id": "ed78efdc-cf09-4704-8de1-ddeb5044f169"
+            }
+        ]
+    },
+    "outcome": {},
+    "selectedCourseTemp": "d8a7c5d5-441d-41d3-8889-05036d9c4df3",
+    "historicCourseDetails": [
+        {
+            "courseDetails": {
+                "ageRange": "11 to 18",
+                "code": "G640",
+                "duration": 1,
+                "id": "eedb5a80-431d-4e4c-9c8b-a6de5631120a",
+                "isPublishCourse": true,
+                "phase": "Secondary",
+                "qualifications": [
+                    "QTS",
+                    "PGCE"
+                ],
+                "qualificationsSummary": "PGCE with QTS full time",
+                "route": "Teaching apprenticeship (postgrad)",
+                "startDateVague": "2021-08-31T23:00:00.000Z",
+                "academicYear": "2021 to 2022",
+                "studyMode": "Full time",
+                "publishSubjects": {
+                    "first": "Physics"
+                },
+                "courseNameShort": "Physics",
+                "courseNameLong": "Physics (G640)",
+                "subjects": {
+                    "first": "Physics"
+                },
+                "startDate": "2021-09-02T23:00:00.000Z",
+                "endDate": "2022-06-02T23:00:00.000Z"
+            },
+            "schools": {
+                "leadSchool": {
+                    "urn": "137628",
+                    "localAuthority": "Nottinghamshire",
+                    "schoolName": "The Joseph Whitaker School",
+                    "type": "Academy converter",
+                    "status": "Open",
+                    "phase": "Secondary",
+                    "ukprn": "10035689",
+                    "addressLine1": "Warsop Lane",
+                    "addressLine2": "Rainworth",
+                    "town": "Mansfield",
+                    "postcode": "NG21 0AG",
+                    "uuid": "c3d5b7f8-f53a-45a9-bb3e-ba0f72338b1a"
+                },
+                "employingSchool": {
+                    "urn": "122762",
+                    "localAuthority": "Nottinghamshire",
+                    "schoolName": "Kneesall CofE Primary School",
+                    "type": "Voluntary controlled school",
+                    "status": "Open",
+                    "phase": "Primary",
+                    "ukprn": "10077939",
+                    "addressLine1": "School Lane",
+                    "addressLine2": "Kneesall",
+                    "town": "Newark",
+                    "postcode": "NG22 0AB",
+                    "uuid": "315867fe-1897-4503-90e5-01c4feb4ae0e"
+                }
+            },
+            "funding": {
+                "initiative": "Not on a training initiative",
+                "source": "grant"
+            },
+            "dateFinished": [
+                "1",
+                "2",
+                "2022"
+            ]
+        }
     ]
-  },
-  "diversity": {
-    "diversityDisclosed": "false",
-    "status": [
-      "Completed"
-    ]
-  },
-  "degree": {
-    "items": [
-      {
-        "isInternational": "true",
-        "subject": "Biology",
-        "country": "United States",
-        "endDate": "2013",
-        "type": "Bachelor degree",
-        "id": "31dc5e93-b521-425c-98d8-dec96eb2388c"
-      },
-      {
-        "isInternational": "false",
-        "subject": "Sport and exercise sciences",
-        "org": "The University of Manchester",
-        "endDate": "2016",
-        "type": "BSc - Bachelor of Science",
-        "grade": "First-class honours",
-        "id": "1faf0ae6-4c01-4224-9e49-06beffc0c5d0"
-      }
-    ],
-    "status": [
-      "Completed"
-    ]
-  },
-  "courseDetails": {
-    "subjects": ["Physics"],
-    "ageRange": "3 to 11 programme",
-    "startDate": [
-      "1",
-      "2",
-      "2021"
-    ],
-    "endDate": [
-      "1",
-      "6",
-      "2021"
-    ],
-    "status": [
-      "Completed"
-    ]
-  },
-  "trainingDetails": {
-    "commencementDate": [
-      "1",
-      "2",
-      "2021"
-    ],
-    "traineeId": "AO/03/21",
-    "status": [
-      "Completed"
-    ]
-  }
 }

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -144,6 +144,8 @@ settings.draftsInPrimaryNav = 'true'
 // Start date is required when registering trainees
 settings.requireTraineeStartDate = 'true'
 
+settings.skipCourseDatesPage = 'true'
+
 // Default number of Publish courses that the provider offers
 settings.courseLimit = 12
 

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -15,6 +15,8 @@ const generateReference      = require('./../data/generators/reference-number')
 const academicQualifications = require('./../data/academic-qualifications.js')
 const years                  = require('./../data/years.js')
 
+let skipCourseDatesPage = true
+
 // -------------------------------------------------------------------
 // General
 // -------------------------------------------------------------------
@@ -288,6 +290,8 @@ exports.getNextPublishCourseDetailsUrl = (record, recordPath, referrer) => {
   let isMissingDates = exports.needsCourseDates(record)
   let isAllocated = exports.hasAllocatedPlaces(record)
 
+  let isMissingCourseMoveQuestion = !Boolean(record?.temp?.courseMoveTemp)
+
   if (hasUnmappedPublishSubjects){
     return `${recordPath}/course-details/choose-specialisms${referrer}`
   }
@@ -296,13 +300,16 @@ exports.getNextPublishCourseDetailsUrl = (record, recordPath, referrer) => {
     return `${recordPath}/course-details/study-mode${referrer}`
   }
   // Backfill course dates
-  else if (isMissingDates){
+  else if (isMissingDates && !skipCourseDatesPage){
     return `${recordPath}/course-details/dates${referrer}`
   }
   // else if (isAllocated) {
   //   // After /allocated-place the journey will match other course-details routes
   //   return `${recordPath}/course-details/allocated-place${referrer}`
   // }
+  else if (exports.isNonDraft(record) && isMissingCourseMoveQuestion){
+    return `${recordPath}/course-details/course-move-question${referrer}`
+  }
   else {
     return `${recordPath}/course-details/confirm${referrer}`
   }
@@ -2369,6 +2376,29 @@ exports.makeUrlWithQuery = (pathname, query) => {
     query: query,
   })
 }
+
+// New URL parsing functions
+exports.parseUrl = (inputUrl) => {
+  if (!_.isString(inputUrl)){
+    console.log(`Error with parseUrl: input not a string`)
+    return inputUrl
+  }
+  else return url.parse(inputUrl, true)
+}
+
+// Get structured query
+exports.getQueryFromUrl = (inputUrl) => {
+  return exports.parseUrl(inputUrl).query
+}
+
+// Get structured query
+exports.getPathnameFromUrl = (inputUrl) => {
+  return exports.parseUrl(inputUrl).pathname
+}
+
+// end new url passing functions
+
+
 
 // Update the current query with sort order set
 exports.createSortLink = function(pathname, sortOrder){

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -347,6 +347,8 @@ exports.getNextCourseChangeUrl = (record, recordPath, referrer) => {
 
   let startWithReviewPage = false
 
+  let isMissingCourseMoveQuestion = !Boolean(record?.temp?.courseMoveTemp)
+
   if (startWithReviewPage){
     return `${recordPath}/course-details/final-check-course-change${referrer}`
   }
@@ -361,6 +363,9 @@ exports.getNextCourseChangeUrl = (record, recordPath, referrer) => {
   }
   else if (missingItems.includes("funding method")){
     return `${recordPath}/funding/financial-support${referrer}`
+  }
+  else if (isMissingCourseMoveQuestion){
+    return `${recordPath}/course-details/course-move-question${referrer}`
   }
   else {
     return `${recordPath}/course-details/final-check-course-change${referrer}`

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -307,9 +307,9 @@ exports.getNextPublishCourseDetailsUrl = (record, recordPath, referrer) => {
   //   // After /allocated-place the journey will match other course-details routes
   //   return `${recordPath}/course-details/allocated-place${referrer}`
   // }
-  else if (exports.isNonDraft(record) && isMissingCourseMoveQuestion){
-    return `${recordPath}/course-details/course-move-question${referrer}`
-  }
+  // else if (exports.isNonDraft(record) && isMissingCourseMoveQuestion){
+  //   return `${recordPath}/course-details/course-move-question${referrer}`
+  // }
   else {
     return `${recordPath}/course-details/confirm${referrer}`
   }

--- a/app/routes.js
+++ b/app/routes.js
@@ -92,6 +92,8 @@ router.post('/direct-set-data', function(req, res, next){
   let theValue = data.directSet?.value
   let theValueJson = data.directSet?.valueJson
   let shouldMerge = data.directSet?.mergeJson == 'true'
+  let updateRecord = data.directSet?.updateRecord == 'true'
+
   let parsedJson
 
   delete data.directSet
@@ -121,6 +123,19 @@ router.post('/direct-set-data', function(req, res, next){
   console.log({theValue})
 
   _.set(data, theKey, theValue)
+
+  // If we were given record data, save it back to data.records so it persists
+  if (updateRecord){
+    if (data?.record?.id){
+      let recordIndex = data.records.findIndex(record => record.id == data.record.id)
+      if (recordIndex){
+        console.log(`Updating record at index ${recordIndex}`)
+        data.records[recordIndex] = data.record
+      }
+    }
+    else console.log("Error: no record id to update to")
+
+  }
 
   res.redirect("/direct-set-data")
 })

--- a/app/routes/existing-record-routes.js
+++ b/app/routes/existing-record-routes.js
@@ -642,6 +642,8 @@ module.exports = router => {
 
     let isCourseMove = (record?.temp?.courseMoveTemp?.isCourseMove == "true") ? true : false
 
+    let timelineMessage = (isCourseMove) ? "Traineed moved to new course" : false
+
     if (isCourseMove){
 
       let bundle = {}
@@ -666,7 +668,17 @@ module.exports = router => {
 
     delete record?.temp
 
-    res.redirect(307, `${recordPath}/course-details/update${referrer}`);
+    utils.deleteTempData(data)
+    utils.updateRecord(data, record, timelineMessage)
+    req.flash('success', 'Trainee record updated')
+
+    if (referrer){
+      res.redirect(utils.getReferrerDestination(req.query.referrer))
+    }
+    else {
+      // More likely we've come from this tab where most things are on
+      res.redirect(`/record/${req.params.uuid}`)
+    }
 
   })
 

--- a/app/routes/existing-record-routes.js
+++ b/app/routes/existing-record-routes.js
@@ -651,11 +651,11 @@ module.exports = router => {
         ...( previousRecord.funding ? { funding: previousRecord.funding } : {} ),  // conditional
         dateFinished: record?.temp?.courseMoveTemp?.courseMoveDate
       }
-      if (record.historicCourseData){
-        record.historicCourseData.push(oldCourseData)
+      if (record.historicCourseDetails){
+        record.historicCourseDetails.push(oldCourseData)
       }
       else {
-        record.historicCourseData = [oldCourseData]
+        record.historicCourseDetails = [oldCourseData]
       }
     }
 

--- a/app/routes/existing-record-routes.js
+++ b/app/routes/existing-record-routes.js
@@ -501,47 +501,50 @@ module.exports = router => {
 
     let isCourseMove = record?.temp?.courseMoveTemp?.isCourseMove
 
+    // No data
     if (!isCourseMove){
       res.redirect(`/record/${req.params.uuid}/course-details/course-move-question${referrer}`)
     }
-    else if (isCourseMove == 'true'){
-      res.redirect(`/record/${req.params.uuid}/course-details/course-move-date${referrer}`)
-    }
     else {
 
-      // Clear previous data if we've now been told it’s not a course change
-      delete record?.temp?.courseMoveTemp?.courseMoveDate
-
-      // If coming from final check page, send user back there
-      if (req.query.referrer && req.query.referrer.includes("final-check")){
-        res.redirect(`/record/${req.params.uuid}/course-details/final-check-course-change${referrer}`)
+      if (isCourseMove == 'false') {
+        // Clear previous data if we've now been told it’s not a course change
+        delete record?.temp?.courseMoveTemp?.courseMoveDate
       }
 
-      // Otherwise go to confirmation page
       res.redirect(`/record/${req.params.uuid}/course-details/confirm${referrer}`)
 
+      // // If coming from final check page, send user back there
+      // if (req.query.referrer && req.query.referrer.includes("final-check")){
+      //   res.redirect(`/record/${req.params.uuid}/course-details/final-check-course-change${referrer}`)
+      // }
+      // else {
+      //   // Otherwise go to course details confirmation page
+      //   res.redirect(`/record/${req.params.uuid}/course-details/confirm${referrer}`)
+      // }
+
     }
   })
 
-  // Redirect to course question if we don’t yet have data for it
-  router.get('/:recordtype/:uuid/course-details/confirm', function (req, res) {
-    const data = req.session.data
-    let record = data.record
-    let referrer = utils.getReferrer(req.query.referrer)
-    let recordPath = utils.getRecordPath(req)
+  // // Redirect to course question if we don’t yet have data for it
+  // router.get('/:recordtype/:uuid/course-details/confirm', function (req, res) {
+  //   const data = req.session.data
+  //   let record = data.record
+  //   let referrer = utils.getReferrer(req.query.referrer)
+  //   let recordPath = utils.getRecordPath(req)
 
-    console.log('Record temp: ' + record?.temp)
+  //   console.log('Record temp: ' + record?.temp)
 
-    let isMissingCourseMoveQuestion = !Boolean(record?.temp?.courseMoveTemp)
+  //   let isMissingCourseMoveQuestion = !Boolean(record?.temp?.courseMoveTemp)
 
-    if (isMissingCourseMoveQuestion){
-      res.redirect(`${recordPath}/course-details/course-move-question${referrer}`)
-    }
-    else {
-      res.render(`${req.params.recordtype}/course-details/confirm`)
-    }
+  //   if (isMissingCourseMoveQuestion){
+  //     res.redirect(`${recordPath}/course-details/course-move-question${referrer}`)
+  //   }
+  //   else {
+  //     res.render(`${req.params.recordtype}/course-details/confirm`)
+  //   }
 
-  })
+  // })
 
   // Work out if course details have changed significantly and so we need to have the user
   // check the school and funding sections
@@ -560,9 +563,13 @@ module.exports = router => {
     }
 
     let routeChanged = (record?.route != previousRecord?.route)
-
     if (routeChanged){
-      console.log(`Course change: route changed from ${previousRecord?.route} to ${record?.rou}`)
+      console.log(`Course change: route changed from ${previousRecord?.route} to ${record?.route}`)
+    }
+
+    let studyModeChanged = (record?.courseDetails?.studyMode != previousRecord?.courseDetails?.studyMode)
+    if (studyModeChanged){
+      console.log(`Course change: study mode changed from ${previousRecord?.courseDetails?.studyMode} to ${record?.courseDetails?.studyMode}`)
     }
 
     // Check if the allocation subject has changed.
@@ -604,7 +611,7 @@ module.exports = router => {
 
     // If the route or first subject has changed, that's a significant change and providers
     // should review the rest of the training details
-    if (routeChanged || allocationSubjectChanged || isCourseMove){
+    if (routeChanged || allocationSubjectChanged || isCourseMove || studyModeChanged){
       res.redirect(`${recordPath}/course-details/course-change-instructions${referrer}`)
     }
     else {

--- a/app/routes/existing-record-routes.js
+++ b/app/routes/existing-record-routes.js
@@ -494,30 +494,6 @@ module.exports = router => {
 
   })
 
-  router.post('/record/:uuid/course-details/course-move-question-answer', function (req, res) {
-    let data = req.session.data
-    let record = data.record
-    let referrer = utils.getReferrer(req.query.referrer)
-    let recordPath = utils.getRecordPath(req)
-
-    let isCourseMove = record?.temp?.courseMoveTemp?.isCourseMove
-
-    // No data
-    if (!isCourseMove){
-      res.redirect(`/record/${req.params.uuid}/course-details/course-move-question${referrer}`)
-    }
-    else {
-
-      if (isCourseMove == 'false') {
-        // Clear previous data if we've now been told it’s not a course change
-        delete record?.temp?.courseMoveTemp?.courseMoveDate
-      }
-
-      res.redirect(utils.getNextCourseChangeUrl(record, recordPath, referrer))
-
-    }
-  })
-
   // Work out if course details have changed significantly and so we need to have the user
   // check the school and funding sections
   router.post('/:recordtype/:uuid/course-details/course-change-significant-change-check', function (req, res) {
@@ -533,6 +509,8 @@ module.exports = router => {
     if (isCourseMove){
       console.log(`Course change: changed on ${courseMove.courseMoveDate}`)
     }
+
+    let courseCodeChanged = record?.courseDetails?.code != previousRecord?.courseDetails?.code
 
     let routeChanged = (record?.route != previousRecord?.route)
     if (routeChanged){
@@ -583,7 +561,7 @@ module.exports = router => {
 
     // If the route or first subject has changed, that's a significant change and providers
     // should review the rest of the training details
-    if (routeChanged || allocationSubjectChanged || isCourseMove || studyModeChanged){
+    if (routeChanged || courseCodeChanged || allocationSubjectChanged || isCourseMove || studyModeChanged){
       res.redirect(`${recordPath}/course-details/course-change-instructions${referrer}`)
     }
     else {
@@ -591,6 +569,30 @@ module.exports = router => {
       delete record?.temp?.courseMoveTemp
       // 307 Redirect to POST route
       res.redirect(307, `${recordPath}/course-details/update${referrer}`);
+    }
+  })
+
+  router.post('/:recordtype/:uuid/course-details/course-move-question-answer', function (req, res) {
+    let data = req.session.data
+    let record = data.record
+    let referrer = utils.getReferrer(req.query.referrer)
+    let recordPath = utils.getRecordPath(req)
+
+    let isCourseMove = record?.temp?.courseMoveTemp?.isCourseMove
+
+    // No data
+    if (!isCourseMove){
+      res.redirect(`/record/${req.params.uuid}/course-details/course-move-question${referrer}`)
+    }
+    else {
+
+      if (isCourseMove == 'false') {
+        // Clear previous data if we've now been told it’s not a course change
+        delete record?.temp?.courseMoveTemp?.courseMoveDate
+      }
+
+      res.redirect(utils.getNextCourseChangeUrl(record, recordPath, referrer))
+
     }
   })
 

--- a/app/routes/existing-record-routes.js
+++ b/app/routes/existing-record-routes.js
@@ -498,6 +498,7 @@ module.exports = router => {
     let data = req.session.data
     let record = data.record
     let referrer = utils.getReferrer(req.query.referrer)
+    let recordPath = utils.getRecordPath(req)
 
     let isCourseMove = record?.temp?.courseMoveTemp?.isCourseMove
 
@@ -512,39 +513,10 @@ module.exports = router => {
         delete record?.temp?.courseMoveTemp?.courseMoveDate
       }
 
-      res.redirect(`/record/${req.params.uuid}/course-details/confirm${referrer}`)
-
-      // // If coming from final check page, send user back there
-      // if (req.query.referrer && req.query.referrer.includes("final-check")){
-      //   res.redirect(`/record/${req.params.uuid}/course-details/final-check-course-change${referrer}`)
-      // }
-      // else {
-      //   // Otherwise go to course details confirmation page
-      //   res.redirect(`/record/${req.params.uuid}/course-details/confirm${referrer}`)
-      // }
+      res.redirect(utils.getNextCourseChangeUrl(record, recordPath, referrer))
 
     }
   })
-
-  // // Redirect to course question if we don’t yet have data for it
-  // router.get('/:recordtype/:uuid/course-details/confirm', function (req, res) {
-  //   const data = req.session.data
-  //   let record = data.record
-  //   let referrer = utils.getReferrer(req.query.referrer)
-  //   let recordPath = utils.getRecordPath(req)
-
-  //   console.log('Record temp: ' + record?.temp)
-
-  //   let isMissingCourseMoveQuestion = !Boolean(record?.temp?.courseMoveTemp)
-
-  //   if (isMissingCourseMoveQuestion){
-  //     res.redirect(`${recordPath}/course-details/course-move-question${referrer}`)
-  //   }
-  //   else {
-  //     res.render(`${req.params.recordtype}/course-details/confirm`)
-  //   }
-
-  // })
 
   // Work out if course details have changed significantly and so we need to have the user
   // check the school and funding sections

--- a/app/routes/new-record-routes.js
+++ b/app/routes/new-record-routes.js
@@ -16,7 +16,7 @@ module.exports = router => {
   router.get('/new-record/direct-add', function (req, res) {
     const data = req.session.data
     utils.deleteTempData(data)
-    data.record = require('./../data/direct-add-record.json')
+    data.record = require('./../data/direct-add-draft-record.json')
     res.redirect('/new-record/overview')
   })
 

--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -12,6 +12,18 @@ const getSchools = () => {
 
 module.exports = router => {
 
+  // Hacky solution to manually import a record to draft state
+  // Useful for testing bugs so we can quickly restore a state
+  router.get('/record-direct-add', (req, res) => {
+    const data = req.session.data
+
+    utils.deleteTempData(data)
+    let record = require('./../data/direct-add-record.json')
+    data.records.push(record)
+    // utils.updateRecord(data, record)
+    res.redirect(`/record/${record.id}`)
+  })
+
   // Load up data for a record
   // This implimentation makes a copy of the record and stores it in a temporary location
   // any edits happen on this temporary data - depending on the journey, some routes may then

--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -309,6 +309,10 @@ module.exports = router => {
     let existingCourseDetails = record?.courseDetails
     let recordIsDraft = utils.isDraft(record)
 
+    // In case we’re changing course
+    // Todo: I forget why we delete this here
+    delete record?.temp?.courseMoveTemp?.courseMoveUpFront
+
     // No data, return to page
     if (!route){
       res.redirect(`${recordPath}/course-details/select-route${referrer}`)
@@ -393,7 +397,7 @@ module.exports = router => {
 
   })
 
-    // Decide whether to go down Publish pick-course journey or directly to manual course details
+  // Interpret which year we're looking for
   router.post(['/:recordtype/:uuid/course-details/course-year-answer','/:recordtype/course-details/course-year-answer'], function (req, res) {
     const data = req.session.data
     const record = data.record
@@ -441,7 +445,7 @@ module.exports = router => {
 
   })
 
-    // Decide whether to go down Publish pick-course journey or directly to manual course details
+  // Render publish courses for a specific year
   router.get(['/:recordtype/:uuid/course-details/pick-course/:courseStartYear','/:recordtype/course-details/pick-course/:courseStartYear'], function (req, res) {
     const data = req.session.data
     const record = data.record
@@ -478,7 +482,6 @@ module.exports = router => {
     }
 
   })
-
 
   // =============================================================================
   // Course details - Apply
@@ -609,7 +612,7 @@ module.exports = router => {
           // particular course we ask if the dates they add for that trainee should be saved back to
           // the course - if so we’ll now have them and can apply them to future trainees on that
           // course and study mode.
-          record.courseDetails = utils.setCourseDatesIfPresent(courseDetails)
+          record.courseDetails = utils.setCourseDatesIfPresent(record.courseDetails)
 
           if (utils.isDraft(record)){
             record = utils.setAcademicYear(record)
@@ -758,7 +761,8 @@ module.exports = router => {
   // =============================================================================
 
   // Picking a phase (Primary or Secondary education)
-  router.post(['/:recordtype/:uuid/course-details/phase','/:recordtype/course-details/phase'], function (req, res) {
+  // Mostly doing cleanup of data
+  router.post(['/:recordtype/:uuid/course-details/phase-answer','/:recordtype/course-details/phase-answer'], function (req, res) {
     const data = req.session.data
     let record = data.record
     let recordPath = utils.getRecordPath(req)
@@ -840,66 +844,8 @@ module.exports = router => {
     }
     else {
       res.redirect(`${recordPath}/course-details/confirm${referrer}`)
+
     }
-
-  })
-
-  // Work out if course details have changed significantly and so we need to have the user
-  // check the school and funding sections
-  router.post('/:recordtype/:uuid/course-details/course-change-check', function (req, res) {
-    let data = req.session.data
-    let record = data.record
-    let referrer = utils.getReferrer(req.query.referrer)
-    let recordPath = utils.getRecordPath(req)
-
-    let previousRecord = utils.getRecordById(data.records, record.id)
-
-    let routeChanged = (previousRecord?.route != record?.route)
-
-    let firstSubject = record?.courseDetails?.subjects?.first
-    let previousFirstSubject = previousRecord?.courseDetails?.subjects?.first
-    let firstSubjectChanged = !Boolean(firstSubject) || (previousFirstSubject !== firstSubject)
-
-    // Clear out school data if schools no longer needed
-    if (!utils.requiresSection(record, "degree")){
-      delete record?.degree
-    }
-    if (!utils.requiresSection(record, "schools")){
-      delete record?.schools
-    }
-    if (!utils.requiresField(record, "leadSchool")){
-      delete record?.schools?.leadSchool
-    }
-    if (!utils.requiresField(record, "employingSchool")){
-      delete record?.schools?.employingSchool
-    }
-
-    // If the route or first subject has changed, that's a significant change and providers
-    // should review the rest of the training details
-    if (routeChanged || firstSubjectChanged){
-
-      // Don’t trust financial incentives after a significant change - better to
-      // collect again.
-      delete record?.funding?.source
-
-      res.redirect(`${recordPath}/course-details/course-change-instructions${referrer}`)
-    }
-    else {
-      res.redirect(307, `${recordPath}/course-details/update${referrer}`);
-    }
-  })
-
-  router.get(['/:recordtype/:uuid/course-details/get-next-course-change-url','/:recordtype/course-details/get-next-course-change-url'], function (req, res) {
-    const data = req.session.data
-    let record = data.record
-    let recordPath = utils.getRecordPath(req)
-
-    // Unlike most pages, here we want to insert a new referrer in the query string
-    let reviewCourseChangeUrl = `${recordPath}/course-details/final-check-course-change`
-    let referrerArray = utils.pushReferrer(req.query.referrer, reviewCourseChangeUrl)
-    let referrer = utils.getReferrer(referrerArray)
-
-    res.redirect(utils.getNextCourseChangeUrl(record, recordPath, referrer))
 
   })
 

--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -321,10 +321,6 @@ module.exports = router => {
     let existingCourseDetails = record?.courseDetails
     let recordIsDraft = utils.isDraft(record)
 
-    // In case we’re changing course
-    // Todo: I forget why we delete this here
-    delete record?.temp?.courseMoveTemp?.courseMoveUpFront
-
     // No data, return to page
     if (!route){
       res.redirect(`${recordPath}/course-details/select-route${referrer}`)

--- a/app/views/_includes/forms/course-details/course-move-date.html
+++ b/app/views/_includes/forms/course-details/course-move-date.html
@@ -1,0 +1,43 @@
+{% set startStartDateArray = record.temp.courseMoveTemp.courseMoveDate | toDateArray %}
+
+{% set startDateHint = "For example, " + "" | today | toDateArray | spaceSeparate %}
+
+{% include "_includes/trainee-name-caption.njk" %}
+
+{{ govukDateInput({
+  id: "start-start-date",
+  namePrefix: "record[temp][courseMoveTemp][courseMoveDate]",
+  fieldset: {
+    legend: {
+      text: pageHeading,
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--l"
+    }
+  },
+  hint: {
+    html: startDateHint
+  },
+  items: [
+      {
+        name: "day",
+        classes: "govuk-input--width-2",
+        value: startStartDateArray["0"]
+      },
+      {
+        name: "month",
+        classes: "govuk-input--width-2",
+        value: startStartDateArray["1"]
+      },
+      {
+        name: "year",
+        classes: "govuk-input--width-4",
+        value: startStartDateArray["2"]
+      }
+    ]
+}) }}
+
+{{ govukButton({
+  text: "Continue"
+}) }}
+
+

--- a/app/views/_includes/forms/course-details/course-move-date.html
+++ b/app/views/_includes/forms/course-details/course-move-date.html
@@ -1,4 +1,4 @@
-{% set startStartDateArray = record.temp.courseMoveTemp.courseMoveDate | toDateArray %}
+{% set courseMoveDateArray = record.temp.courseMoveTemp.courseMoveDate | toDateArray %}
 
 {% set startDateHint = "For example, " + "" | today | toDateArray | spaceSeparate %}
 
@@ -21,17 +21,17 @@
       {
         name: "day",
         classes: "govuk-input--width-2",
-        value: startStartDateArray["0"]
+        value: courseMoveDateArray["0"]
       },
       {
         name: "month",
         classes: "govuk-input--width-2",
-        value: startStartDateArray["1"]
+        value: courseMoveDateArray["1"]
       },
       {
         name: "year",
         classes: "govuk-input--width-4",
-        value: startStartDateArray["2"]
+        value: courseMoveDateArray["2"]
       }
     ]
 }) }}

--- a/app/views/_includes/forms/course-details/course-move-question.html
+++ b/app/views/_includes/forms/course-details/course-move-question.html
@@ -1,0 +1,28 @@
+{% include "_includes/trainee-name-caption.njk" %}
+{# <h1 class="govuk-heading-l">
+  {{pageHeading}}
+</h1> #}
+
+{{ govukRadios({
+  fieldset: {
+    legend: {
+      text: pageHeading,
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--l"
+    }
+  },
+  items: [
+    {
+      value: "true",
+      text: "Yes, the trainee has moved to a different course"
+    },
+    {
+      value: "false",
+      text: "No, I am correcting a mistake or updating their existing course details"
+    }
+  ]
+} | decorateAttributes(record, "record.temp.courseMoveTemp.isCourseMove")) }}
+
+{{ govukButton({
+  text: "Continue"
+}) }}

--- a/app/views/_includes/forms/course-details/course-move-question.html
+++ b/app/views/_includes/forms/course-details/course-move-question.html
@@ -1,7 +1,4 @@
 {% include "_includes/trainee-name-caption.njk" %}
-{# <h1 class="govuk-heading-l">
-  {{pageHeading}}
-</h1> #}
 
 {% set courseMoveDateArray = record.temp.courseMoveTemp.courseMoveDate | toDateArray %}
 

--- a/app/views/_includes/forms/course-details/course-move-question.html
+++ b/app/views/_includes/forms/course-details/course-move-question.html
@@ -3,6 +3,43 @@
   {{pageHeading}}
 </h1> #}
 
+{% set courseMoveDateArray = record.temp.courseMoveTemp.courseMoveDate | toDateArray %}
+
+{% set courseMoveDateHint = "For example, " + "" | today | toDateArray | spaceSeparate %}
+
+{% set dateHtml %}
+  {{ govukDateInput({
+    id: "course-move-date",
+    namePrefix: "record[temp][courseMoveTemp][courseMoveDate]",
+    fieldset: {
+      legend: {
+        text: "On what date?",
+        classes: "govuk-label govuk-label--s"
+      }
+    },
+    hint: {
+      text: courseMoveDateHint
+    },
+    items: [
+        {
+          name: "day",
+          classes: "govuk-input--width-2",
+          value: courseMoveDateArray["0"]
+        },
+        {
+          name: "month",
+          classes: "govuk-input--width-2",
+          value: courseMoveDateArray["1"]
+        },
+        {
+          name: "year",
+          classes: "govuk-input--width-4",
+          value: courseMoveDateArray["2"]
+        }
+      ]
+  }) }}
+{% endset %}
+
 {{ govukRadios({
   fieldset: {
     legend: {
@@ -14,11 +51,17 @@
   items: [
     {
       value: "true",
-      text: "Yes, the trainee has moved to a different course"
+      text: "Yes, the change happened after they started",
+      conditional: {
+        html: dateHtml
+      }
     },
     {
       value: "false",
-      text: "No, I am correcting a mistake or updating their existing course details"
+      text: "No, they’ve always been studying with these details",
+      hint: {
+        text: "For example, you are correcting a mistake"
+      }
     }
   ]
 } | decorateAttributes(record, "record.temp.courseMoveTemp.isCourseMove")) }}

--- a/app/views/_includes/summary-cards/course-details.html
+++ b/app/views/_includes/summary-cards/course-details.html
@@ -49,6 +49,17 @@
   } if canAmend
 } %}
 
+{# Shown if trainee has been on a previous course - this is the date they started the latest course #}
+{% set dateMovedRow = {
+  key: {
+    text: "Date moved to this course"
+  },
+  value: {
+    html: (record.historicCourseDetails | last).dateFinished | govukDate or 'Not provided',
+    classes: "govuk-hint"
+  }
+} if record.historicCourseDetails %}
+
 {# For use in course move flow #}
 {% set previousRecord = data.records | getRecordById(record.id) %}
 {% set previousCourseRow = {
@@ -263,7 +274,8 @@
     studyModeRow,
     startDateRow,
     endDateRow,
-    courseMoveRow if showCourseMoveRow
+    courseMoveRow if showCourseMoveRow,
+    dateMovedRow if showDateMovedRow
   ] %}
 
 {% else %}
@@ -277,7 +289,8 @@
     apprenticeshipStartDateRow,
     startDateRow,
     endDateRow,
-    courseMoveRow if showCourseMoveRow
+    courseMoveRow if showCourseMoveRow,
+    dateMovedRow if showDateMovedRow
   ] %}
 
 {% endif %}

--- a/app/views/_includes/summary-cards/course-details.html
+++ b/app/views/_includes/summary-cards/course-details.html
@@ -7,28 +7,41 @@
   {% set expectedDuration = courseDetails.duration + " years" %}
 {% endif %}
 
-{% macro courseAndRouteHtml(record) %}
-  {% set _isPublishCourse = record.courseDetails.isPublishCourse | falsify %}
+{% macro courseAndRouteHtml(record, minimalPublishSummary) %}
+  {% set isPublishCourse = record.courseDetails.isPublishCourse | falsify %}
   <p class="govuk-body">{{record.route}}</p>
-
-  {% if _isPublishCourse %}
-    <p class="govuk-body">{{ record.courseDetails.courseNameLong }}</p>
-  {% elseif minimalPublishSummary %}
-    <p class="govuk-body">{{ record.courseDetails.subjects | prettifySubjects }}</p>
-  {% endif %}
+  <span class="govuk-hint">
+    {% if isPublishCourse %}
+      {{ record.courseDetails.courseNameLong }}
+    {% elseif minimalPublishSummary %}
+      {{ record.courseDetails.subjects | prettifySubjects }}
+    {% endif %}
+  </span>
 {% endmacro %}
+
+{% macro getCourseMoveLinkPath(defaultPath, nextPath, referrer, showCourseMoveQuestionUpFront) -%}
+  {%- if showCourseMoveQuestionUpFront -%}
+    {{- defaultPath + '/course-move-question'| addReferrer(defaultPath + nextPath) -}}
+  {% else %}
+    {{ (defaultPath + nextPath) | addReferrer(referrer) }}
+  {%- endif -%}
+{%- endmacro %}
+
+{% set testUrl = getCourseMoveLinkPath((recordPath + "/course-details"), '/select-route', referrer, showCourseMoveQuestionUpFront).val %}
+
 
 {% set courseRow = {
   key: {
     text: "Course" if not showPreviousCourse else "New course"
   },
   value: {
-    html: courseAndRouteHtml(record) | safe | trim or 'Not provided'
+    html: courseAndRouteHtml(record, minimalPublishSummary) | safe | trim or 'Not provided'
   },
   actions: {
     items: [
       {
         href: recordPath + "/course-details/select-route" | addReferrer(referrer),
+        href: getCourseMoveLinkPath((recordPath + "/course-details"), '/select-route', referrer, showCourseMoveQuestionUpFront),
         text: "Change",
         visuallyHiddenText: "course"
       }
@@ -36,14 +49,14 @@
   } if canAmend
 } %}
 
-{# For use in course change flow #}
+{# For use in course move flow #}
 {% set previousRecord = data.records | getRecordById(record.id) %}
 {% set previousCourseRow = {
   key: {
     text: "Previous course"
   },
   value: {
-    html: courseAndRouteHtml(previousRecord) | safe | trim or 'Not provided',
+    html: courseAndRouteHtml(previousRecord, minimalPublishSummary) | safe | trim or 'Not provided',
     classes: "govuk-hint"
   }
 } %}
@@ -59,6 +72,7 @@
     items: [
       {
         href: recordPath + "/course-details/phase" | addReferrer(referrer),
+        href: recordPath + "/course-details/course-move-question" | addReferrer(recordPath + "/course-details/phase"),
         text: "Change",
         visuallyHiddenText: "education phase"
       }
@@ -174,6 +188,38 @@
   } if canAmend
 } %}
 
+{% set courseMove = record.temp.courseMoveTemp %}
+
+{% set courseMoveHtml -%}
+  {%- if courseMove -%}
+    {%- if courseMove.isCourseMove | falsify -%}
+      {{- courseMove.courseMoveDate | govukDate -}}
+    {%- else -%}
+      Not a change of course
+    {%- endif -%}
+  {%- else -%}
+    Not provided
+  {%- endif -%}
+{% endset %}
+
+{% set courseMoveRow = {
+  key: {
+    text: "Course move" if not courseMove.isCourseMove | falsify else "Course move date"
+  },
+  value: {
+    text: courseMoveHtml | safe or 'Not provided'
+  },
+  actions: {
+    items: [
+      {
+        href: recordPath + "/course-details/course-move-question" | addReferrer(referrer),
+        text: "Change",
+        visuallyHiddenText: "change of course question"
+      }
+    ]
+  } if canAmend
+} if record | isNonDraft %}
+
 {# {% set durationRow = {
   key: {
     text: "Duration"
@@ -216,7 +262,8 @@
     courseRow,
     studyModeRow,
     startDateRow,
-    endDateRow
+    endDateRow,
+    courseMoveRow if showCourseMoveRow
   ] %}
 
 {% else %}
@@ -229,7 +276,8 @@
     studyModeRow,
     apprenticeshipStartDateRow,
     startDateRow,
-    endDateRow
+    endDateRow,
+    courseMoveRow if showCourseMoveRow
   ] %}
 
 {% endif %}
@@ -238,6 +286,7 @@
 {% if minimalPublishSummary %}
   {% set courseDetailsRows = [
     courseRow,
+    courseMoveRow if showCourseMoveRow,
     previousCourseRow if showPreviousCourse
   ] | removeEmpty %}
 {% endif %}
@@ -278,9 +327,16 @@
   {% include "_includes/incomplete.njk" %}
 
 {% else %}
+
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
     titleText: "Course details",
+    actions: {
+    items: [{
+      href: recordPath + "/course-details/is-course-move" | addReferrer(referrer),
+      text: "Move the trainee to a new course"
+    }]
+  } if canAmend and showCourseChangeOption,
     html: courseDetailsHtml
   }) }}
   

--- a/app/views/_includes/summary-cards/course-details.html
+++ b/app/views/_includes/summary-cards/course-details.html
@@ -83,7 +83,6 @@
     items: [
       {
         href: recordPath + "/course-details/phase" | addReferrer(referrer),
-        href: recordPath + "/course-details/course-move-question" | addReferrer(recordPath + "/course-details/phase"),
         text: "Change",
         visuallyHiddenText: "education phase"
       }

--- a/app/views/_includes/summary-cards/course-details.html
+++ b/app/views/_includes/summary-cards/course-details.html
@@ -212,6 +212,14 @@
   {%- endif -%}
 {% endset %}
 
+{% set courseMoveRowHref -%}
+  {%- if courseMove.courseMoveUpFront | falsify -%}
+    /course-details/course-move-date
+  {%- else -%}
+    /course-details/course-move-question
+  {%- endif -%}
+{%- endset %}
+
 {% set courseMoveRow = {
   key: {
     text: "Course move" if not courseMove.isCourseMove | falsify else "Course move date"
@@ -222,7 +230,7 @@
   actions: {
     items: [
       {
-        href: recordPath + "/course-details/course-move-question" | addReferrer(referrer),
+        href: (recordPath + courseMoveRowHref) | addReferrer(referrer),
         text: "Change",
         visuallyHiddenText: "change of course question"
       }

--- a/app/views/direct-set-data.html
+++ b/app/views/direct-set-data.html
@@ -99,6 +99,19 @@
           ]
         } | decorateAttributes(data, "data.directSet.mergeJson")) }}
 
+        {{ govukCheckboxes({
+          items: [
+            {
+              value: 'true',
+              text: "Update trainee record" if data.record.id else "Update trainee record (no record to update)",
+              disabled: true if not data.record.id,
+              hint: {
+                text: "Will write changes in data.record back to data.records"
+              }
+            }
+          ]
+        } | decorateAttributes(data, "data.directSet.updateRecord")) }}
+
         <input name="successFlash" type="hidden" value="Data set">
 
         {{ govukButton({

--- a/app/views/new-record/course-details/dates.html
+++ b/app/views/new-record/course-details/dates.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_new-record.html" %}
 
-{% set pageHeading = "ITT dates" %}
+{% set pageHeading = "Course ITT dates" %}
 
 {% set formAction = "./dates-answer" | addReferrer(referrer)%}
 

--- a/app/views/new-record/course-details/phase.html
+++ b/app/views/new-record/course-details/phase.html
@@ -2,7 +2,7 @@
 
 {% set pageHeading = "Which phase of education will the trainee teach?" %}  
 
-{# {% set formAction = "./course-details/details" %} #}
+{% set formAction = "./phase-answer" | addReferrer(referrer) %}
 
 {% block formContent %}
   {% include "_includes/forms/course-details/phase.html" %}

--- a/app/views/record.html
+++ b/app/views/record.html
@@ -74,6 +74,10 @@
     {# {% set showCourseMoveQuestionUpFront = true %} #}
     {% include "_includes/summary-cards/course-details.html" %}
 
+    {% if record.historicCourseDetails %}
+      <p class="govuk-body"><a href="{{recordPath}}/previous-course-details" class="govuk-link">View details of previous courses this trainee has been on</a></p>
+    {% endif %}
+
     {% if record | requiresSection("schools") %}
       <h2 class="govuk-heading-s">Schools</h2>
       {% include "_includes/summary-cards/schools.html" %}

--- a/app/views/record.html
+++ b/app/views/record.html
@@ -70,6 +70,8 @@
     {% include "_includes/summary-cards/trainee-progress.html" %}
 
     <h2 class="govuk-heading-s">Course details</h2>
+    {% set showCourseChangeOption = true %}
+    {# {% set showCourseMoveQuestionUpFront = true %} #}
     {% include "_includes/summary-cards/course-details.html" %}
 
     {% if record | requiresSection("schools") %}

--- a/app/views/record.html
+++ b/app/views/record.html
@@ -71,6 +71,7 @@
 
     <h2 class="govuk-heading-s">Course details</h2>
     {% set showCourseChangeOption = true %}
+    {% set showDateMovedRow = true %}
     {# {% set showCourseMoveQuestionUpFront = true %} #}
     {% include "_includes/summary-cards/course-details.html" %}
 

--- a/app/views/record.html
+++ b/app/views/record.html
@@ -70,9 +70,8 @@
     {% include "_includes/summary-cards/trainee-progress.html" %}
 
     <h2 class="govuk-heading-s">Course details</h2>
-    {% set showCourseChangeOption = true %}
+    {# {% set showCourseChangeOption = true %} #}
     {% set showDateMovedRow = true %}
-    {# {% set showCourseMoveQuestionUpFront = true %} #}
     {% include "_includes/summary-cards/course-details.html" %}
 
     {% if record.historicCourseDetails %}

--- a/app/views/record/course-details/confirm.html
+++ b/app/views/record/course-details/confirm.html
@@ -1,18 +1,28 @@
 {% extends "_templates/_record-form.html" %}
 
-{% set pageHeading = "Confirm trainee’s course details" %}
+{% set isCourseMove = data.record.temp.courseMoveTemp.isCourseMove | falsify %}
+
+{% set pageHeading = "Confirm trainee’s " + ("new " if isCourseMove) + "course details" %}
 
 {% set backLink = ("/record/" + data.record.id) | orReferrer(referrer) %}
 {% set backText = "Back to record" %}
 
 {% set gridColumn = 'govuk-grid-column-full' %}
-{% set formAction = "./course-change-check" | addReferrer(referrer) %}
+
+{# Checks if these changes are significant enough we should confirm the rest of the training details #}
+{% set formAction = "./course-change-significant-change-check" | addReferrer(referrer) %}
+
+{# {% set referrer = currentPageUrl %} #}
+
 
 {% block formContent %}
+
   {% include "_includes/trainee-name-caption.njk" %}
   <h1 class="govuk-heading-l">
     {{pageHeading}}
   </h1>
+
+  {% set showCourseMoveRow = true %}
   {% include "_includes/summary-cards/course-details.html" %}
 
   {# {{ govukCheckboxes({

--- a/app/views/record/course-details/confirm.html
+++ b/app/views/record/course-details/confirm.html
@@ -22,7 +22,7 @@
     {{pageHeading}}
   </h1>
 
-  {% set showCourseMoveRow = true %}
+  {# {% set showCourseMoveRow = true %} #}
   {% include "_includes/summary-cards/course-details.html" %}
 
   {# {{ govukCheckboxes({

--- a/app/views/record/course-details/course-move-date.html
+++ b/app/views/record/course-details/course-move-date.html
@@ -1,0 +1,18 @@
+{% extends "_templates/_record-form.html" %}
+
+{% set pageHeading = "When did the trainee move course?" %}
+
+{% if data.record.temp.courseMoveTemp.courseMoveUpFront | falsify %}
+  {% set formAction = "./select-route" | addReferrer(referrer) %}
+{% elseif referrer | includes("final-check") %}
+  {% set formAction = "./final-check-course-change" | addReferrer(referrer) %}
+{# {% elseif referrer %}
+  {% set formAction = "./confirm" | orReferrer(referrer) %} #}
+{% else %}
+  {% set formAction = "./confirm" | addReferrer(referrer) %}
+{% endif %}
+
+{% block formContent %}
+  {% include "_includes/forms/course-details/course-move-date.html" %}
+{% endblock %}
+

--- a/app/views/record/course-details/course-move-date.html
+++ b/app/views/record/course-details/course-move-date.html
@@ -2,15 +2,11 @@
 
 {% set pageHeading = "When did the trainee move course?" %}
 
-{# {% if data.record.temp.courseMoveTemp.courseMoveUpFront | falsify %} #}
+{% if referrer | includes("final-check") %}
+  {% set formAction = "./final-check-course-change" | addReferrer(referrer) %}
+{% else %}
   {% set formAction = "./select-route" | addReferrer(referrer) %}
-{# {% elseif referrer | includes("final-check") %} #}
-  {# {% set formAction = "./final-check-course-change" | addReferrer(referrer) %} #}
-{# {% elseif referrer %}
-  {% set formAction = "./confirm" | orReferrer(referrer) %} #}
-{# {% else %} #}
-  {# {% set formAction = "./confirm" | addReferrer(referrer) %} #}
-{# {% endif %} #}
+{% endif %}
 
 {% block formContent %}
   {% include "_includes/forms/course-details/course-move-date.html" %}

--- a/app/views/record/course-details/course-move-date.html
+++ b/app/views/record/course-details/course-move-date.html
@@ -2,15 +2,15 @@
 
 {% set pageHeading = "When did the trainee move course?" %}
 
-{% if data.record.temp.courseMoveTemp.courseMoveUpFront | falsify %}
+{# {% if data.record.temp.courseMoveTemp.courseMoveUpFront | falsify %} #}
   {% set formAction = "./select-route" | addReferrer(referrer) %}
-{% elseif referrer | includes("final-check") %}
-  {% set formAction = "./final-check-course-change" | addReferrer(referrer) %}
+{# {% elseif referrer | includes("final-check") %} #}
+  {# {% set formAction = "./final-check-course-change" | addReferrer(referrer) %} #}
 {# {% elseif referrer %}
   {% set formAction = "./confirm" | orReferrer(referrer) %} #}
-{% else %}
-  {% set formAction = "./confirm" | addReferrer(referrer) %}
-{% endif %}
+{# {% else %} #}
+  {# {% set formAction = "./confirm" | addReferrer(referrer) %} #}
+{# {% endif %} #}
 
 {% block formContent %}
   {% include "_includes/forms/course-details/course-move-date.html" %}

--- a/app/views/record/course-details/course-move-question.html
+++ b/app/views/record/course-details/course-move-question.html
@@ -1,0 +1,10 @@
+{% extends "_templates/_record-form.html" %}
+
+{% set pageHeading = "Is the trainee moving to a new course?" %}
+
+{% set formAction = "./course-move-question-answer" | addReferrer(referrer) %}
+
+{% block formContent %}
+  {% include "_includes/forms/course-details/course-move-question.html" %}
+{% endblock %}
+

--- a/app/views/record/course-details/course-move-question.html
+++ b/app/views/record/course-details/course-move-question.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_record-form.html" %}
 
-{% set pageHeading = "Is the trainee moving to a new course?" %}
+{% set pageHeading = "Did this course change happen after they started training?" %}
 
 {% set formAction = "./course-move-question-answer" | addReferrer(referrer) %}
 

--- a/app/views/record/course-details/dates.html
+++ b/app/views/record/course-details/dates.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_record-form.html" %}
 
-{% set pageHeading = "ITT dates" %}
+{% set pageHeading = "Course ITT dates" %}
 
 {% set formAction = "./dates-answer" | addReferrer(referrer) %}
 

--- a/app/views/record/course-details/final-check-course-change.html
+++ b/app/views/record/course-details/final-check-course-change.html
@@ -9,7 +9,7 @@
 
 {% set gridColumn = 'govuk-grid-column-full' %}
 
-{% set formAction = "./update" | addReferrer("/record/" + data.record.id) %}
+{% set formAction = "./final-check-course-change-answer" | addReferrer("/record/" + data.record.id) %}
 
 {% set returnLink = {
   href: "./cancel-course-change" | addReferrer(referrer),
@@ -30,7 +30,12 @@
 
   {# Use minimal summary to provide a way to change, but not promote the full course #}
   {% set minimalPublishSummary = true %}
-  {# {% set showPreviousCourse = true %} #}
+
+  {% set showCourseMoveRow = true %}
+  {% if record.temp.courseMoveTemp.isCourseMove | falsify %}
+    {% set showPreviousCourse = true %}
+  {% endif %}
+
   {% include "_includes/summary-cards/course-details.html" %}
 
   {# Only show the degree section if they’ve changed from a course that didn't need degrees

--- a/app/views/record/course-details/phase.html
+++ b/app/views/record/course-details/phase.html
@@ -2,7 +2,7 @@
 
 {% set pageHeading = "Which phase of education will the trainee teach?" %}  
 
-{# {% set formAction = "./course-details/details" %} #}
+{% set formAction = "./phase-answer" | addReferrer(referrer) %}
 
 {% block formContent %}
   {% include "_includes/forms/course-details/phase.html" %}

--- a/app/views/record/course-details/select-route.html
+++ b/app/views/record/course-details/select-route.html
@@ -2,6 +2,10 @@
 
 {% set pageHeading = "What type of training are they doing?" %}
 
+{% if data.record.temp.courseMoveTemp.isCourseMove %}
+  {% set pageHeading = "What type of training is the new course?" %}
+{% endif %}
+
 {% set formAction = "./select-route-answer" | addReferrer(referrer) %}
 
 

--- a/app/views/record/previous-course-details.html
+++ b/app/views/record/previous-course-details.html
@@ -1,0 +1,26 @@
+{% extends "_templates/_page.html" %}
+
+{% set pageHeading = 'Previous course details' %}
+{% set gridColumn = 'govuk-grid-column-full' %}
+
+{% set record = data.record %}
+
+
+{# {% set formAction = "./reinstate/confirm" %} #}
+  
+{% block content %}
+
+<h1 class="govuk-heading-l">{{pageHeading}}</h1>
+
+{% for historicCourse in record.historicCourseDetails %}
+  <h2 class="govuk-heading-m">Course {{loop.index}}</h2>
+
+  {% include "_includes/summary-cards/course-details.html" %}
+
+  {% include "_includes/summary-cards/schools.html" %}
+
+  {% include "_includes/summary-cards/funding.html" %}
+{% endfor %}
+
+
+{% endblock %}

--- a/app/views/record/previous-course-details.html
+++ b/app/views/record/previous-course-details.html
@@ -3,26 +3,33 @@
 {% set pageHeading = 'Previous course details' %}
 {% set gridColumn = 'govuk-grid-column-full' %}
 
+{# Todo - this is needed as we don't have a non-form page template for records #}
 {% set record = data.record %}
+{% if not record %}
+  {% set record = {} %}
+{% endif %}
 
-
-{# {% set formAction = "./reinstate/confirm" %} #}
-  
 {% block content %}
 
 <h1 class="govuk-heading-l">{{pageHeading}}</h1>
 
-{% for historicCourse in record.historicCourseDetails %}
+{% for historicCourse in record.historicCourseDetails | reverse %}
 
+  {% set recordBackup = record %}
+
+  {# Override record so that subsequent summary cards render correctly #}
   {% set record = historicCourse.recordData %}
-  <h2 class="govuk-heading-m">Course {{ loop.index }} – ended {{ historicCourse.dateFinished | govukDate }}</h2>
+  <h2 class="govuk-heading-m">Course {{ loop.length - loop.index0 }} – ended {{ historicCourse.dateFinished | govukDate }}</h2>
 
   {% include "_includes/summary-cards/course-details.html" %}
 
   {% include "_includes/summary-cards/schools.html" %}
 
   {% include "_includes/summary-cards/funding.html" %}
-{% endfor %}
 
+  {# Restore the real record #}
+  {% set record = recordBackup %}
+
+{% endfor %}
 
 {% endblock %}

--- a/app/views/record/previous-course-details.html
+++ b/app/views/record/previous-course-details.html
@@ -13,7 +13,9 @@
 <h1 class="govuk-heading-l">{{pageHeading}}</h1>
 
 {% for historicCourse in record.historicCourseDetails %}
-  <h2 class="govuk-heading-m">Course {{loop.index}}</h2>
+
+  {% set record = historicCourse.recordData %}
+  <h2 class="govuk-heading-m">Course {{ loop.index }} – ended {{ historicCourse.dateFinished | govukDate }}</h2>
 
   {% include "_includes/summary-cards/course-details.html" %}
 


### PR DESCRIPTION
This adds a question to the courses flow for registered trainees to ask if the change the provider is making happened on a date after the trainee started - or if they're fixing a mistake. For the moment I'm only asking this when the change is 'significant' - meaning we're on the course change flow. Significant includes: route, allocation subject, study mode.

Where it's the result of a move, we collect the date of move, and store a history of the previous course.

As a starter, I've just added a new page to show historic courses. In the future we may want to expand this area.

Asking when the changed happened:
<img width="1014" alt="Screenshot 2022-04-07 at 11 46 01" src="https://user-images.githubusercontent.com/2204224/162187999-2ab5ded3-4554-48a5-bef8-c19c0203fd50.png">
<img width="1056" alt="Screenshot 2022-04-07 at 11 47 35" src="https://user-images.githubusercontent.com/2204224/162188009-194481c5-c027-47ca-a724-28cd359d9d3d.png">


Where the change happened after training, we'll show the previous course summary and a date:
<img width="1022" alt="Screenshot 2022-04-07 at 12 26 14" src="https://user-images.githubusercontent.com/2204224/162188459-d5f2af8b-ca83-4a2d-ab1a-004874053eb3.png">


After confirming, the date this course started is shown:
<img width="1036" alt="Screenshot 2022-04-07 at 12 27 25" src="https://user-images.githubusercontent.com/2204224/162188651-01fdbb30-e045-4121-a5f4-444d00b62754.png">


A history of previous training is shown on a dedicated page:
<img width="1040" alt="Screenshot 2022-04-07 at 12 27 54" src="https://user-images.githubusercontent.com/2204224/162188718-327f29cf-7268-4ba4-a9dd-8ce86c9b1007.png">


This history page shows course details, schools, and funding if relevant.
