### PR TITLE
Content tweaks for when users can't do bulk actions

### DIFF
--- a/app/views/_includes/bulk-update/update-individual-records.html
+++ b/app/views/_includes/bulk-update/update-individual-records.html
@@ -1,9 +1,6 @@
 {% set filteredRecords = data.records | filterRecords(data) %}
 <p class="govuk-body">
-  You have {{ filteredRecords | filterByCannotBulkUpdate | length }} trainees with incomplete records.
-</p> 
-<p class="govuk-body">
-  Not all trainee records can be updated in bulk and you may need to add information to these records individually.
+  You have {{ filteredRecords | filterByCannotBulkUpdate | length }} trainees with incomplete records. Not all records can be updated in bulk. You will need to update these records individually.
 </p>
 <p class="govuk-body">
   <a href="/records?%5BfilterCompleteStatus%5D=Incomplete" class="govuk-link">

--- a/app/views/bulk-update/index.html
+++ b/app/views/bulk-update/index.html
@@ -25,7 +25,7 @@ filterByCanBeRecommended %}
       </h2>
       {% if traineesThatCanBeUpdated %}
         <p class="govuk-body">
-          Bulk add {{ "trainee start dates" if traineesWithoutStartDates }} {{ "and" if traineesWithoutStartDates and traineesWithoutPlacements }} {{ "placement schools" if traineesWithoutPlacements }} to trainee records.
+          You can bulk add {{ "trainee start dates" if traineesWithoutStartDates }} {{ "and" if traineesWithoutStartDates and traineesWithoutPlacements }} {{ "placement schools" if traineesWithoutPlacements }} to trainee records.
         </p>
         <p class="govuk-body">
           <a href="/bulk-update/add-details" class="govuk-link">
@@ -44,8 +44,8 @@ filterByCanBeRecommended %}
           Recommend trainees for {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}
         </h2>
         <p class="govuk-body">
-          Bulk recommended trainees for {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}.
-          After you have recommended trainees, the DfE will award QTS or EYTS where appropriate within <span class="app-nowrap">3 working days</span>.
+          You can bulk recommended {{ traineesThatCanBeRecommended | length }} {{"trainee" | pluralise(traineesThatCanBeRecommended.length)}} for {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}.
+          The DfE will award {{ traineesThatCanBeRecommended | getQualifications | orSeparate }} where appropriate within <span class="app-nowrap">3 working days</span>.
         </p>
         <p class="govuk-body">
           <a href="/bulk-update/recommend" class="govuk-link">

--- a/app/views/bulk-update/index.html
+++ b/app/views/bulk-update/index.html
@@ -23,8 +23,7 @@ filterByCanBeRecommended %}
       <h2 class="govuk-heading-m">
         Add missing details
       </h2>
-      {% if traineesThatCanBeUpdated == false %}
-       
+      {% if traineesThatCanBeUpdated %}
         <p class="govuk-body">
           Bulk add {{ "trainee start dates" if traineesWithoutStartDates }} {{ "and" if traineesWithoutStartDates and traineesWithoutPlacements }} {{ "placement schools" if traineesWithoutPlacements }} to trainee records.
         </p>

--- a/app/views/bulk-update/index.html
+++ b/app/views/bulk-update/index.html
@@ -18,12 +18,13 @@ filterByCanBeRecommended %}
         {{ pageHeading }}
       </h1>
       <p class="govuk-body">
-        Update groups of trainee records at the same time.
-      </p>
-      {% if traineesThatCanBeUpdated %}
-        <h2 class="govuk-heading-m">
-          Add missing details
-        </h2>
+        Make changes to multiple trainee records at the same time.
+      </p> 
+      <h2 class="govuk-heading-m">
+        Add missing details
+      </h2>
+      {% if traineesThatCanBeUpdated == false %}
+       
         <p class="govuk-body">
           Bulk add {{ "trainee start dates" if traineesWithoutStartDates }} {{ "and" if traineesWithoutStartDates and traineesWithoutPlacements }} {{ "placement schools" if traineesWithoutPlacements }} to trainee records.
         </p>

--- a/app/views/bulk-update/index.html
+++ b/app/views/bulk-update/index.html
@@ -2,14 +2,10 @@
 {% set pageHeading = "Bulk updates" %}
 {% set navActive = 'bulk' %}
 {% set filteredRecords = data.records | filterRecords(data) %}
-{% set traineesThatCanBeUpdated = filteredRecords |
-filterByCanBulkUpdate %}
-{% set traineesWithoutStartDates = traineesThatCanBeUpdated |
-filterByNeedsStartDate | length %}
-{% set traineesWithoutPlacements = traineesThatCanBeUpdated |
-filterByNeedsPlacements | length %}
-{% set traineesThatCanBeRecommended = filteredRecords |
-filterByCanBeRecommended %}
+{% set traineesThatCanBeUpdated = filteredRecords | filterByCanBulkUpdate %}
+{% set traineesWithoutStartDates = traineesThatCanBeUpdated | filterByNeedsStartDate | length %}
+{% set traineesWithoutPlacements = traineesThatCanBeUpdated | filterByNeedsPlacements | length %}
+{% set traineesThatCanBeRecommended = filteredRecords | filterByCanBeRecommended %}
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
@@ -60,19 +56,6 @@ filterByCanBeRecommended %}
           You do not have any trainees that can be bulk recommended for
           {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}.
         </p>
-      {% endif %}
-      {% if not traineesThatCanBeUpdated and not traineesThatCanBeRecommended %}
-        <p class="govuk-body">
-          You do not have any trainee records that need additional
-          details or can be recommended for {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}.
-        </p>
-        {% if incompleteTrainees %}
-          <p class="govuk-body">
-            <a href="/records?%5BfilterCompleteStatus%5D=Incomplete" class="govuk-link">
-              View incomplete trainees records
-            </a>
-          </p>
-        {% endif %}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
- Updated the content for when trainee records cannot be updated in bulk, and need to be updated individually
- Updated the content for when trainee records can be recommended for QTS/EYTS, but not updated
- Removed the bespoke state for having no trainees that can be updated or recommended