### PR TITLE
Changes 'date standards met' to 'Assessment date'

### DIFF
--- a/app/assets/downloads/recommend-with-errors.csv
+++ b/app/assets/downloads/recommend-with-errors.csv
@@ -1,4 +1,4 @@
-TRN,Postgraduate qualification,Date standards met,Errors
+TRN,Postgraduate qualification,Assessment date,Errors
 Do not change this column,"For postgraduate trainees, in the column ‘Postgraduate qualification’ add one of these options:
 - PGCE
 - PGDE
@@ -15,7 +15,7 @@ LY9214,None,11/06/2022,
 CB0736,None,17/06/2022,
 GM2844,PGCE,11/06/2022,
 EH4015,PGCE,18/06/2022,
-CZ5140,None,20/07/2023,"Date standards met: ‘20/07/2023’, date the trainee met QTS must be in the past"
+CZ5140,None,20/07/2023,"Assessment date: ‘20/07/2023’, date must be in the past"
 SF6298,PGCE,05/06/2022,
 CB6515,PGCE,08/06/2022,
 TL1239,None,04/06/2022,
@@ -25,7 +25,7 @@ ES4157,PGCE,26/06/2022,
 EA5531,PGCE,05/06/2022,
 DT4917,PGCE,09/06/2022,
 HY1346,PGDE,05/06/2022,
-CP5267,PGCE,07/20/2023,"Date standards met: ‘07/20/2023’, enter a valid date"
+CP5267,PGCE,07/20/2023,"Assessment date: ‘07/20/2023’, enter a valid date"
 NN0456,PGCE,06/06/2022,
 TC6049,PGDE,26/06/2022,
 ZG5797,PGDE,27/06/2022,
@@ -49,7 +49,7 @@ QW1061,None,26/06/2022,
 CD1243,PGCE,15/06/2022,
 PR7820,Not applicable,13/06/2022,
 AG1726,None,20/06/2022,
-WY9461,PGCE,07/20/2023,"Date standards met: ‘07/20/2023’, enter a valid date"
+WY9461,PGCE,07/20/2023,"Assessment date: ‘07/20/2023’, enter a valid date"
 AY1140,None,02/06/2022,
 FP7341,PGDE,27/06/2022,
 QD9244,None,19/06/2022,

--- a/app/assets/downloads/recommend.csv
+++ b/app/assets/downloads/recommend.csv
@@ -1,4 +1,4 @@
-TRN,Postgraduate qualification,Date standards met,
+TRN,Postgraduate qualification,Assessment date,
 Do not change this column,"For postgraduate trainees, in the column ‘Postgraduate qualification’ add one of these options:
 - PGCE
 - PGDE

--- a/app/views/bulk-update/recommend/check-pending-updates.html
+++ b/app/views/bulk-update/recommend/check-pending-updates.html
@@ -21,7 +21,7 @@
       classes: "app-table__column-25"
     },
     {
-      text: "Date standards met",
+      text: "Assessment date",
       classes: "app-table__column-25"
     }
   ]

--- a/app/views/bulk-update/recommend/fix-errors.html
+++ b/app/views/bulk-update/recommend/fix-errors.html
@@ -36,8 +36,8 @@
     {% set errorMessage = [
       'TRN not recognised',
       'TRN missing',
-      'Date standards met: ‘09/20/2023’ — enter a valid date',
-      'Date standards met: ‘20/09/2023’ — date the trainee met QTS must be in the past',
+      'Assessment date: ‘09/20/2023’ — enter a valid date',
+      'Assessment date: ‘20/09/2023’ — date must be in the past',
       'Postgraduate qualification: ‘BA (Hons)’ — enter ‘PGCE’, ‘PGDE’ or ‘None’ for postgraduate qualification',
       'Postgraduate qualification: ‘PGCE’ — trainees on undergraduate courses cannot be awarded a postgraduate qualification.',
       'Postgraduate qualification missing. If the trainee did not get a postgraduate qualification enter ‘None’.'

--- a/app/views/bulk-update/recommend/index.html
+++ b/app/views/bulk-update/recommend/index.html
@@ -40,10 +40,10 @@
         You can leave rows or cells empty if you do not want to recommend the trainees for {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}.
       </p>
       <h3 class="govuk-heading-s">
-        When the trainee met {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}
+        {{ traineesThatCanBeRecommended | getQualifications | orSeparate }} assessment date
       </h3>
       <p class="govuk-body">
-        In the column ‘Date standards met’ add the date the trainee met {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}.
+        In the column ‘Assessment date’ add the date the trainee met {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}.
       </p>
       <p class="govuk-body">
         The date must be written in the format <span class="app-nowrap">‘DD/MM/YYYY’</span>.


### PR DESCRIPTION
This is how the date is referred to in the ITT provider portal. I think its a simpler way of referring to it and consistency is a benefit given we don't want the user to question that we're asking for something different to their usual process.