### PR TITLE
Bulk recommend flow – no add missing or postgrad award

### DIFF
--- a/app/assets/downloads/recommend-with-errors.csv
+++ b/app/assets/downloads/recommend-with-errors.csv
@@ -1,12 +1,10 @@
 TRN,Postgraduate qualification,Date standards met,Errors
 Do not change this column,"For postgraduate trainees, in the column ‘Postgraduate qualification’ add one of these options:
-- PGCE
-- PGDE
-- None
-
+- PGCE- PGDE
+- None
 If the trainee was not on a postgraduate course, leave the cell as ‘Not applicable’.","When the trainee met the QTS or EYTS standards.
 Must be written DD/MM/YYYY. 
-For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.
+For example, if the trainee met the teaching standard on 20 July 2022, write ‘20/07/2022’.
 The date must be in the past.
 If the trainee has not met the teaching standard, leave the cell empty.","Fix these errors and upload this file again.
 

--- a/app/assets/downloads/recommend.csv
+++ b/app/assets/downloads/recommend.csv
@@ -1,63 +1,61 @@
-TRN,Postgraduate qualification,Date standards met,
+TRN,Postgraduate qualification,Date standards met
 Do not change this column,"For postgraduate trainees, in the column ‘Postgraduate qualification’ add one of these options:
-- PGCE
-- PGDE
-- None
-
+- PGCE- PGDE
+- None
 If the trainee was not on a postgraduate course, leave the cell as ‘Not applicable’.","When the trainee met the QTS or EYTS standards.
 Must be written DD/MM/YYYY. 
-For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.
+For example, if the trainee met the teaching standard on 20 July 2022, write ‘20/07/2022’.
 The date must be in the past.
-If the trainee has not met the teaching standard, leave the cell empty.","Fix these errors and upload this file again.
-LY9214,,11/06/2022
-CB0736,,17/06/2022
-GM2844,,11/06/2022
-EH4015,,18/06/2022
-CZ5140,,21/06/2022
-SF6298,,05/06/2022
-CB6515,,08/06/2022
-TL1239,,04/06/2022
-XP1904,,02/06/2022
-LZ4060,,13/06/2022
-ES4157,,26/06/2022
-EA5531,,05/06/2022
-DT4917,,09/06/2022
-HY1346,,05/06/2022
-CP5267,,08/06/2022
-NN0456,,06/06/2022
-TC6049,,26/06/2022
-ZG5797,,27/06/2022
-QY9024,,26/06/2022
-BX1488,,09/06/2022
-DM3787,,07/06/2022
-LY8349,,13/06/2022
-HC4662,,09/06/2022
-YL7503,Not applicable,12/06/2022
-TN0521,,01/06/2022
-FH7057,,18/06/2022
-FT3026,,22/06/2022
-TX2114,,26/06/2022
-GX7531,,27/06/2022
-CY5405,,24/06/2022
-AS7594,,27/06/2022
-AM2248,,28/06/2022
-TF0044,,28/06/2022
-BM6053,,09/06/2022
-QW1061,,26/06/2022
-CD1243,,15/06/2022
-PR7820,Not applicable,13/06/2022
-AG1726,,20/06/2022
-WY9461,,02/06/2022
-AY1140,,02/06/2022
-FP7341,,27/06/2022
-QD9244,,19/06/2022
-GW2621,,14/06/2022
-FQ7206,,16/06/2022
-FY8755,,17/06/2022
-CK0063,,03/06/2022
-HY3693,,22/06/2022
-QW7739,,12/06/2022
-FS2391,,10/06/2022
-AW1698,,28/06/2022
-TQ4748,,12/06/2022
-ZP8118,,27/06/2022
+If the trainee has not met the teaching standard, leave the cell empty."
+LY9214,,
+CB0736,,
+GM2844,,
+EH4015,,
+CZ5140,,
+SF6298,,
+CB6515,,
+TL1239,,
+XP1904,,
+LZ4060,,
+ES4157,,
+EA5531,,
+DT4917,,
+HY1346,,
+CP5267,,
+NN0456,,
+TC6049,,
+ZG5797,,
+QY9024,,
+BX1488,,
+DM3787,,
+LY8349,,
+HC4662,,
+YL7503,,
+TN0521,,
+FH7057,,
+FT3026,,
+TX2114,,
+GX7531,,
+CY5405,,
+AS7594,,
+AM2248,,
+TF0044,,
+BM6053,,
+QW1061,,
+CD1243,,
+PR7820,,
+AG1726,,
+WY9461,,
+AY1140,,
+FP7341,,
+QD9244,,
+GW2621,,
+FQ7206,,
+FY8755,,
+CK0063,,
+HY3693,,
+QW7739,,
+FS2391,,
+AW1698,,
+TQ4748,,
+ZP8118,,

