### PR TITLE
Update feedback links

### DIFF
--- a/app/assets/sass/components/_footer.scss
+++ b/app/assets/sass/components/_footer.scss
@@ -1,6 +1,6 @@
 .govuk-footer--app {
   .govuk-footer__meta-custom {
-    max-width: 40rem;
+    max-width: 50rem;
   }
 
   .govuk-footer__inline-list {

--- a/app/views/_includes/footer-settings.njk
+++ b/app/views/_includes/footer-settings.njk
@@ -1,0 +1,22 @@
+
+
+<div class="govuk-footer">
+  <div class="govuk-width-container">
+    <ul class="govuk-footer__inline-list">
+      <li class="govuk-footer__inline-list-item">
+        <a class="govuk-footer__link" href="/admin">
+          Settings
+        </a>
+      </li>
+
+      <li class="govuk-footer__inline-list-item">
+        <form method="post" action="/admin/clear-data" class="app-hidden-form">
+          <button class="app-link-button">
+            Clear data
+          </button>
+        </form>
+
+      </li>
+    </ul>
+  </div>
+</div>

--- a/app/views/_includes/footer-settings.njk
+++ b/app/views/_includes/footer-settings.njk
@@ -15,7 +15,6 @@
             Clear data
           </button>
         </form>
-
       </li>
     </ul>
   </div>

--- a/app/views/_includes/footer-settings.njk
+++ b/app/views/_includes/footer-settings.njk
@@ -1,5 +1,3 @@
-
-
 <div class="govuk-footer">
   <div class="govuk-width-container">
     <ul class="govuk-footer__inline-list">

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -196,7 +196,7 @@
         Give feedback
       </h2>
 
-      <p class="govuk-body govuk-!-font-size-16"><a href="/guidance" class="govuk-link govuk-footer__link">Give feedback to help us improve Register trainee teachers</a></p>
+      <p class="govuk-body govuk-!-font-size-16"><a href="/guidance" class="govuk-link govuk-footer__link">Give feedback to help us improve <span class="app-nowrap">Register trainee teachers</span></a></p>
 
     </div>
   </div>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -168,7 +168,7 @@
     text: "prototype"
   },
   classes: 'govuk-!-margin-top-1',
-  html: 'This is a prototype of a new service – <a href="#" class="govuk-link">give feedback or report a problem</a>'
+  html: 'This is a prototype of a new service – <a href="#" class="govuk-link">give feedback</a>'
 }) }}
 {% block pageNavigation %}
 {% endblock %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -196,7 +196,7 @@
         Give feedback
       </h2>
 
-      <p class="govuk-body govuk-!-font-size-16"><a href="/guidance" class="govuk-link govuk-footer__link">Link goes here</a></p>
+      <p class="govuk-body govuk-!-font-size-16"><a href="/guidance" class="govuk-link govuk-footer__link">Give feedback to help us improve Register trainee teachers</a></p>
 
     </div>
   </div>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -168,7 +168,7 @@
     text: "prototype"
   },
   classes: 'govuk-!-margin-top-1',
