### PR TITLE
Show confirmation page before deleting degrees

### DIFF
--- a/app/views/_includes/summary-cards/bulk-details.html
+++ b/app/views/_includes/summary-cards/bulk-details.html
@@ -26,7 +26,7 @@
   Route: {{ (data.bulk.filters.trainingRoutes | commaSeparate | lower) or 'all routes' }}
   <br>
   <br>
-  Subject: {{ data.bulk.filters.subject | lower }}
+  Subject: {{ data.bulk.filters.subject | dynamicLowercase }}
 {% endset %}
 
 {% set rows = [

--- a/app/views/_includes/summary-cards/degree/single-degree-details.html
+++ b/app/views/_includes/summary-cards/degree/single-degree-details.html
@@ -199,7 +199,7 @@
   titleText: titleText | replace("**invalid**", ""),
   actions: {
     items: [{
-      href: recordPath + "/degree/" + loop.index0 + "/delete" | addReferrer(referrer),
+      href: recordPath + "/degree/" + loop.index0 + "/confirm-delete" | addReferrer(referrer),
       text: "Delete degree"
     }]
   } if canAmend,

--- a/app/views/new-record/degree/confirm-delete.html
+++ b/app/views/new-record/degree/confirm-delete.html
@@ -1,0 +1,45 @@
+{% extends "_templates/_new-record.html" %}
+
+{% set pageHeading = "Are you sure you want to delete this degree?" %}
+{# {% set backLink = './../overview' %}
+{% set backText = "Back to draft record" %} #}
+{% set returnLink = { href: './../overview', text: 'Cancel and return to record'} %}
+
+{% set returnLink = {
+  href: 'javascript:history.back();',
+  text: "Cancel"
+} %}
+
+{# Get degree (if it exists) from existing data #}
+{% set degree = data.record.degree.items[itemIndex] %}
+{# Merge with temp store (temp store has) #}
+{% set degreeTemp = degree | mergeObjects(data.degreeTemp) %}
+
+{# Generate title text for card #}
+{% if degree.isInternational %}
+  {% if degree.type != 'UK ENIC not provided' %}
+    {% set typeText = "Non-UK " + degree.type + ": " %}
+  {% else %}
+      {% set typeText = "Non-UK degree: " %}
+  {% endif %}
+  {% set degreeText = typeText + (degree.subject | dynamicLowercase) %}
+{% else %}
+  {% set degreeText = degree.type + ": " + (degree.subject | dynamicLowercase) %}
+{% endif %}
+
+{% block formContent %}
+
+{% include "_includes/trainee-name-caption.njk" %}
+<h1 class="govuk-heading-l govuk-!-margin-bottom-8">
+  {{pageHeading}}
+</h1>
+
+<p class="govuk-body govuk-!-margin-bottom-7">{{degreeText}}</p>
+
+{{ govukButton({
+  text: "Yes I’m sure — delete this degree",
+  href: "./delete",
+  classes: "govuk-button--warning"
+}) }}
+
+{% endblock %}

--- a/app/views/record/degree/confirm-delete.html
+++ b/app/views/record/degree/confirm-delete.html
@@ -1,0 +1,45 @@
+{% extends "_templates/_record-form.html" %}
+
+{% set pageHeading = "Are you sure you want to delete this degree?" %}
+{# {% set backLink = './../overview' %}
+{% set backText = "Back to draft record" %} #}
+{% set returnLink = { href: './../overview', text: 'Cancel and return to record'} %}
+
+{% set returnLink = {
+  href: 'javascript:history.back();',
+  text: "Cancel"
+} %}
+
+{# Get degree (if it exists) from existing data #}
+{% set degree = data.record.degree.items[itemIndex] %}
+{# Merge with temp store (temp store has) #}
+{% set degreeTemp = degree | mergeObjects(data.degreeTemp) %}
+
+{# Generate title text for card #}
+{% if degree.isInternational %}
+  {% if degree.type != 'UK ENIC not provided' %}
+    {% set typeText = "Non-UK " + degree.type + ": " %}
+  {% else %}
+      {% set typeText = "Non-UK degree: " %}
+  {% endif %}
+  {% set degreeText = typeText + (degree.subject | dynamicLowercase) %}
+{% else %}
+  {% set degreeText = degree.type + ": " + (degree.subject | dynamicLowercase) %}
+{% endif %}
+
+{% block formContent %}
+
+{% include "_includes/trainee-name-caption.njk" %}
+<h1 class="govuk-heading-l govuk-!-margin-bottom-8">
+  {{pageHeading}}
+</h1>
+
+<p class="govuk-body govuk-!-margin-bottom-7">{{degreeText}}</p>
+
+{{ govukButton({
+  text: "Yes I’m sure — delete this degree",
+  href: "./delete",
+  classes: "govuk-button--warning"
+}) }}
+
+{% endblock %}


### PR DESCRIPTION
The delete action on degrees currently immediately deletes. Everywhere else in the app we confirm changes. 

This adds a confirmation page in a similar style to our draft delete confirmation page.

![Screenshot 2022-04-05 at 16 00 44](https://user-images.githubusercontent.com/2204224/161784136-3f3946c7-4667-4a20-b550-ef1a34547aa1.png)