--- a/app/assets/downloads/recommendOnly-with-data.csv
+++ b/app/assets/downloads/recommendOnly-with-data.csv
@@ -1,0 +1,94 @@
+TRN,Start academic year,Route and course,Assessment Date
+Do not change this column,Do not change this column,Do not change this column,"When the trainee met the QTS or EYTS.
+Must be written DD/MM/YYYY. 
+For example, if the trainee met the teaching standard on 20 July 2022, write ‘20/07/2022’.
+The date must be in the past.
+If the trainee has not met the QTS or EYTS, leave the cell empty."
+2015912,2021 to 2022,"School direct (salaried)
+Latin",6/10/2022
+7079455,2021 to 2022,"School direct (fee funded)
+Physical education",7/18/2022
+8124750,2021 to 2022,"Provider-led (postgrad)
+Physics with health and social care",7/22/2022
+4823775,2021 to 2022,"School direct (fee funded)
+Design and technology",7/7/2022
+7222837,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",7/25/2022
+4397456,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",6/26/2022
+2473855,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary",6/25/2022
+4548896,2021 to 2022,"Provider-led (postgrad)
+Physical education with chemistry",6/3/2022
+4525999,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",7/20/2022
+6253405,2021 to 2022,Early years (postgrad),7/16/2022
+6616795,2021 to 2022,Early years (assessment only),6/10/2022
+1310447,2021 to 2022,"Provider-led (postgrad)
+Physical education with chemistry",7/14/2022
+3917788,2021 to 2022,"School direct (fee funded)
+Design and technology",6/19/2022
+1685672,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary",6/10/2022
+7524363,2021 to 2022,Early years (salaried),6/10/2022
+4418349,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",6/27/2022
+5291127,2021 to 2022,"School direct (fee funded)
+Latin",6/17/2022
+6074078,2021 to 2022,"School direct (salaried)
+Geography with communication and media studies",7/7/2022
+5844797,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary",7/20/2022
+2435235,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",6/21/2022
+2990499,2021 to 2022,"School direct (fee funded)
+Physical education with chemistry",6/13/2022
+2794905,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",7/16/2022
+7195453,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",7/4/2022
+6064341,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary",7/23/2022
+7833796,2021 to 2022,"School direct (fee funded)
+Primary",7/19/2022
+2817299,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",6/27/2022
+8652512,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",7/3/2022
+3989873,2021 to 2022,"Provider-led (postgrad)
+Physics with health and social care",6/14/2022
+3626742,2021 to 2022,"School direct (fee funded)
+Design and technology",6/20/2022
+7443258,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",7/21/2022
+7596050,2021 to 2022,"Provider-led (postgrad)
+Physical education with chemistry",7/11/2022
+7028834,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",7/25/2022
+1499011,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",6/17/2022
+6383574,2021 to 2022,"Provider-led (postgrad)
+Physics with health and social care",7/18/2022
+5231551,2021 to 2022,"School direct (fee funded)
+Physical education with chemistry",6/24/2022
+7111186,2021 to 2022,"Provider-led (postgrad)
+Physics with health and social care",6/26/2022
+8758546,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",6/1/2022
+3929321,2021 to 2022,Early years (salaried),7/18/2022
+6905517,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",7/3/2022
+7525609,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",7/14/2022
+4820996,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",6/27/2022
+2188518,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",6/10/2022
+8198887,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",6/14/2022
+1929947,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",6/23/2022
+8605561,2022 to 2023,"Provider-led (postgrad)
+Primary with mathematics",6/20/2022
+8554375,2022 to 2023,"Provider-led (postgrad)
+Design and technology",7/16/2022

--- a/app/assets/downloads/recommendOnly-with-errors.csv
+++ b/app/assets/downloads/recommendOnly-with-errors.csv
@@ -1,0 +1,92 @@
+TRN,Start academic year,Route and course,Assessment Date,
+Do not change this column,Do not change this column,Do not change this column,"When the trainee met the QTS or EYTS.
+Must be written DD/MM/YYYY. 
+For example, if the trainee met the teaching standard on 20 July 2022, write ‘20/07/2022’.
+The date must be in the past.
+If the trainee has not met the QTS or EYTS, leave the cell empty.",
+2015912,2021 to 2022,"School direct (salaried)
+Latin",6/11/2022,
+7079455,2021 to 2022,"School direct (fee funded)
+Physical education",6/17/2022,
+8124750,2021 to 2022,"Provider-led (postgrad)
+Physics with health and social care",6/25/2022,
+4823775,2021 to 2022,"School direct (fee funded)
+Design and technology",7/13/2022,
+7222837,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",7/19/2022,
+4397456,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",20/09/2023,Date standards met: ‘20/09/2023’ — assessment date must be in the past
+2473855,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary",6/13/2022,
+4548896,2021 to 2022,"Provider-led (postgrad)
+Physical education with chemistry",6/17/2022,
+4525999,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",6/6/2022,
+6253405,2021 to 2022,Early years (postgrad),7/6/2022,
+6616795,2021 to 2022,Early years (assessment only),6/8/2022,
+1310447,2021 to 2022,"Provider-led (postgrad)
+Physical education with chemistry",6/21/2022,
+3917788,2021 to 2022,"School direct (fee funded)
+Design and technology",7/24/2022,
+1685672,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary",7/23/2022,
+7524363,2021 to 2022,Early years (salaried),7/10/2022,
+4418349,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",7/27/2022,
+5291127,2021 to 2022,"School direct (fee funded)
+Latin",6/1/2022,
+6074078,2021 to 2022,"School direct (salaried)
+Geography with communication and media studies",7/21/2022,
+5844797,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary",6/10/2022,
+2435235,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",6/9/2022,
+2990499,2021 to 2022,"School direct (fee funded)
+Physical education with chemistry",6/13/2022,
+2794905,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",7/4/2022,
+7195453,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",7/9/2022,
+6064341,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary",7/9/2022,
+7833796,2021 to 2022,"School direct (fee funded)
+Primary",6/25/2022,
+2817299,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",6/10/2022,
+8652512,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",7/12/2022,
+Angeline Fournier,2021 to 2022,"Provider-led (postgrad)
+Physics with health and social care",7/12/2022,TRN not recognised
+3626742,2021 to 2022,"School direct (fee funded)
+Design and technology",7/22/2022,
+7443258,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",20/09/2023,Date standards met: ‘20/09/2023’ — assessment date must be in the past
+7596050,2021 to 2022,"Provider-led (postgrad)
+Physical education with chemistry",7/23/2022,
+7028834,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",7/6/2022,
+1499011,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",7/21/2022,
+6383574,2021 to 2022,"Provider-led (postgrad)
+Physics with health and social care",7/10/2022,
+5231551,2021 to 2022,"School direct (fee funded)
+Physical education with chemistry",6/12/2022,
+7111186,2021 to 2022,"Provider-led (postgrad)
+Physics with health and social care",7/21/2022,
+8758546,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",6/23/2022,
+3929321,2021 to 2022,Early years (salaried),7/15/2022,
+6905517,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",7/7/2022,
+,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",6/5/2022,TRN missing
+4820996,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",6/2/2022,
+2188518,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",6/9/2022,
+8198887,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",7/12/2022,
+1929947,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",7/25/2022,
+8605561,2022 to 2023,"Provider-led (postgrad)
+Primary with mathematics",7/5/2022,