-  html: 'This is a prototype of a new service – <a href="#" class="govuk-link">give feedback</a>'
+  html: 'This is a prototype of a new service – your <a href="#" class="govuk-link">feedback</a> will help us improve it'
 }) }}
 {% block pageNavigation %}
 {% endblock %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -179,17 +179,27 @@
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 
 {% set metaHtml %}
-  <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-    <li>Email: <a class="govuk-link govuk-footer__link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher<wbr>@digital.education.gov.uk</a></li>
-    <li>We aim to respond within 5 working days, or one working day for more urgent&nbsp;queries</li>
-  </ul>
-  {% set guidanceLink = '/guidance' %}
-  <p class="govuk-body govuk-!-font-size-16"><a href="{{guidanceLink}}" class="govuk-link govuk-footer__link">Find out about Register trainee teachers</a></p>
-  <form method="post" action="/admin/clear-data" class="app-hidden-form">
-    <button class="app-link-button">
-      Clear data
-    </button>
-  </form>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <h2 class="govuk-heading-s">
+        Get support
+      </h2>
+
+      <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
+        <li><a class="govuk-link govuk-footer__link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher<wbr>@digital.education.gov.uk</a></li>
+        <li>We aim to respond within 5 working days, or one working day for more urgent&nbsp;queries</li>
+      </ul>
+    </div>
+
+    <div class="govuk-grid-column-one-half">
+      <h2 class="govuk-heading-s">
+        Give feedback
+      </h2>
+
+      <p class="govuk-body govuk-!-font-size-16"><a href="/guidance" class="govuk-link govuk-footer__link">Link goes here</a></p>
+
+    </div>
+  </div>
 {% endset %}
 
 {% if useAutoStoreData %}
@@ -197,33 +207,26 @@
     {{ appFooter({
       classes: "govuk-footer--app",
       meta: {
-        title: "Get support",
+        _title: "Get support",
         html: metaHtml,
         items: [
-        {
-          href: "/accessibility-statement",
-          text: "Accessibility"
-        },{
-          href: "/cookies",
-          text: "Cookies"
-        },{
-          href: "/privacy-policy",
-          text: "Privacy policy"
-        }, {
-          href: "/admin",
-          text: "Prototype admin"
-        }, {
-          href: "/apply/" + providerCode + "/" + courseCode + "?dualrunning=true&variant=1",
-          text: "v1"
-        } if providerCode and courseCode, {
-          href: "/apply/" + providerCode + "/" + courseCode + "?dualrunning=true&variant=2",
-          text: "v2"
-        } if providerCode and courseCode, {
-          href: "/apply/" + providerCode + "/" + courseCode + "?dualrunning=true&variant=3",
-          text: "v3"
-        } if providerCode and courseCode]
+          {
+            href: "/guidance",
+            text: "Guidance"
+          },{
+            href: "/accessibility-statement",
+            text: "Accessibility"
+          },{
+            href: "/cookies",
+            text: "Cookies"
+          },{
+            href: "/privacy-policy",
+            text: "Privacy"
+          }
+        ]
       }
     }) }}
+    {% include "_includes/footer-settings.njk" %}
   {% endblock %}
 {% endif %}
 

--- a/app/views/new-record/submitted.html
+++ b/app/views/new-record/submitted.html
@@ -28,12 +28,12 @@
 <h2 class="govuk-heading-m">Notifying your trainees</h2>
 <p class="govuk-body">DfE will contact trainees to give them their TRN.</p>
 
-<h2 class="govuk-heading-m">Giving us feedback</h2>
+{# <h2 class="govuk-heading-m">Giving us feedback</h2>
 <p class="govuk-body">Tell us how registering a trainee with the new service is working for you. We use this to make improvements. It takes 3 minutes to complete.</p>
 {{ govukButton({
   text: "Give feedback (opens in a new tab)",
   href: "/survey-trn"
-}) }}
+}) }} #}
 
 <h2 class="govuk-heading-m">Next steps</h2>
 {# The name is only stored short term so make sure we have a fallback #}

--- a/app/views/record/qualification/passed/recommended.html
+++ b/app/views/record/qualification/passed/recommended.html
@@ -23,12 +23,12 @@
 <h2 class="govuk-heading-m">Getting {{ record | getQualificationText }} status</h2>
 <p class="govuk-body">The Department for Education will award {{ record | getQualificationText }} where appropriate within 3 working days.</p>
 
-<h2 class="govuk-heading-m">Giving us feedback</h2>
+{# <h2 class="govuk-heading-m">Giving us feedback</h2>
 <p class="govuk-body">Tell us how recommending a trainee for {{ record | getQualificationText }} with the new service is working for you. We use this to make improvements. It takes 3 minutes to complete.</p>
 {{ govukButton({
   text: "Give feedback (opens in a new tab)",
   href: "/survey-qualification"
-}) }}
+}) }} #}
 
 <h2 class="govuk-heading-m">Next steps</h2>
 {# The name is only stored short term so make sure we have a fallback #}


### PR DESCRIPTION
This update:
* removes the feedback link from the registration form
* removes the feedback link from the qts recommend form
* updates the phase banner to only ask about feedback
* update our footer to have two sections
* misc updates to links in footer

New phase banner:
<img width="1026" alt="Screenshot 2022-04-14 at 10 05 11" src="https://user-images.githubusercontent.com/2204224/163352281-d7d14006-559b-4597-81fe-4403554093fd.png">

Updated footer:
<img width="1163" alt="Screenshot 2022-04-14 at 15 18 15" src="https://user-images.githubusercontent.com/2204224/163410072-f923aebb-0499-4c7e-9e6d-fc9bccfc632a.png">

