### PR TITLE
mark-up changes to privacy policy

### DIFF
--- a/app/views/privacy-policy.html
+++ b/app/views/privacy-policy.html
@@ -125,7 +125,7 @@
 
       <p class="govuk-body">We share your anonymised personal data so that we can analyse the ITT  process, its operation and any strategic or policy related studies on behalf of DfE.</p>
 
-      <h2 class="govuk-heading-m" id="to-raise-a-concern">Your rights</h2>
+      <h2 class="govuk-heading-m" id="your-rights">Your rights</h2>
 
       <p class="govuk-body">Under the DPA 2018 and the UK GDPR, you have the right to find out what data we have about you. However, your rights are conditional on the lawful basis under which your data is being processed. Our lawful basis is public task, which grants you the following rights:</p>
 

--- a/app/views/privacy-policy.html
+++ b/app/views/privacy-policy.html
@@ -1,8 +1,8 @@
 
 {% extends "_templates/_page.html" %}
-{% set backLink = '/home' %}
+{% set backLink = "/home" %}
 
-{% set pageHeading = 'Register trainee teachers privacy policy' %}
+{% set pageHeading = "Register trainee teachers privacy policy" %}
 
 {% block content %}
 
@@ -10,35 +10,35 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-9">{{pageHeading}}</h1>
 
-    <h2 class='govuk-heading-m' id='who-are-we'>Who we are</h2>
-​
-      <p class='govuk-body'>Register trainee teachers (‘Register’) is run by the Department for Education (‘we’) for the purpose of registering trainee teachers.</p>
-​
-      <p class='govuk-body'>For the purpose of UK General Data Protection Regulation (UK GDPR), the DfE is the data controller for data held and processed in Register. Initial teacher training (ITT) providers, who use Register, are both data processors for DfE and also independent Data Controllers within the delivery of teacher training.</p>
-​
-      <h2 class='govuk-heading-m' id='who-this-privacy-notice-is-for'>Who this privacy policy is for</h2>
-      <ul class='govuk-list govuk-list--bullet'>
+    <h2 class="govuk-heading-m" id="who-are-we">Who we are</h2>
+
+      <p class="govuk-body">Register trainee teachers (‘Register’) is run by the Department for Education (‘we’) for the purpose of registering trainee teachers.</p>
+
+      <p class="govuk-body">For the purpose of UK General Data Protection Regulation (UK GDPR), the DfE is the data controller for data held and processed in Register. Initial teacher training (ITT) providers, who use Register, are both data processors for DfE and also independent Data Controllers within the delivery of teacher training.</p>
+
+      <h2 class="govuk-heading-m" id="who-this-privacy-notice-is-for">Who this privacy policy is for</h2>
+      <ul class="govuk-list govuk-list--bullet">
         <li>trainee teachers when you register with the Department for Education’s (DfE) Apply for teacher training service</li>
         <li>trainee teachers when you register directly with a teacher training provider</li>
         <li>Initial teacher training (ITT) provider staff when you access the Register system</li>
       </ul>
-​
-      <h2 class='govuk-heading-m' id='the-personal-data-we-collect-and-why'>The personal data we collect and how we use it</h2>
-​
-      <p class='govuk-body'>The personal data we collect will depend on whether you’re a trainee teacher or an ITT provider staff member.</p>
-      <p class='govuk-body'>We will state in this privacy policy when we’re referring to trainee personal data and when we’re referring to ITT provider staff personal data.</p>
-​
-      <h3 class='govuk-heading-s'>The data we collect from ITT provider staff</h3>
-​
-      <p class='govuk-body'>We use your personal data to run and improve Register. We collect your:</p>
-      <ul class='govuk-list govuk-list--bullet'>
+
+      <h2 class="govuk-heading-m" id="the-personal-data-we-collect-and-why">The personal data we collect and how we use it</h2>
+
+      <p class="govuk-body">The personal data we collect will depend on whether you’re a trainee teacher or an ITT provider staff member.</p>
+      <p class="govuk-body">We will state in this privacy policy when we’re referring to trainee personal data and when we’re referring to ITT provider staff personal data.</p>
+
+      <h3 class="govuk-heading-s">The data we collect from ITT provider staff</h3>
+
+      <p class="govuk-body">We use your personal data to run and improve Register. We collect your:</p>
+      <ul class="govuk-list govuk-list--bullet">
         <li>name</li>
         <li>email address</li>
       </ul>