--- a/app/assets/downloads/recommendOnly.csv
+++ b/app/assets/downloads/recommendOnly.csv
@@ -1,0 +1,94 @@
+TRN,Start academic year,Route and course,Assessment Date
+Do not change this column,Do not change this column,Do not change this column,"When the trainee met the QTS or EYTS.
+Must be written DD/MM/YYYY. 
+For example, if the trainee met the teaching standard on 20 July 2022, write ‘20/07/2022’.
+The date must be in the past.
+If the trainee has not met the QTS or EYTS, leave the cell empty."
+2015912,2021 to 2022,"School direct (salaried)
+Latin",
+7079455,2021 to 2022,"School direct (fee funded)
+Physical education",
+8124750,2021 to 2022,"Provider-led (postgrad)
+Physics with health and social care",
+4823775,2021 to 2022,"School direct (fee funded)
+Design and technology",
+7222837,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",
+4397456,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",
+2473855,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary",
+4548896,2021 to 2022,"Provider-led (postgrad)
+Physical education with chemistry",
+4525999,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",
+6253405,2021 to 2022,Early years (postgrad),
+6616795,2021 to 2022,Early years (assessment only),
+1310447,2021 to 2022,"Provider-led (postgrad)
+Physical education with chemistry",
+3917788,2021 to 2022,"School direct (fee funded)
+Design and technology",
+1685672,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary",
+7524363,2021 to 2022,Early years (salaried),
+4418349,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",
+5291127,2021 to 2022,"School direct (fee funded)
+Latin",
+6074078,2021 to 2022,"School direct (salaried)
+Geography with communication and media studies",
+5844797,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary",
+2435235,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",
+2990499,2021 to 2022,"School direct (fee funded)
+Physical education with chemistry",
+2794905,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",
+7195453,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",
+6064341,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary",
+7833796,2021 to 2022,"School direct (fee funded)
+Primary",
+2817299,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",
+8652512,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",
+3989873,2021 to 2022,"Provider-led (postgrad)
+Physics with health and social care",
+3626742,2021 to 2022,"School direct (fee funded)
+Design and technology",
+7443258,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",
+7596050,2021 to 2022,"Provider-led (postgrad)
+Physical education with chemistry",
+7028834,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",
+1499011,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",
+6383574,2021 to 2022,"Provider-led (postgrad)
+Physics with health and social care",
+5231551,2021 to 2022,"School direct (fee funded)
+Physical education with chemistry",
+7111186,2021 to 2022,"Provider-led (postgrad)
+Physics with health and social care",
+8758546,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",
+3929321,2021 to 2022,Early years (salaried),
+6905517,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",
+7525609,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",
+4820996,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",
+2188518,2021 to 2022,"Provider-led (postgrad)
+Modern languages (other)",
+8198887,2021 to 2022,"Provider-led (postgrad)
+Physical education with biology",
+1929947,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",
+8605561,2022 to 2023,"Provider-led (postgrad)
+Primary with mathematics",
+8554375,2022 to 2023,"Provider-led (postgrad)
+Design and technology",

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -125,7 +125,7 @@ settings.highlightInvalidAnswers = 'true'
 // Enable timeline on records
 settings.includeDeclaration = false
 
-settings.bulkLinksInPrimaryNav = "Show bulk updates"
+settings.bulkLinksInPrimaryNav = "Show bulk recommend"
 
 settings.skipCourseDatesPage = 'true'
 

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -1722,11 +1722,9 @@ exports.filterByCannotBulkUpdate = (records) => {
 }
 
 // Trainees that can be bulk recommended
-exports.filterByCanBulkRecommend = (records) => {
+exports.filterByReadyToRecommend = (records) => {
   let filteredRecords = exports.filterByComplete(records)
-  filteredRecords = exports.filterByStatus(filteredRecords, "Draft", true)
-  filteredRecords = exports.filterByActive(filteredRecords)
-  filteredRecords = exports.filterOutDeferred(filteredRecords)
+  filteredRecords = exports.filterByStatus(filteredRecords, "TRN received")
   return filteredRecords
 }
 

--- a/app/views/_includes/bulk-update/check-pending-updates.html
+++ b/app/views/_includes/bulk-update/check-pending-updates.html
@@ -43,7 +43,7 @@
           text: buttonText
         }) }}
         <p class="govuk-body">
-          <a href="/bulk-update/cancel-bulk-updates" class="govuk-link">Cancel bulk updates to records</a>
+          <a href="/bulk-update/cancel-bulk-updates" class="govuk-link">Cancel bulk {{ "recommending trainees" if data.settings.bulkLinksInPrimaryNav == "Show bulk recommend" else "updates to records" }}</a>
         </p>
     </form>
   </div>

--- a/app/views/_includes/bulk-update/errors-found.html
+++ b/app/views/_includes/bulk-update/errors-found.html
@@ -31,7 +31,7 @@
       }) }}
     </form>
     <p class="govuk-body">
-      <a href="/bulk-update/cancel-bulk-updates" class="govuk-link">Cancel bulk updates to records</a>
+      <a href="/bulk-update/cancel-bulk-updates" class="govuk-link">Cancel bulk {{ "recommending trainees" if data.settings.bulkLinksInPrimaryNav == "Show bulk recommend" else "updates to records" }}</a>
     </p>
   </div>
 </div>

--- a/app/views/_includes/bulk-update/fix-file.html
+++ b/app/views/_includes/bulk-update/fix-file.html
@@ -11,7 +11,7 @@
       1. Export a new template or update your original file
     </h2>
     <p class="govuk-body">
-      <a href="/public/downloads/{{ bulkPath }}{{ "-with-errors" if pageContent == "fixErrors" }}.csv" download="{{ fileName}}">Your trainee records {{ "with a description of the errors" if pageContent == "fixErrors" }} (csv)</a>
+      <a href="/public/downloads/{{ filePath }}.csv" download="{{ fileName }}">{{ "Trainees ready to be recommened for " + traineesThatCanBeRecommended | getQualifications | orSeparate if bulkPath == "recommend" else "Trainee records with missing details " }} {{ "— with a description of errors" if pageContent == "fixErrors" }} (csv)</a>
     </p>
     <h2 class="govuk-heading-m">
       2. {{ "Fix the errors" if pageContent == "fixErrors" else "Update your trainee records" }}
@@ -68,7 +68,7 @@
       </p>
     {% endif %}
     <p class="govuk-body">
-      <a href="/bulk-update/cancel-bulk-updates" class="govuk-link">Cancel bulk updates to records</a>
+      <a href="/bulk-update/cancel-bulk-updates" class="govuk-link">Cancel bulk {{ "recommending trainees" if data.settings.bulkLinksInPrimaryNav == "Show bulk recommend" else "updates to records" }}</a>
     </p>
   </div>
 </div>

--- a/app/views/admin.html
+++ b/app/views/admin.html
@@ -104,6 +104,10 @@
         },
         items: [
           {
+            value: 'Show bulk recommend',
+            text: "Show bulk recommend"
+          },
+          {
             value: 'Show bulk updates',
             text: "Show bulk updates"
           },

--- a/app/views/bulk-update/add-details/confirmation.html
+++ b/app/views/bulk-update/add-details/confirmation.html
@@ -6,7 +6,7 @@
 {% set filteredRecords = data.records | filterRecords(data) %}
 {% set traineesThatCanBeUpdated = filteredRecords | filterByCanBulkUpdate %}
 
-{% set traineesThatCanBeRecommended = filteredRecords | filterByCanBulkRecommend %}
+{% set traineesThatCanBeRecommended = filteredRecords | filterByReadyToRecommend %}
 {% set pageHeading = traineesThatCanBeUpdated | length  + " trainee records updated" %}
 
 {% block content %}

--- a/app/views/bulk-update/add-details/fix-errors.html
+++ b/app/views/bulk-update/add-details/fix-errors.html
@@ -4,6 +4,7 @@
 {% set pageContent = "fixErrors" %}
 {% set pageHeading = "Fix errors in your pending updates" %}
 
+{% set filePath = "add-details-with-errors" %}
 {% set rowsWithErrors = data.bulkUpload.processedRows | where("uploadStatus", "error") %}
 
 {% set tableBodyRows = [] %}
@@ -23,7 +24,7 @@
     </p>
   {% endset %}
   {% set errorMessage = row.errorMessage %}
-  {% if row.errorMessage == "TRN missing" %}
+  {% if row.errorMessage == "Assessment date provided without a TRN — add a TRN or remove the assessment date" %}
     {% set traineeInfoHtml = "–" %}
   {% endif %}
   {% if row.errorMessage == "TRN not recognised" %}

--- a/app/views/bulk-update/add-details/fix-pending-updates.html
+++ b/app/views/bulk-update/add-details/fix-pending-updates.html
@@ -3,7 +3,7 @@
 {% set pageContent = "makeChanges" %}
 {% set pageHeading = "Change your pending updates" %}
 {% set navActive = 'bulk' %}
-
+{% set filePath = "add-details-with-data" %}
 {% set bulkPath = "add-details" %}
 
 {% block content %}

--- a/app/views/bulk-update/cancel-bulk-updates.html
+++ b/app/views/bulk-update/cancel-bulk-updates.html
@@ -7,12 +7,19 @@
   text: "Return to the previous page"
 } %}
 