-​
-      <h3 class='govuk-heading-s'>The data we collect from trainee teachers</h3>
-      <p class='govuk-body'>We collect your personal data to register you with the DfE as a trainee teacher. We collect your:</p>
-      <ul class='govuk-list govuk-list--bullet'>
+
+      <h3 class="govuk-heading-s">The data we collect from trainee teachers</h3>
+      <p class="govuk-body">We collect your personal data to register you with the DfE as a trainee teacher. We collect your:</p>
+      <ul class="govuk-list govuk-list--bullet">
         <li>first name</li>
         <li>middle name</li>
         <li>last name</li>
@@ -50,11 +50,11 @@
         <li>qualifications</li>
         <li>equality and diversity information</li>
       </ul>
-​
-      <h2 class='govuk-heading-m' id='how-provider-staff-personal-data-us-used-in-register'>How ITT provider staff personal data is used in Register</h3>
-​
-      <p class='govuk-body'>We collect your name and email address so that we can:</p>
-      <ul class='govuk-list govuk-list--bullet'>
+
+      <h2 class="govuk-heading-m" id="how-provider-staff-personal-data-us-used-in-register">How ITT provider staff personal data is used in Register</h3>
+
+      <p class="govuk-body">We collect your name and email address so that we can:</p>
+      <ul class="govuk-list govuk-list--bullet">
         <li>enable you to access the Register service</li>
         <li>validate your role in your organisation</li>
         <li>send important updates about the service</li>
@@ -63,14 +63,14 @@
         <li>record a timeline of your activity so that you can review trainee progress</li>
         <li>create log files of your activity and any error messages you come across</li>
       </ul>
-​
-      <h2 class='govuk-heading-m' id='how-trainee-personal-data-is-used-in-register'>How trainee personal data is used in Register</h2>
-​
-      <p class='govuk-body'>Register processes trainee teacher personal data when candidates apply for teacher training and provide their personal data to the DfE or to ITT providers.</p>
-​
-      <p class='govuk-body'>Access to the service allows accredited ITT providers to:</p>
-​
-      <ul class='govuk-list govuk-list--bullet'>
+
+      <h2 class="govuk-heading-m" id="how-trainee-personal-data-is-used-in-register">How trainee personal data is used in Register</h2>
+
+      <p class="govuk-body">Register processes trainee teacher personal data when candidates apply for teacher training and provide their personal data to the DfE or to ITT providers.</p>
+
+      <p class="govuk-body">Access to the service allows accredited ITT providers to:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
         <li>submit and view ITT data, including personal details</li>
         <li>update ITT records, including personal details</li>
         <li>request a Teacher Reference Number (TRN)</li>
@@ -78,81 +78,81 @@
         <li>confirm when a TRN was issued</li>
         <li>confirm when QTS or EYTS was awarded</li>
       </ul>
-​
-      <h2 class='govuk-heading-m' id='our-lawful-basis-for-processing-your-personal-data'>Our lawful basis for processing your personal data</h2>
-​
-      <p class='govuk-body'>In order for our use of your personal data to be lawful, we need to meet one (or more) conditions in the data protection legislation, as defined in data protection law (UK GDPR and Data Protection Act 2018). For Register, we rely on:</p>
-​      <ul class='govuk-list govuk-list--bullet'>
+
+      <h2 class="govuk-heading-m" id="our-lawful-basis-for-processing-your-personal-data">Our lawful basis for processing your personal data</h2>
+
+      <p class="govuk-body">In order for our use of your personal data to be lawful, we need to meet one (or more) conditions in the data protection legislation, as defined in data protection law (UK GDPR and Data Protection Act 2018). For Register, we rely on:</p>
+      <ul class="govuk-list govuk-list--bullet">
        <li>article 6(1)(e) UK General Data Protection Regulation (UK GDPR), to perform a public task carried out in the public interest as part of our function as a department</li>
        <li>article 9(2)(g) UK GDPR reasons of substantial public interest (with a basis in law)</li>
       </ul>
 
-      <h2 class='govuk-heading-m' id='how-we-use-third-parties-to-process-your-data'>How we use third parties to process your data</h2>
-​
-      <p class='govuk-body'>Some of your personal information is processed by our Data Processors, listed below. They allow us to run and improve Register trainee teachers.</p>
-​
-      <p class='govuk-body'>We share your data with our Data Processors (ITT Providers) for the provision of this service. Data Protection Agreements are in place with each of these Processors and they are required to comply with the UK GDPR and the UK Data Protection Act 2018 as Data Processors.</p>
-​
-      <h3 class='govuk-heading-s'>Customer service management systems</h3>
-​
-      <p class='govuk-body'>We use Zendesk to manage and respond to your queries.</p>
-​
-      <p class='govuk-body'><a href='https://www.zendesk.co.uk/company/privacy-and-data-protection/#faq-general-1' class='govuk-link'>Visit the Zendesk website to find out how they use and look after your data (“service data”)</a></p>
-​
-      <h3 class='govuk-heading-s'>Website hosting services</h3>
-​
-      <p class='govuk-body'>We use GOV.UK PaaS to enable us to run the service.</p>
-​
-      <p class='govuk-body'><a href='https://www.cloud.service.gov.uk/privacy-notice/#what-data-we-collect-from-end-users' class='govuk-link'>Visit the GOV.UK PaaS website to find out how they use and look after your data (“end user data”)</a></p>
-​
-      <h2 class='govuk-heading-m' id='how-long-we-keep-your-personal-data'>How long we keep your personal data</h2>
-​
-      <h3 class='govuk-heading-s'>Provider staff data</h3>
-​
-      <p class='govuk-body'>We keep your personal data for as long as you use Register. We will keep it for no longer than 7 years after you stop using Register.</p>
-​
-      <h3 class='govuk-heading-s'>Trainee data</h3>
-​
-      <p class='govuk-body'>We keep your personal data for 7 years after you’ve finished your teacher training. After 7 years, your personal data will be removed from Register.</p>
-​
-      <h2 class='govuk-heading-m' id='sharing-itt-trainee-data-within-dfe'>Sharing ITT trainee data within DfE</h2>
-​
-      <p class='govuk-body'>Trainee teacher data on Register is shared with other teams and executive agencies within the DfE for the purposes of funding, issuing TRNs and confirming QTS or EYTS.</p>
-​
-      <h2 class='govuk-heading-m' id='sharing-itt-trainee-data-with-third-parties'>Sharing trainee personal data with third parties</h2>
-​
-      <p class='govuk-body'>We anonymise all trainee teacher personal data if we need to share it with third parties. This is so you cannot be identified. We will only share your anonymised data where data protection laws allow it, or there is a legal requirement to share it.</p>
-​
-      <p class='govuk-body'>We share your anonymised personal data so that we can analyse the ITT  process, its operation and any strategic or policy related studies on behalf of DfE.</p>
-​
-      <h2 class='govuk-heading-m' id='to-raise-a-concern'>Your rights</h2>
-​
-      <p class='govuk-body'>Under the DPA 2018 and the UK GDPR, you have the right to find out what data we have about you. However, your rights are conditional on the lawful basis under which your data is being processed. Our lawful basis is public task, which grants you the following rights:</p>
-​
-      <ul class='govuk-list govuk-list--bullet'>
+      <h2 class="govuk-heading-m" id="how-we-use-third-parties-to-process-your-data">How we use third parties to process your data</h2>
+
+      <p class="govuk-body">Some of your personal information is processed by our Data Processors, listed below. They allow us to run and improve Register trainee teachers.</p>
+
+      <p class="govuk-body">We share your data with our Data Processors (ITT Providers) for the provision of this service. Data Protection Agreements are in place with each of these Processors and they are required to comply with the UK GDPR and the UK Data Protection Act 2018 as Data Processors.</p>
+
+      <h3 class="govuk-heading-s">Customer service management systems</h3>
+
+      <p class="govuk-body">We use Zendesk to manage and respond to your queries.</p>
+
+      <p class="govuk-body"><a href="https://www.zendesk.co.uk/company/privacy-and-data-protection/#faq-general-1" class="govuk-link">Visit the Zendesk website to find out how they use and look after your data (“service data”)</a></p>
+
+      <h3 class="govuk-heading-s">Website hosting services</h3>
+
+      <p class="govuk-body">We use GOV.UK PaaS to enable us to run the service.</p>
+
+      <p class="govuk-body"><a href="https://www.cloud.service.gov.uk/privacy-notice/#what-data-we-collect-from-end-users" class="govuk-link">Visit the GOV.UK PaaS website to find out how they use and look after your data (“end user data”)</a></p>
+
+      <h2 class="govuk-heading-m" id="how-long-we-keep-your-personal-data">How long we keep your personal data</h2>
+
+      <h3 class="govuk-heading-s">Provider staff data</h3>
+
+      <p class="govuk-body">We keep your personal data for as long as you use Register. We will keep it for no longer than 7 years after you stop using Register.</p>
+
+      <h3 class="govuk-heading-s">Trainee data</h3>
+
+      <p class="govuk-body">We keep your personal data for 7 years after you’ve finished your teacher training. After 7 years, your personal data will be removed from Register.</p>
+
+      <h2 class="govuk-heading-m" id="sharing-itt-trainee-data-within-dfe">Sharing ITT trainee data within DfE</h2>
+
+      <p class="govuk-body">Trainee teacher data on Register is shared with other teams and executive agencies within the DfE for the purposes of funding, issuing TRNs and confirming QTS or EYTS.</p>
+
+      <h2 class="govuk-heading-m" id="sharing-itt-trainee-data-with-third-parties">Sharing trainee personal data with third parties</h2>
+
+      <p class="govuk-body">We anonymise all trainee teacher personal data if we need to share it with third parties. This is so you cannot be identified. We will only share your anonymised data where data protection laws allow it, or there is a legal requirement to share it.</p>
+
+      <p class="govuk-body">We share your anonymised personal data so that we can analyse the ITT  process, its operation and any strategic or policy related studies on behalf of DfE.</p>
+
+      <h2 class="govuk-heading-m" id="to-raise-a-concern">Your rights</h2>
+
+      <p class="govuk-body">Under the DPA 2018 and the UK GDPR, you have the right to find out what data we have about you. However, your rights are conditional on the lawful basis under which your data is being processed. Our lawful basis is public task, which grants you the following rights:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
         <li>being informed about how your data is being used</li>
         <li>accessing personal data</li>
         <li>having incorrect data corrected</li>
         <li>restricting the processing of your data (for example where the data is inaccurate or outdated)</li>
         <li>objecting to how your data is processed in certain circumstances, including automated processing and profiling</li>
       </ul>