+{% set bulkOnly = true if data.settings.bulkLinksInPrimaryNav == "Show bulk recommend" %}
+
 {% block formContent %}
   {% include "_includes/trainee-name-caption.njk" %}
 
   <h1 class="govuk-heading-l">
     {# {{pageHeading}} #}
-    Confirm you want to cancel your <span class="app-nowrap">bulk updates</span>
+    Confirm you want to cancel 
+    {% if bulkOnly %}
+      bulk recommending trainees
+    {% else %}
+      your <span class="app-nowrap">bulk updates</span>
+    {% endif %}
   </h1>
 
   <p class="govuk-body">
@@ -21,7 +28,7 @@
 
   {{ govukButton({
     text: "Confirm cancel",
-    href: "/bulk-update",
+    href: "/bulk-update/recommend" if bulkOnly else "/bulk-update",
     classes: "govuk-button--warning"
   }) }}
 

--- a/app/views/bulk-update/index.html
+++ b/app/views/bulk-update/index.html
@@ -1,11 +1,15 @@
 {% extends "_templates/_page.html" %}
 {% set pageHeading = "Bulk updates" %}
+
+{% set backText = "Home" %}
+{% set backLink = '/home' %}
 {% set navActive = 'bulk' %}
+
 {% set filteredRecords = data.records | filterRecords(data) %}
 {% set traineesThatCanBeUpdated = filteredRecords | filterByCanBulkUpdate %}
 {% set traineesWithoutStartDates = traineesThatCanBeUpdated | filterByNeedsStartDate | length %}
 {% set traineesWithoutPlacements = traineesThatCanBeUpdated | filterByNeedsPlacements | length %}
-{% set traineesThatCanBeRecommended = filteredRecords | filterByCanBulkRecommend %}
+{% set traineesThatCanBeRecommended = filteredRecords | filterByReadyToRecommend %}
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/bulk-update/recommend/check-pending-updates.html
+++ b/app/views/bulk-update/recommend/check-pending-updates.html
@@ -1,31 +1,53 @@
 {% extends "_templates/_page.html" %}
 
 {% set filteredRecords = data.records | filterRecords(data) %}
-{% set traineesThatCanBeRecommended = filteredRecords | filterByCanBulkRecommend %}
+{% set traineesThatCanBeRecommended = filteredRecords | filterByReadyToRecommend %}
 
+{% set fileName = data.signedInProviders | makeFileName("check pending","csv") %}
 {% set pageHeading = "Check pending updates before recommending trainees for " + traineesThatCanBeRecommended | getQualifications | orSeparate %}
 {% set navActive = 'bulk' %}
 
+{% set bulkOnly = true if data.settings.bulkLinksInPrimaryNav == "Show bulk recommend" %}
 
-{% set tableHeadRow = [
-    {
-      text: "Trainee",
-      classes: "app-table__column-25"
-    },
-    {
-      text: "Route and course",
-      classes: "app-table__column-25"
-    },
-    {
-      text: "Postgraduate qualification",
-      classes: "app-table__column-25"
-    },
-    {
-      text: "Date standards met",
-      classes: "app-table__column-25"
-    }
-  ]
-%}
+{% if bulkOnly %}
+  {% set tableHeadRow = [
+      {
+        text: "Trainee",
+        classes: "app-table__column-25"
+      },
+      {
+        text: "Start academic year",
+        classes: "app-table__column-25"
+      } if bulkOnly,
+      {
+        text: "Route and course",
+        classes: "app-table__column-25"
+      },
+      {
+        text: "Assessment date",
+        classes: "app-table__column-25"
+      }
+    ]%}
+{% else %}
+    {% set tableHeadRow = [
+      {
+        text: "Trainee",
+        classes: "app-table__column-25"
+      },
+      {
+        text: "Route and course",
+        classes: "app-table__column-25"
+      },
+      {
+        text: "Postgraduate qualification",
+        classes: "app-table__column-25"
+      },
+      {
+        text: "Assessment date",
+        classes: "app-table__column-25"
+      }
+    ]%}
+{% endif %}
 
 {% set qtsTableBodyRows  = [] %}
 {% set eytsTableBodyRows = [] %}
@@ -56,12 +78,13 @@
 
   {% set routeAndCourseHtml %}
     <p class="govuk-body govuk-!-margin-bottom-1">
-      {{ row.trainee.courseDetails.courseNameShort if row.trainee.courseDetails.courseNameShort
-        else row.trainee.route }}
+      {{ row.trainee.route }}
     </p>
-    <p class="govuk-body govuk-!-margin-bottom-0">
-      {{ row.trainee.courseDetails.studyMode }}
-    </p>
+    {% if row.trainee.courseDetails.courseNameShort %}
+      <p class="govuk-body govuk-!-margin-bottom-0">
+        {{ row.trainee.courseDetails.courseNameShort }}
+      </p>
+    {% endif %}
   {% endset %}
 
   
@@ -73,12 +96,22 @@
       {% set qualification = "—" %}
     {% endif %}
 
-  {% set tableRow = [
-      { text: traineeInfoHtml    | safe },
-      { text: routeAndCourseHtml | safe },
-      { text: qualification },
-      { text: row.assessmentDate | govukDate }
-    ] %}
+    {% if bulkOnly %}
+      {% set tableRow = [
+        { text: traineeInfoHtml    | safe },
+        { text: row.trainee.academicYear },
+        { text: routeAndCourseHtml | safe },
+        { text: row.assessmentDate | govukDate }
+      ]%}
+    {% else %}
+      {% set tableRow = [
+        { text: traineeInfoHtml    | safe },
+        { text: routeAndCourseHtml | safe },
+        { text: qualification },
+        { text: row.assessmentDate | govukDate }
+      ]%}
+    {% endif %}
+  
 
   {% if row.trainee | getQualificationText == "QTS" %}
     {% set qtsTableBodyRows = qtsTableBodyRows   | push(tableRow) %}
@@ -88,8 +121,8 @@
 
 {% endfor %}
 
-{% set qtsTableCaption  = "Trainees to be recommended for QTS (" + qtsTableBodyRows.length + ")" %}
-{% set eytsTableCaption = "Trainees to be recommended for EYTS (" + eytsTableBodyRows.length + ")" %}
+{% set qtsTableCaption  = "Trainees being recommended for QTS (" + qtsTableBodyRows.length + ")" %}
+{% set eytsTableCaption = "Trainees being recommended for EYTS (" + eytsTableBodyRows.length + ")" %}
 {% set tableCaptionClasses = "govuk-table__caption--m" %}
 
 {% set buttonText = "Recommend trainees for " + traineesThatCanBeRecommended | getQualifications | orSeparate %}

--- a/app/views/bulk-update/recommend/confirmation.html
+++ b/app/views/bulk-update/recommend/confirmation.html
@@ -4,7 +4,7 @@
 {% set backLink = 'false' %}
 
 {% set filteredRecords = data.records | filterRecords(data) %}
-{% set traineesThatCanBeRecommended = filteredRecords | filterByCanBulkRecommend %}
+{% set traineesThatCanBeRecommended = filteredRecords | filterByReadyToRecommend %}
 
 {% set pageHeading = traineesThatCanBeRecommended | length  + " trainee records recommended for " + traineesThatCanBeRecommended | getQualifications | orSeparate %}
 

--- a/app/views/bulk-update/recommend/fix-errors.html
+++ b/app/views/bulk-update/recommend/fix-errors.html
@@ -1,8 +1,13 @@
 {% extends "_templates/_page.html" %}
 {% set navActive = 'bulk' %}
 
+{% set filteredRecords = data.records | filterRecords(data) %}
+{% set traineesThatCanBeRecommended = filteredRecords | filterByReadyToRecommend %}
+
+{% set bulkOnly = true if data.settings.bulkLinksInPrimaryNav == "Show bulk recommend" %}
 {% set pageContent = "fixErrors" %}
 {% set pageHeading = "Fix errors in your pending updates" %}
+{% set filePath = "recommendOnly-with-errors" if bulkOnly else "recommend-with-errors" %}
 
 {% set fileName = data.signedInProviders | makeFileName("fix errors","csv") %}
 {% set bulkPath = "recommend" %}
@@ -29,7 +34,7 @@
   {% if errorMessage == 'TRN not recognised' %}
     {% set traineeInfoHtml = "–" %}
     {% set errorMessage = 'TRN: ‘' + row.trainee.trn + '’, enter a valid TRN' %}
-  {% elseif errorMessage == 'TRN missing' %}
+  {% elseif errorMessage == 'Assessment date provided without a TRN — add a TRN or remove the assessment date' %}
     {% set traineeInfoHtml = '–' %}
   {% endif %}
 

--- a/app/views/bulk-update/recommend/fix-pending-updates.html
+++ b/app/views/bulk-update/recommend/fix-pending-updates.html
@@ -4,8 +4,11 @@
 {% set pageHeading = "Change your pending updates" %}
 {% set navActive = 'bulk' %}
 
+{% set bulkOnly = true if data.settings.bulkLinksInPrimaryNav == "Show bulk recommend" %}
+{% set filePath = "recommendOnly-with-data" if bulkOnly else "recommend-with-data" %}
+
 {% set filteredRecords = data.records | filterRecords(data) %}
-{% set traineesThatCanBeRecommended = filteredRecords | filterByCanBulkRecommend %}
+{% set traineesThatCanBeRecommended = filteredRecords | filterByReadyToRecommend %}
 
 {% set fileName = data.signedInProviders | makeFileName("change pending","csv") %}
 

--- a/app/views/bulk-update/recommend/hidden-recommend-trainees.html
+++ b/app/views/bulk-update/recommend/hidden-recommend-trainees.html
@@ -1,0 +1,65 @@
+{% extends "_templates/_page.html" %}
+{% set navActive = 'bulk' %}
+
+{% set pageContent = "fixErrors" %}
+{% set pageHeading = "Fix errors in your pending updates" %}
+
+{% set rows = data.bulkUpload.processedRows %}
+
+{% set tableBodyRows = [] %}
+
+{% for row in rows %}
+  {% set routeAndCourse %}
+    {{ row.trainee.courseDetails.route }}<br>
+    {{ row.trainee.courseDetails.courseNameShort }}
+  {% endset %}
+  {% set tableRow = [
+    { text: row.rowNumber },
+    { text: row.trainee.trn },
+    { text: row.trainee.personalDetails.shortName },
+    { text: row.trainee.academicYear },
+    { text: routeAndCourse | safe },
+    { text: row.assessmentDate },
+    { text: row.errorMessage }
+  ] %}
+  {% set tableBodyRows = tableBodyRows | push(tableRow) %}
+{% endfor %}
+
+{% set tableCaption = "Trainee " + 'record' | pluralise(tableBodyRows.length) + " (" + tableBodyRows.length + ")" %}
+{% set tableCaptionClasses = "govuk-table__caption--m" %}
+{% set tableHeadRow = 
+  [
+    {
+      text: "Row"
+    },
+    {
+      text: "TRN"
+    },
+    {
+      text: "Trainee name"
+    },
+    {
+      text: "Start academic year"
+    },
+    {
+      text: "Route and course"
+    },
+    {
+      text: "Assessment date"
+    },
+    {
+      text: "Error"
+    }
+  ]
+%}
+
+{% block content %}
+
+  {{ govukTable({
+      caption: tableCaption,
+      captionClasses: tableCaptionClasses,
+      head: tableHeadRow,
+      rows: tableBodyRows
+    }) }}
+
+{% endblock %}

--- a/app/views/bulk-update/recommend/index.html
+++ b/app/views/bulk-update/recommend/index.html
@@ -1,9 +1,19 @@
 {% extends "_templates/_page.html" %}
 
+{% if data.settings.bulkLinksInPrimaryNav == "Show bulk recommend" %}
+  {% set backText = "Home" %}
+  {% set backLink = '/home' %}
+  {% set bulkRecommendOnly = true %}
+{% endif %}
+
+{% set headingLevel = "h3" if bulkRecommendOnly else "h2" %}
+
+{% set filePath = "/public/downloads/recommendOnly.csv" if bulkRecommendOnly else "/public/downloads/recommend.csv" %}
+
 {% set navActive = 'bulk' %}
 
 {% set filteredRecords = data.records | filterRecords(data) %}
-{% set traineesThatCanBeRecommended = filteredRecords | filterByCanBulkRecommend %}
+{% set traineesThatCanBeRecommended = filteredRecords | filterByReadyToRecommend %}
 
 {% set needAcademicAward = traineesThatCanBeRecommended | filterByAcademicQualificationsApply %}
 
@@ -15,69 +25,122 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <h1 class="govuk-heading-l">
+      <h1 class="govuk-heading-{{ 'xl' if bulkRecommendOnly else 'l' }}">
         <span class="govuk-caption-l">{{ data.signedInProviders | andSeparate }}</span>
         {{ pageHeading }}
       </h1>
+      {% if bulkRecommendOnly %}
+        {% if traineesThatCanBeRecommended %}
+          <p class="govuk-body">
+            Bulk recommend multiple trainees for {{ traineesThatCanBeRecommended | getQualifications | orSeparate }} at the same time.
+          </p>
+          <p class="govuk-body">
+            You have {{ traineesThatCanBeRecommended.length }} trainees that you can recommend for {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}.
+          </p>
+          <p class="govuk-body">
+            After you recommend trainees for {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}, the DfE will award them (where appropriate) within <span class="app-nowrap">3 working days</span>.
+          </p>
+        {% else %}
+          <p class="govuk-body">
+            You do not have any trainees that can be recommended for {{ filteredRecords | getQualifications | orSeparate }}.
+          </p>
+          <h2 class="govuk-heading-m">
+            Next steps
+          </h2>
+          <p class="govuk-body">
+            <a href="/records">View you trainee trainee records</a> and check if any are incomplete, or contact <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Bulk%20recommending%20trainees">becomingateacher@digital.education.gov.uk</a> for help.
+          </p>
+        {% endif %}
+      {% else %}
+        <p class="govuk-body">
+          You have {{ traineesThatCanBeRecommended | length }} trainees ready to be recommend for {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}.
+        </p>
+      {% endif %}
+      {% if data.settings.bulkLinksInPrimaryNav == "Show bulk recommend" %}
+        <h2 class="govuk-heading-l">
+          How to recommend trainees
+        </h2>
+      {% endif %}
+
+      <{{ headingLevel }} class="govuk-heading-m">
+        1. Download the template 
+      </{{ headingLevel }}>
       <p class="govuk-body">
-        You have {{ traineesThatCanBeRecommended | length }} trainees ready to be recommend for {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}.
-      </p>
-      <h2 class="govuk-heading-m">
-        1. Export a template file
-      </h2>
-      <p class="govuk-body">
-        <a href="../public/downloads/recommend.csv" download="{{ fileName }}" class="govuk-link">
-          Trainee records with missing details (csv)
+        <a href="{{ filePath }}" download="{{ fileName }}" class="govuk-link">
+          Trainees ready to be recommended for {{ traineesThatCanBeRecommended | getQualifications | orSeparate }} (csv)
         </a>
       </p>
-      <h2 class="govuk-heading-m">
-        2. Add details of the trainee’s outcome
-      </h2>
+
+      <{{ headingLevel }} class="govuk-heading-m">
+        2. Add {{ "the assessment dates" if bulkRecommendOnly else "details of the trainee’s outcome" }}
+      </{{ headingLevel }}>
       <p class="govuk-body">
-        Open ‘ <span class="govuk-!-font-weight-bold">{{ fileName }}</span>’ in <span class="app-nowrap">spreadsheet software</span> (for example, <span class="app-nowrap">Microsoft Excel</span>) and add when the trainee met {{ traineesThatCanBeRecommended | getQualifications | orSeparate }} {{ "and their postgraduate academic qualification" if needAcademicAward | filterByPostgraduate }}{{ ", where applicable" if traineesThatCanBeRecommended.length > needAcademicAward.length }}.
+        Open ‘<span class="govuk-!-font-weight-bold">{{ fileName }}</span>’ in <span class="app-nowrap">spreadsheet software</span> (for example, <span class="app-nowrap">Microsoft Excel</span>).
       </p>
-      <p class="govuk-body">
-        Leave rows or cells empty if you do not want to recommend the trainees for {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}.
-      </p>
-      <h3 class="govuk-heading-s">
-        When the trainee met {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}
-      </h3>
-      <p class="govuk-body">
-        In the column ‘Date standards met’ add the date the trainee met {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}.
-      </p>
-      <p class="govuk-body">
-        The date must be written in the format <span class="app-nowrap">‘DD/MM/YYYY’</span>.
-        For example, if the trainee met the standard on <span class="app-nowrap">20 June {{ data.years.defaultCourseYear }}</span>, write <span class="app-nowrap">‘20/07/{{ data.years.defaultCourseYear }}’</span>.
-      </p>
-      <p class="govuk-body">
-        If the trainee has not met {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}, withdraw them manually.
-      </p>
-      {% if needAcademicAward | filterByPostgraduate %}
-      <h3 class="govuk-heading-s">
-        Postgraduate academic qualification
-      </h3>
-        {# Notes - consider tolerating 'None' for routes that are not
-        postgrad #}
+      {% if bulkRecommendOnly %}
         <p class="govuk-body">
-          For postgraduate trainees, in the column ‘Postgraduate qualification’ add one of these
-          options:
+          In the column ‘Assessment date’ add the date the trainee met {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}.
         </p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>PGCE</li>
-          <li>PGDE</li>
-          <li>None</li>
-        </ul>
-        {% if traineesThatCanBeRecommended.length > needAcademicAward.length %}
-          <p class="govuk-body">
-            For trainees not on a postgraduate course, leave the cell as <span class="app-nowrap">‘Not applicable’</span>.
-          </p>
+        <p class="govuk-body">
+          The date must be written in the format <span class="app-nowrap">‘DD/MM/YYYY’</span>.
+          For example, if the trainee met the standard on <span class="app-nowrap">20 June {{ data.years.defaultCourseYear }}</span>, write <span class="app-nowrap">‘20/07/{{ data.years.defaultCourseYear }}’</span>.
+        </p>
+        <p class="govuk-body">
+          Leave the cell empty if you do not want to recommend the trainee for {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}.
+        </p>
+        <p class="govuk-body">
+          If the trainee has not met {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}, withdraw them manually.
+        </p>
+      {% else %}
+        <p class="govuk-body">
+          Add when the trainee met {{ traineesThatCanBeRecommended | getQualifications | orSeparate }} {{ "and their postgraduate academic qualification" if needAcademicAward | filterByPostgraduate }}{{ ", where applicable" if traineesThatCanBeRecommended.length > needAcademicAward.length }}.
+        </p>
+        <p class="govuk-body">
+          Leave rows or cells empty if you do not want to recommend the trainee for {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}.
+        </p>
+        <h3 class="govuk-heading-s">
+          Assessment date
+        </h3>
+        <p class="govuk-body">
+          In the column ‘Assessment date’ add the date the trainee met {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}.
+        </p>
+        <p class="govuk-body">
+          The date must be written in the format <span class="app-nowrap">‘DD/MM/YYYY’</span>.
+          For example, if the trainee met the standard on <span class="app-nowrap">20 June {{ data.years.defaultCourseYear }}</span>, write <span class="app-nowrap">‘20/07/{{ data.years.defaultCourseYear }}’</span>.
+        </p>
+        <p class="govuk-body">
+          If the trainee has not met {{ traineesThatCanBeRecommended | getQualifications | orSeparate }}, withdraw them manually.
+        </p>
+          {% if needAcademicAward | filterByPostgraduate %}
+          <h3 class="govuk-heading-s">
+            Postgraduate academic qualification
+          </h3>
+            {# Notes - consider tolerating 'None' for routes that are not
+            postgrad #}
+            <p class="govuk-body">
+              For postgraduate trainees, in the column ‘Postgraduate qualification’ add one of these
+              options:
+            </p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>PGCE</li>
+              <li>PGDE</li>
+              <li>None</li>
+            </ul>
+          {% if traineesThatCanBeRecommended.length > needAcademicAward.length %}
+            <p class="govuk-body">
+              For trainees not on a postgraduate course, leave the cell as <span class="app-nowrap">‘Not applicable’</span>.
+            </p>
+          {% endif %}
         {% endif %}
       {% endif %}
 
-      <h2 class="govuk-heading-m">
-        3. Upload your trainee records
-      </h2>
-      <form action="/bulk-update/recommend/bulk-update-answer" method="post" novalidate>
+      <{{ headingLevel }} class="govuk-heading-m">
+        3. Upload the file
+      </{{ headingLevel }}>
+      <p class="govuk-body">
+        You will be able to check the trainee’s details after uploading the file.
+      </p>
+       <form action="/bulk-update/recommend/bulk-update-answer" method="post" novalidate>
         {{ govukFileUpload({
           id: "file-upload-1",
           name: "file-upload-1",

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -126,6 +126,11 @@
       active: true if navActive == 'records'
     },
     {
+      text: 'Bulk recommend',
+      href: '/bulk-update/recommend',
+      active: true if navActive == 'bulk'
+    } if isAuthorised('bulkActions') and data.settings.bulkLinksInPrimaryNav == "Show bulk recommend",
+    {
       text: 'Bulk updates',
       href: '/bulk-update',
       active: true if navActive == 'bulk'


### PR DESCRIPTION
Adds feature flag:
- users can recommend trainees without needing to provide academic award
- hides bulk add missing details

Makes small tweaks to content (more to come)

Adds hidden table page (makes it easier to create example CSVs)