-​
-      <p class='govuk-body'>You can find more information about how we handle personal data in our <a href='https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter' class='govuk-link'>personal information charter</a>.</p>
-​
-      <h2 class='govuk-heading-m' id='to-raise-a-concern'>Getting help raising a concern</h2>
-​
-      <p class='govuk-body'>If you would like to exercise any of your rights, you can email us at <a href='mailto:becomingateacher@digital.education.gov.uk?subject=Raising a concern - personal data in Register' class='govuk-link'>becomingateacher@digital.education.gov.uk</a></p>      
 
-      <p class='govuk-body'>You can also use our <a href='https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen' class='govuk-link'>contact form</a> to get in touch with our Data Protection Officer.
-​
-      <p class='govuk-body'>If we cannot resolve your issue, you have the right to raise it with the <a href='https://ico.org.uk/' class='govuk-link'>Information Commissioner's Office (ICO).</a></p>
-​
-      <h2 class='govuk-heading-m' id='keep-up-to-date'>Keeping our privacy policy up to date</h2>
-​
-      <p class='govuk-body'>We’ll update this privacy policy when required. You should regularly review the notice.
+      <p class="govuk-body">You can find more information about how we handle personal data in our <a href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter" class="govuk-link">personal information charter</a>.</p>
+
+      <h2 class="govuk-heading-m" id="to-raise-a-concern">Getting help raising a concern</h2>
+
+      <p class="govuk-body">If you would like to exercise any of your rights, you can email us at <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Raising a concern - personal data in Register" class="govuk-link">becomingateacher@digital.education.gov.uk</a></p>      
+
+      <p class="govuk-body">You can also use our <a href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen" class="govuk-link">contact form</a> to get in touch with our Data Protection Officer.
+
+      <p class="govuk-body">If we cannot resolve your issue, you have the right to raise it with the <a href="https://ico.org.uk/" class="govuk-link">Information Commissioner"s Office (ICO).</a></p>
+
+      <h2 class="govuk-heading-m" id="keep-up-to-date">Keeping our privacy policy up to date</h2>
+
+      <p class="govuk-body">We’ll update this privacy policy when required. You should regularly review the notice.
       </p>
-​
-      <p class='govuk-body'>This version was last updated on 31 March 2022.</p>
+
+      <p class="govuk-body">This version was last updated on 31 March 2022.</p>
 
   </div>
 </div>


### PR DESCRIPTION
- removes white space (this isn't picked-up by github, but there was extra line breaks between paragraphs)
- makes single quotes into double quotes