### PR TITLE
Adds provider’s trainee ID to bulk recommend

### DIFF
--- a/app/assets/downloads/recommendOnly-template.csv
+++ b/app/assets/downloads/recommendOnly-template.csv
@@ -1,7 +1,8 @@
-TRN,Date standards met
+TRN,Trainee ID,Date standards met
 "Add the TRN for trainees you want to recommend.
+Can be blank if Trainee ID is provided","Your ID for the trainee.
 
-TRNs must be 7 digits.","Add the date when the trainee met QTS or EYTS standards.
+Can be blank if TRN is provided.","Add the date when the trainee met QTS or EYTS standards.
 Must be written DD/MM/YYYY. 
 For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.
 The date must be in the past.

--- a/app/assets/downloads/recommendOnly-template.csv
+++ b/app/assets/downloads/recommendOnly-template.csv
@@ -1,6 +1,7 @@
 TRN,Trainee ID,Date standards met
 "Add the TRN for trainees you want to recommend.
-Can be blank if Trainee ID is provided","Your ID for the trainee.
+
+Can be blank if Trainee ID is provided.","Add your ID for the trainee you want to recommend.
 
 Can be blank if TRN is provided.","Add the date when the trainee met QTS or EYTS standards.
 Must be written DD/MM/YYYY. 

--- a/app/assets/downloads/recommendOnly-template.csv
+++ b/app/assets/downloads/recommendOnly-template.csv
@@ -1,7 +1,7 @@
 TRN,Provider trainee ID,Date standards met
-"Add the TRN for trainees you want to recommend.  Can be blank if Trainee ID is provided","Add the Trainee ID for trainees you want to recommend.
+"Add the TRN for trainees you want to recommend. Can be empty if Provider trainee ID is provided","Add your trainee ID for trainees you want to recommend.
 
-Can be left blank if TRN is provided","Add the date when the trainee met QTS or EYTS standards.
+Can be empty if TRN is provided","Add the date when the trainee met QTS or EYTS standards.
 Must be written DD/MM/YYYY. 
 For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.
 The date must be in the past.

--- a/app/assets/downloads/recommendOnly-template.csv
+++ b/app/assets/downloads/recommendOnly-template.csv
@@ -1,4 +1,4 @@
-TRN,Trainee ID,Date standards met
+TRN,Provider trainee ID,Date standards met
 "Add the TRN for trainees you want to recommend.  Can be blank if Trainee ID is provided","Add the Trainee ID for trainees you want to recommend.
 
 Can be left blank if TRN is provided","Add the date when the trainee met QTS or EYTS standards.

--- a/app/assets/downloads/recommendOnly-template.csv
+++ b/app/assets/downloads/recommendOnly-template.csv
@@ -1,9 +1,7 @@
 TRN,Trainee ID,Date standards met
-"Add the TRN for trainees you want to recommend.
+"Add the TRN for trainees you want to recommend.  Can be blank if Trainee ID is provided","Add the Trainee ID for trainees you want to recommend.
 
-Can be blank if Trainee ID is provided.","Add your ID for the trainee you want to recommend.
-
-Can be blank if TRN is provided.","Add the date when the trainee met QTS or EYTS standards.
+Can be left blank if TRN is provided","Add the date when the trainee met QTS or EYTS standards.
 Must be written DD/MM/YYYY. 
 For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.
 The date must be in the past.

--- a/app/assets/downloads/recommendOnly-with-data.csv
+++ b/app/assets/downloads/recommendOnly-with-data.csv
@@ -1,4 +1,4 @@
-TRN,Trainee ID,First names,Last names,Start academic year,Route and course,Date standards met
+TRN,Provider trainee ID,First names,Last names,Start academic year,Route and course,Date standards met
 "Must contain a trainee's TRN, or be empty.
 Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
 Delete or add trainees as necessary.",For reference only,For reference only,For reference only,"Add the date when the trainee met QTS or EYTS standards.

--- a/app/assets/downloads/recommendOnly-with-data.csv
+++ b/app/assets/downloads/recommendOnly-with-data.csv
@@ -1,6 +1,6 @@
 TRN,Provider trainee ID,Last names,First names,Start academic year,Route and course,Date standards met
 "Must contain a trainee's TRN, or be empty.
-Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
+Delete or add trainees as necessary.","Must contain your trainee ID or be empty.
 Delete or add trainees as necessary.",For reference only,For reference only,For reference only,For reference only,"Add the date when the trainee met QTS or EYTS standards.
 Must be written DD/MM/YYYY.
 For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.

--- a/app/assets/downloads/recommendOnly-with-data.csv
+++ b/app/assets/downloads/recommendOnly-with-data.csv
@@ -1,4 +1,4 @@
-TRN,Trainee ID,Trainee name,Start academic year,Route and course,Date standards met,
+TRN,Trainee ID,First names,Last names,Start academic year,Route and course,Date standards met
 "Must contain a trainee's TRN, or be empty.
 Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
 Delete or add trainees as necessary.",For reference only,For reference only,For reference only,"Add the date when the trainee met QTS or EYTS standards.
@@ -9,17 +9,17 @@ If the trainee has not met the QTS, leave the cell empty or delete the row.",
 6666531,GD6448,Jack,Abshire,2021 to 2022,"School direct (fee funded)
 Biology with chemistry",10/06/2022
 4912274,PD4888,Terrence,Altenwerth,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",08/03/2022
+Primary with physical education",25/02/2022
 1995355,BC3735,Al,Auer,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022
 7004997,XX4142,Angelo,Auer,2021 to 2022,"School direct (fee funded)
 Physical education",10/06/2022
 8260100,SK3817,Joanne,Aufderhar,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",10/05/2022
+Biology with chemistry",09/03/2022
 1069262,YM8630,June,Bailey,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022
 3417658,DN8645,Yolanda,Barrows,2021 to 2022,"Provider-led (postgrad)
-Design and technology",05/01/2022
+Design and technology",03/03/2022
 4078189,AC7745,Isaac,Barton,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022
 7900253,ST6988,Jose,Batz,2021 to 2022,"Provider-led (postgrad)
@@ -30,7 +30,7 @@ Italian",17/06/2022
 2732947,RS1429,Jaime,Beier,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022
 9837500,RN4482,Olive,Benoit,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",15/04/2022
+Physical education with physics",20/04/2022
 7851957,NH4668,Émeric,Bertrand,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022
 9956721,FC3909,Irving,Boehm,2021 to 2022,"Provider-led (postgrad)
@@ -43,7 +43,7 @@ Latin",10/06/2022
 Physical education with physics",10/06/2022
 4930476,EC6238,Laureline,Caron,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022
-6408379,LM5954,Eudoxe,Caron,2021 to 2022,Provider-led (undergrad),03/03/2022
+6408379,LM5954,Eudoxe,Caron,2021 to 2022,Provider-led (undergrad),09/03/2022
 8537680,YM1278,Raoul,Carpentier,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
 5751332,LP2348,Pearl,Champlin,2021 to 2022,"School direct (fee funded)
@@ -88,7 +88,7 @@ Physical education with physics",10/06/2022
 Latin",10/06/2022
 4371388,ZW8916,Aphélie,Garcia,2021 to 2022,Provider-led (undergrad),10/06/2022
 5843544,DG6419,Elena,Gibson,2021 to 2022,"Teaching apprenticeship (postgrad)
-Primary with mathematics",22/01/2022
+Primary with mathematics",11/05/2022
 3969536,HK1030,Byron,Gottlieb,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",10/06/2022
 9150187,HB3671,Isabelle,Guerin,2021 to 2022,"Provider-led (postgrad)
@@ -137,7 +137,7 @@ Modern languages",10/06/2022
 2177277,DQ8137,Oliver,Kovacek,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",24/06/2022
 4073732,QS6710,Vital,Lacroix,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",06/02/2022
+Biology with chemistry",05/02/2022
 5999712,LX1542,Christina,Langosh,2021 to 2022,"Provider-led (postgrad)
 Primary",10/06/2022
 9888335,AB9131,Fidèle,Laurent,2021 to 2022,"Provider-led (postgrad)
@@ -153,7 +153,7 @@ Design and technology",24/06/2022
 1484766,RB6215,Jessica,Lubowitz,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022
 6638309,GW6401,Antoinette,Lueilwitz,2021 to 2022,"Provider-led (postgrad)
-Latin",03/03/2022
+Latin",07/05/2022
 4236028,CR0592,Olive,Mante,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022
 5597817,CY1368,Marlène,Marie,2021 to 2022,"Provider-led (postgrad)
@@ -178,7 +178,7 @@ Design and technology",10/06/2022
 3860744,HT5730,Orlando,O'Reilly,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",10/06/2022
 8384234,BH1454,Annette,Pacocha,2021 to 2022,"Provider-led (postgrad)
-Latin",13/02/2022
+Latin",03/04/2022
 1204048,BH9051,Angélina,Perrot,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022
 6088600,NT0340,Léonne,Petit,2021 to 2022,"Provider-led (postgrad)
@@ -212,7 +212,7 @@ Latin",10/06/2022
 7311560,MN8220,Amalthée,Roger,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",10/06/2022
 1767139,CS1630,Kelly,Rolfson,2021 to 2022,"Teaching apprenticeship (postgrad)
-Biology with chemistry",08/03/2022
+Biology with chemistry",03/03/2022
 4966948,MD2264,Yolanda,Runolfsdottir,2021 to 2022,"Provider-led (postgrad)
 Modern languages",10/06/2022
 3081702,AM9800,Lee,Sawayn,2021 to 2022,Provider-led (undergrad),10/06/2022
@@ -221,7 +221,7 @@ Primary",24/06/2022
 2260987,NF7094,Jody,Schneider,2021 to 2022,"Provider-led (postgrad)
 Primary with physical education",10/06/2022
 2693809,DN2616,Mabel,Schroeder,2021 to 2022,"Provider-led (postgrad)
-Modern languages",18/04/2022
+Modern languages",26/01/2022
 8675815,TX1993,Gwen,Shields,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",10/06/2022
 1723973,DK3273,Alfred,Sipes,2021 to 2022,Provider-led (undergrad),24/06/2022
@@ -235,9 +235,9 @@ Design and technology",10/06/2022
 6423079,MC9068,Randal,Stracke,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",17/06/2022
 5609184,QH2562,Sheldon,Swaniawski,2021 to 2022,"School direct (fee funded)
-Primary",24/02/2022
+Primary",02/02/2022
 8802182,TC8129,Nathan,Swift,2021 to 2022,"Provider-led (postgrad)
-Latin",08/03/2022
+Latin",11/05/2022
 2008753,AT3764,Héloïse,Thomas,2021 to 2022,"Teaching apprenticeship (postgrad)
 Design and technology",10/06/2022
 5507441,LA5215,Drew,Tillman,2021 to 2022,"Provider-led (postgrad)

--- a/app/assets/downloads/recommendOnly-with-data.csv
+++ b/app/assets/downloads/recommendOnly-with-data.csv
@@ -1,252 +1,253 @@
-TRN,Start academic year,Route and course,Date standards met
-"Must contain a trainee's TRN. Delete or add trainees as necessary.
-TRNs must be 7 digits.",For reference only.,For reference only.,"Add the date when the trainee met QTS or EYTS standards.
+TRN,Trainee ID,Start academic year,Route and course,Date standards met
+"Must contain a trainee's TRN, or be empty.
+Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
+Delete or add trainees as necessary.",For reference only.,For reference only.,"Add the date when the trainee met QTS or EYTS standards.
 Must be written DD/MM/YYYY.
 For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.
 The date must be in the past.
 If the trainee has not met the QTS, leave the cell empty or delete the row."
-6666531,2021 to 2022,"School direct (fee funded)
+9837500,RN4482,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",22/05/2022
+5609184,QH2562,2021 to 2022,"School direct (fee funded)
+Primary",17/03/2022
+8273630,TM7395,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+7311560,MN8220,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",10/06/2022
-4912274,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",09/02/2022
-1995355,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022
-7004997,2021 to 2022,"School direct (fee funded)
-Physical education",17/06/2022
-8260100,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",24/06/2022
-1069262,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-3417658,2021 to 2022,"Provider-led (postgrad)
-Design and technology",03/02/2022
-4078189,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022
-7900253,2021 to 2022,"Provider-led (postgrad)
-Primary",17/06/2022
-5646510,2021 to 2022,"School direct (salaried)
-Italian",17/06/2022
-8744159,2021 to 2022,Provider-led (undergrad),24/06/2022
-2732947,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022
-9837500,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",12/02/2022
-7851957,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022
-9956721,2021 to 2022,"Provider-led (postgrad)
-Modern languages",10/06/2022
-4641293,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",24/06/2022
-5578493,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022
-8691476,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022
-4930476,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022
-6408379,2021 to 2022,Provider-led (undergrad),24/06/2022
-8537680,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022
-5751332,2021 to 2022,"School direct (fee funded)
-Primary",24/06/2022
-9719346,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022
-8457026,2021 to 2022,"School direct (salaried)
-Primary with modern languages",24/06/2022
-3904024,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-9457054,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022
-6896165,2021 to 2022,"School direct (fee funded)
+6896165,CG5580,2021 to 2022,"School direct (fee funded)
 Design and technology with English",24/06/2022
-8832625,2021 to 2022,"School direct (fee funded)
-Physical education",17/06/2022
-7999914,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-3007806,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022
-9410956,2021 to 2022,"Provider-led (postgrad)
+7009193,HH3355,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",10/06/2022
-1256500,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",24/06/2022
-8441731,2021 to 2022,"Provider-led (postgrad)
-Modern languages",10/06/2022
-3738544,2021 to 2022,"Provider-led (postgrad)
-Latin",17/06/2022
-2827462,2021 to 2022,Provider-led (undergrad),24/06/2022
-3073808,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",24/06/2022
-4700830,2021 to 2022,"Provider-led (postgrad)
-Modern languages",17/06/2022
-3379589,2021 to 2022,"School direct (salaried)
-Primary",17/06/2022
-5054746,2021 to 2022,"Provider-led (postgrad)
+9457054,RT7878,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+5054746,AW3371,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",17/06/2022
-4041145,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022
-8569621,2021 to 2022,Provider-led (undergrad),17/06/2022
-9055186,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-4371388,2021 to 2022,Provider-led (undergrad),10/06/2022
-5843544,2021 to 2022,"Teaching apprenticeship (postgrad)
-Primary with mathematics",24/06/2022
-3969536,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",10/06/2022
-9150187,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",10/06/2022
-7279498,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022
-1785167,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-7009193,2021 to 2022,"Provider-led (postgrad)
+8957378,GM5727,2021 to 2022,Provider-led (undergrad),10/06/2022
+4073732,QS6710,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",27/02/2022
+8675815,TX1993,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",10/06/2022
-4456200,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",24/06/2022
-8957378,2021 to 2022,Provider-led (undergrad),10/06/2022
-5598145,2021 to 2022,"Provider-led (postgrad)
+3960844,SH6489,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",17/06/2022
-2493764,2021 to 2022,"Provider-led (postgrad)
-Primary",17/06/2022
-9729520,2021 to 2022,"Provider-led (postgrad)
+7646286,WA3900,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022
+8832625,HD9024,2021 to 2022,"School direct (fee funded)
+Physical education",10/06/2022
+8668206,QW3812,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+9729520,BT0697,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",17/06/2022
-1455999,2021 to 2022,Provider-led (undergrad),24/06/2022
-8262628,2021 to 2022,"Provider-led (postgrad)
-Latin",17/06/2022
-2953057,2021 to 2022,"Provider-led (postgrad)
+6198842,TD9870,2021 to 2022,"Teaching apprenticeship (postgrad)
+Modern languages",10/06/2022
+5578493,XR1159,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+3379589,EM2761,2021 to 2022,"School direct (salaried)
+Primary",24/06/2022
+9800306,BE6825,2021 to 2022,Provider-led (undergrad),10/06/2022
+4930476,EC6238,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022
-5077067,2021 to 2022,Provider-led (undergrad),24/06/2022
-6861505,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022
-6784447,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022
-7769677,2021 to 2022,"School direct (fee funded)
-Physical education",17/06/2022
-8748026,2021 to 2022,"School direct (fee funded)
-Primary",17/06/2022
-9350282,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022
-6780890,2021 to 2022,"Provider-led (postgrad)
-Modern languages",10/06/2022
-4337728,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",10/06/2022
-3865944,2021 to 2022,"School direct (fee funded)
-Classics with English",10/06/2022
-9919650,2021 to 2022,"Provider-led (postgrad)
-Primary",17/06/2022
-6198842,2021 to 2022,"Teaching apprenticeship (postgrad)
-Modern languages",10/06/2022
-2177277,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",24/06/2022
-4073732,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",09/03/2022
-5999712,2021 to 2022,"Provider-led (postgrad)
+5061918,BE0921,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+8748026,CG8977,2021 to 2022,"School direct (fee funded)
 Primary",10/06/2022
-9888335,2021 to 2022,"Provider-led (postgrad)
+7900821,FM9996,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+2493764,EQ2692,2021 to 2022,"Provider-led (postgrad)
+Primary",17/06/2022
+9888335,AB9131,2021 to 2022,"Provider-led (postgrad)
 Primary with physical education",24/06/2022
-2086024,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",10/06/2022
-7646286,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022
-7882048,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-7347971,2021 to 2022,"Provider-led (postgrad)
+8260100,SK3817,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",22/05/2022
+3073808,QB3717,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",24/06/2022
+7347971,PY7485,2021 to 2022,"Provider-led (postgrad)
 Design and technology",24/06/2022
-1484766,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-6638309,2021 to 2022,"Provider-led (postgrad)
-Latin",14/04/2022
-4236028,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022
-5597817,2021 to 2022,"Provider-led (postgrad)
+7851957,NH4668,2021 to 2022,"Provider-led (postgrad)
+Latin",17/06/2022
+4912274,PD4888,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",03/05/2022
+3007806,LY3676,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022
-5410523,2021 to 2022,"Provider-led (postgrad)
+5410523,ZW5355,2021 to 2022,"Provider-led (postgrad)
 Design and technology",24/06/2022
-5536974,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022
-6851156,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022
-5617199,2021 to 2022,"Provider-led (postgrad)
+1389975,HB0070,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
-1389975,2021 to 2022,"Provider-led (postgrad)
+3329403,GC7042,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",10/06/2022
+2008753,AT3764,2021 to 2022,"Teaching apprenticeship (postgrad)
 Design and technology",10/06/2022
-4876485,2021 to 2022,Provider-led (undergrad),17/06/2022
-8215464,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-7900821,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022
-8273630,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-3860744,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",10/06/2022
-8384234,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022
-1204048,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022
-6088600,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022
-4185941,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022
-4828006,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",24/06/2022
-3329403,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",24/06/2022
-5684508,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-3232248,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-7371200,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022
-4922124,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-7109771,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-4817751,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",10/06/2022
-8668206,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022
-4788104,2021 to 2022,"Provider-led (postgrad)
-Modern languages",17/06/2022
-3960844,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",17/06/2022
-3889585,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-7311560,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",17/06/2022
-1767139,2021 to 2022,"Teaching apprenticeship (postgrad)
-Biology with chemistry",24/06/2022
-4966948,2021 to 2022,"Provider-led (postgrad)
+6780890,PM5795,2021 to 2022,"Provider-led (postgrad)
 Modern languages",10/06/2022
-3081702,2021 to 2022,Provider-led (undergrad),10/06/2022
-7030285,2021 to 2022,"Provider-led (postgrad)
-Primary",24/06/2022
-2260987,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",10/06/2022
-2693809,2021 to 2022,"Provider-led (postgrad)
-Modern languages",24/06/2022
-8675815,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",17/06/2022
-1723973,2021 to 2022,Provider-led (undergrad),24/06/2022
-7438582,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",10/06/2022
-3456627,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",24/06/2022
-9800306,2021 to 2022,Provider-led (undergrad),17/06/2022
-5061918,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022
-6423079,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",24/06/2022
-5609184,2021 to 2022,"School direct (fee funded)
-Primary",24/06/2022
-8802182,2021 to 2022,"Provider-led (postgrad)
+8262628,DS2628,2021 to 2022,"Provider-led (postgrad)
 Latin",24/06/2022
-2008753,2021 to 2022,"Teaching apprenticeship (postgrad)
+3860744,HT5730,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",10/06/2022
+7769677,HM3654,2021 to 2022,"School direct (fee funded)
+Physical education",10/06/2022
+5684508,XE4315,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+5597817,CY1368,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
-5507441,2021 to 2022,"Provider-led (postgrad)
-Modern languages",24/06/2022
-5536522,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",10/06/2022
-6146464,2021 to 2022,Opt-in (undergrad),24/06/2022
-2763733,2021 to 2022,"School direct (salaried)
-Music with art and design",24/06/2022
-8621661,2021 to 2022,"Provider-led (postgrad)
+3232248,BA0386,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+3904024,SK9525,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+5598145,ZZ0654,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",17/06/2022
-1715621,2021 to 2022,"Provider-led (postgrad)
+7438582,FY0149,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",10/06/2022
+8537680,YM1278,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+2732947,RS1429,2021 to 2022,"Provider-led (postgrad)
+Design and technology",17/06/2022
+1204048,BH9051,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022
+2763733,FM7612,2021 to 2022,"School direct (salaried)
+Music with art and design",24/06/2022
+4876485,TA1426,2021 to 2022,Provider-led (undergrad),10/06/2022
+4456200,SP9485,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",24/06/2022
+4966948,MD2264,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022
+6784447,SH2853,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022
+9956721,FC3909,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022
+9919650,PM7014,2021 to 2022,"Provider-led (postgrad)
+Primary",10/06/2022
+4922124,DS9993,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+7900253,ST6988,2021 to 2022,"Provider-led (postgrad)
+Primary",17/06/2022
+8384234,BH1454,2021 to 2022,"Provider-led (postgrad)
+Latin",12/03/2022
+1995355,BC3735,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022
+2177277,DQ8137,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",24/06/2022
+1069262,YM8630,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+2953057,YY3036,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+5536974,BB3367,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022
+4371388,ZW8916,2021 to 2022,Provider-led (undergrad),10/06/2022
+7004997,XX4142,2021 to 2022,"School direct (fee funded)
+Physical education",10/06/2022
+2086024,QD7026,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",10/06/2022
+4185941,YG1496,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+8457026,CH1495,2021 to 2022,"School direct (salaried)
+Primary with modern languages",24/06/2022
+5843544,DG6419,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary with mathematics",14/03/2022
+6146464,DL2085,2021 to 2022,Opt-in (undergrad),24/06/2022
+5617199,GY0902,2021 to 2022,"Provider-led (postgrad)
+Design and technology",17/06/2022
+1785167,NL7535,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+8215464,ER6952,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+4041145,RY2137,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022
+4700830,HG4569,2021 to 2022,"Provider-led (postgrad)
+Modern languages",17/06/2022
+8569621,WX3307,2021 to 2022,Provider-led (undergrad),10/06/2022
+3081702,AM9800,2021 to 2022,Provider-led (undergrad),10/06/2022
+5536522,MR6798,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",10/06/2022
+5646510,RC3608,2021 to 2022,"School direct (salaried)
+Italian",17/06/2022
+6851156,EY3088,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022
+9719346,PB6404,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022
+7030285,EX9838,2021 to 2022,"Provider-led (postgrad)
+Primary",24/06/2022
+4337728,SH0505,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",10/06/2022
+8691476,DM8266,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022
+6638309,GW6401,2021 to 2022,"Provider-led (postgrad)
+Latin",19/04/2022
+6666531,GD6448,2021 to 2022,"School direct (fee funded)
+Biology with chemistry",10/06/2022
+2260987,NF7094,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",10/06/2022
+6861505,LY4803,2021 to 2022,"Provider-led (postgrad)
+Latin",17/06/2022
+1767139,CS1630,2021 to 2022,"Teaching apprenticeship (postgrad)
+Biology with chemistry",22/02/2022
+2693809,DN2616,2021 to 2022,"Provider-led (postgrad)
+Modern languages",11/05/2022
+3456627,EK8893,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",24/06/2022
+1715621,LT5293,2021 to 2022,"Provider-led (postgrad)
+Primary",17/06/2022
+6088600,NT0340,2021 to 2022,"Provider-led (postgrad)
+Design and technology",17/06/2022
+1484766,RB6215,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+6423079,MC9068,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",17/06/2022
+3969536,HK1030,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",10/06/2022
+7279498,RT3004,2021 to 2022,"Provider-led (postgrad)
+Design and technology",24/06/2022
+7999914,DQ9717,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+9410956,AF9403,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",10/06/2022
+9350282,MH3891,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022
+8441731,GM2375,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022
+4817751,NL3209,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",10/06/2022
+1723973,DK3273,2021 to 2022,Provider-led (undergrad),24/06/2022
+8744159,HL2974,2021 to 2022,Provider-led (undergrad),24/06/2022
+5507441,LA5215,2021 to 2022,"Provider-led (postgrad)
+Modern languages",24/06/2022
+7109771,WF0871,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+7371200,CS3377,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022
+6408379,LM5954,2021 to 2022,Provider-led (undergrad),04/05/2022
+9150187,HB3671,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",10/06/2022
+3889585,WW9157,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+3865944,GX0521,2021 to 2022,"School direct (fee funded)
+Classics with English",10/06/2022
+7882048,FW4161,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+2827462,CN4219,2021 to 2022,Provider-led (undergrad),24/06/2022
+1455999,BK4097,2021 to 2022,Provider-led (undergrad),24/06/2022
+3417658,DN8645,2021 to 2022,"Provider-led (postgrad)
+Design and technology",21/05/2022
+1256500,MQ9676,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",24/06/2022
+4828006,YK9994,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",24/06/2022
+9055186,GG9603,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+8621661,GE6621,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",17/06/2022
+4641293,QB7031,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",17/06/2022
+5077067,WP3275,2021 to 2022,Provider-led (undergrad),24/06/2022
+3738544,NZ7230,2021 to 2022,"Provider-led (postgrad)
+Latin",17/06/2022
+4788104,AD8428,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022
+5999712,LX1542,2021 to 2022,"Provider-led (postgrad)
+Primary",10/06/2022
+8802182,TC8129,2021 to 2022,"Provider-led (postgrad)
+Latin",06/03/2022
+4236028,CR0592,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022
+4078189,AC7745,2021 to 2022,"Provider-led (postgrad)
+Latin",17/06/2022
+5751332,LP2348,2021 to 2022,"School direct (fee funded)
 Primary",17/06/2022

--- a/app/assets/downloads/recommendOnly-with-data.csv
+++ b/app/assets/downloads/recommendOnly-with-data.csv
@@ -1,253 +1,253 @@
-TRN,Provider trainee ID,First names,Last names,Start academic year,Route and course,Date standards met
+TRN,Provider trainee ID,Last names,First names,Start academic year,Route and course,Date standards met
 "Must contain a trainee's TRN, or be empty.
 Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
-Delete or add trainees as necessary.",For reference only,For reference only,For reference only,"Add the date when the trainee met QTS or EYTS standards.
+Delete or add trainees as necessary.",For reference only,For reference only,For reference only,For reference only,"Add the date when the trainee met QTS or EYTS standards.
 Must be written DD/MM/YYYY.
 For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.
 The date must be in the past.
-If the trainee has not met the QTS, leave the cell empty or delete the row.",
-6666531,GD6448,Jack,Abshire,2021 to 2022,"School direct (fee funded)
+If the trainee has not met the QTS, leave the cell empty or delete the row."
+6666531,GD6448,Abshire,Jack,2021 to 2022,"School direct (fee funded)
 Biology with chemistry",10/06/2022
-4912274,PD4888,Terrence,Altenwerth,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",25/02/2022
-1995355,BC3735,Al,Auer,2021 to 2022,"Provider-led (postgrad)
+4912274,PD4888,Altenwerth,Terrence,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",22/01/2022
+1995355,BC3735,Auer,Al,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022
-7004997,XX4142,Angelo,Auer,2021 to 2022,"School direct (fee funded)
+7004997,XX4142,Auer,Angelo,2021 to 2022,"School direct (fee funded)
 Physical education",10/06/2022
-8260100,SK3817,Joanne,Aufderhar,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",09/03/2022
-1069262,YM8630,June,Bailey,2021 to 2022,"Provider-led (postgrad)
+8260100,SK3817,Aufderhar,Joanne,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",03/02/2022
+1069262,YM8630,Bailey,June,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022
-3417658,DN8645,Yolanda,Barrows,2021 to 2022,"Provider-led (postgrad)
-Design and technology",03/03/2022
-4078189,AC7745,Isaac,Barton,2021 to 2022,"Provider-led (postgrad)
+3417658,DN8645,Barrows,Yolanda,2021 to 2022,"Provider-led (postgrad)
+Design and technology",04/03/2022
+4078189,AC7745,Barton,Isaac,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022
-7900253,ST6988,Jose,Batz,2021 to 2022,"Provider-led (postgrad)
+7900253,ST6988,Batz,Jose,2021 to 2022,"Provider-led (postgrad)
 Primary",17/06/2022
-5646510,RC3608,Rafael,Beatty,2021 to 2022,"School direct (salaried)
+5646510,RC3608,Beatty,Rafael,2021 to 2022,"School direct (salaried)
 Italian",17/06/2022
-8744159,HL2974,Lester,Beer,2021 to 2022,Provider-led (undergrad),24/06/2022
-2732947,RS1429,Jaime,Beier,2021 to 2022,"Provider-led (postgrad)
+8744159,HL2974,Beer,Lester,2021 to 2022,Provider-led (undergrad),24/06/2022
+2732947,RS1429,Beier,Jaime,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022
-9837500,RN4482,Olive,Benoit,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",20/04/2022
-7851957,NH4668,Émeric,Bertrand,2021 to 2022,"Provider-led (postgrad)
+9837500,RN4482,Benoit,Olive,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",26/01/2022
+7851957,NH4668,Bertrand,Émeric,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022
-9956721,FC3909,Irving,Boehm,2021 to 2022,"Provider-led (postgrad)
+9956721,FC3909,Boehm,Irving,2021 to 2022,"Provider-led (postgrad)
 Modern languages",10/06/2022
-4641293,QB7031,Mario,Borer,2021 to 2022,"Provider-led (postgrad)
+4641293,QB7031,Borer,Mario,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",17/06/2022
-5578493,XR1159,Doris,Botsford,2021 to 2022,"Provider-led (postgrad)
+5578493,XR1159,Botsford,Doris,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022
-8691476,DM8266,Vickie,Bradtke,2021 to 2022,"Provider-led (postgrad)
+8691476,DM8266,Bradtke,Vickie,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022
-4930476,EC6238,Laureline,Caron,2021 to 2022,"Provider-led (postgrad)
+4930476,EC6238,Caron,Laureline,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022
-6408379,LM5954,Eudoxe,Caron,2021 to 2022,Provider-led (undergrad),09/03/2022
-8537680,YM1278,Raoul,Carpentier,2021 to 2022,"Provider-led (postgrad)
+6408379,LM5954,Caron,Eudoxe,2021 to 2022,Provider-led (undergrad),20/04/2022
+8537680,YM1278,Carpentier,Raoul,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
-5751332,LP2348,Pearl,Champlin,2021 to 2022,"School direct (fee funded)
+5751332,LP2348,Champlin,Pearl,2021 to 2022,"School direct (fee funded)
 Primary",17/06/2022
-9719346,PB6404,Christine,Chevalier,2021 to 2022,"Provider-led (postgrad)
+9719346,PB6404,Chevalier,Christine,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022
-8457026,CH1495,Gary,Collier,2021 to 2022,"School direct (salaried)
+8457026,CH1495,Collier,Gary,2021 to 2022,"School direct (salaried)
 Primary with modern languages",24/06/2022
-3904024,SK9525,Patty,Collins,2021 to 2022,"Provider-led (postgrad)
+3904024,SK9525,Collins,Patty,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022
-9457054,RT7878,Francisco,Considine,2021 to 2022,"Provider-led (postgrad)
+9457054,RT7878,Considine,Francisco,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
-6896165,CG5580,Alcyone,Da silva,2021 to 2022,"School direct (fee funded)
+6896165,CG5580,Da silva,Alcyone,2021 to 2022,"School direct (fee funded)
 Design and technology with English",24/06/2022
-8832625,HD9024,Max,Deckow,2021 to 2022,"School direct (fee funded)
+8832625,HD9024,Deckow,Max,2021 to 2022,"School direct (fee funded)
 Physical education",10/06/2022
-7999914,DQ9717,Carla,Deckow,2021 to 2022,"Provider-led (postgrad)
+7999914,DQ9717,Deckow,Carla,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
-3007806,LY3676,Shannon,Dickens,2021 to 2022,"Provider-led (postgrad)
+3007806,LY3676,Dickens,Shannon,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022
-9410956,AF9403,Omar,Donnelly,2021 to 2022,"Provider-led (postgrad)
+9410956,AF9403,Donnelly,Omar,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",10/06/2022
-1256500,MQ9676,Lucien,Dupuis,2021 to 2022,"Provider-led (postgrad)
+1256500,MQ9676,Dupuis,Lucien,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",24/06/2022
-8441731,GM2375,Gene,Durgan,2021 to 2022,"Provider-led (postgrad)
+8441731,GM2375,Durgan,Gene,2021 to 2022,"Provider-led (postgrad)
 Modern languages",10/06/2022
-3738544,NZ7230,Jacqueline,Durgan,2021 to 2022,"Provider-led (postgrad)
+3738544,NZ7230,Durgan,Jacqueline,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022
-2827462,CN4219,Julia,Erdman,2021 to 2022,Provider-led (undergrad),24/06/2022
-3073808,QB3717,Theresa,Fahey,2021 to 2022,"Provider-led (postgrad)
+2827462,CN4219,Erdman,Julia,2021 to 2022,Provider-led (undergrad),24/06/2022
+3073808,QB3717,Fahey,Theresa,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",24/06/2022
-4700830,HG4569,Marion,Flatley,2021 to 2022,"Provider-led (postgrad)
+4700830,HG4569,Flatley,Marion,2021 to 2022,"Provider-led (postgrad)
 Modern languages",17/06/2022
-3379589,EM2761,Angélina,Fournier,2021 to 2022,"School direct (salaried)
+3379589,EM2761,Fournier,Angélina,2021 to 2022,"School direct (salaried)
 Primary",24/06/2022
-5054746,AW3371,Margie,Frami,2021 to 2022,"Provider-led (postgrad)
+5054746,AW3371,Frami,Margie,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",17/06/2022
-4041145,RY2137,Lorena,Franey,2021 to 2022,"Provider-led (postgrad)
+4041145,RY2137,Franey,Lorena,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022
-8569621,WX3307,Mamie,Funk,2021 to 2022,Provider-led (undergrad),10/06/2022
-9055186,GG9603,Margarita,Funk,2021 to 2022,"Provider-led (postgrad)
+8569621,WX3307,Funk,Mamie,2021 to 2022,Provider-led (undergrad),10/06/2022
+9055186,GG9603,Funk,Margarita,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022
-4371388,ZW8916,Aphélie,Garcia,2021 to 2022,Provider-led (undergrad),10/06/2022
-5843544,DG6419,Elena,Gibson,2021 to 2022,"Teaching apprenticeship (postgrad)
-Primary with mathematics",11/05/2022
-3969536,HK1030,Byron,Gottlieb,2021 to 2022,"Provider-led (postgrad)
+4371388,ZW8916,Garcia,Aphélie,2021 to 2022,Provider-led (undergrad),10/06/2022
+5843544,DG6419,Gibson,Elena,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary with mathematics",14/03/2022
+3969536,HK1030,Gottlieb,Byron,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",10/06/2022
-9150187,HB3671,Isabelle,Guerin,2021 to 2022,"Provider-led (postgrad)
+9150187,HB3671,Guerin,Isabelle,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",10/06/2022
-7279498,RT3004,Blake,Gulgowski,2021 to 2022,"Provider-led (postgrad)
+7279498,RT3004,Gulgowski,Blake,2021 to 2022,"Provider-led (postgrad)
 Design and technology",24/06/2022
-1785167,NL7535,Alison,Hagenes,2021 to 2022,"Provider-led (postgrad)
+1785167,NL7535,Hagenes,Alison,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
-7009193,HH3355,Rodney,Halvorson,2021 to 2022,"Provider-led (postgrad)
+7009193,HH3355,Halvorson,Rodney,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",10/06/2022
-4456200,SP9485,Woodrow,Hartmann,2021 to 2022,"Provider-led (postgrad)
+4456200,SP9485,Hartmann,Woodrow,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",24/06/2022
-8957378,GM5727,Benny,Harvey,2021 to 2022,Provider-led (undergrad),10/06/2022
-5598145,ZZ0654,Stuart,Hauck,2021 to 2022,"Provider-led (postgrad)
+8957378,GM5727,Harvey,Benny,2021 to 2022,Provider-led (undergrad),10/06/2022
+5598145,ZZ0654,Hauck,Stuart,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",17/06/2022
-2493764,EQ2692,Kim,Heathcote,2021 to 2022,"Provider-led (postgrad)
+2493764,EQ2692,Heathcote,Kim,2021 to 2022,"Provider-led (postgrad)
 Primary",17/06/2022
-9729520,BT0697,Nick,Heller,2021 to 2022,"Provider-led (postgrad)
+9729520,BT0697,Heller,Nick,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",17/06/2022
-1455999,BK4097,Jacquelyn,Herman,2021 to 2022,Provider-led (undergrad),24/06/2022
-8262628,DS2628,Phyllis,Hermann,2021 to 2022,"Provider-led (postgrad)
+1455999,BK4097,Herman,Jacquelyn,2021 to 2022,Provider-led (undergrad),24/06/2022
+8262628,DS2628,Hermann,Phyllis,2021 to 2022,"Provider-led (postgrad)
 Latin",24/06/2022
-2953057,YY3036,Cameron,Hermann,2021 to 2022,"Provider-led (postgrad)
+2953057,YY3036,Hermann,Cameron,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
-5077067,WP3275,Brandy,Hilll,2021 to 2022,Provider-led (undergrad),24/06/2022
-6861505,LY4803,Edna,Hills,2021 to 2022,"Provider-led (postgrad)
+5077067,WP3275,Hilll,Brandy,2021 to 2022,Provider-led (undergrad),24/06/2022
+6861505,LY4803,Hills,Edna,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022
-6784447,SH2853,Katrina,Hodkiewicz,2021 to 2022,"Provider-led (postgrad)
+6784447,SH2853,Hodkiewicz,Katrina,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022
-7769677,HM3654,Patti,Jacobson,2021 to 2022,"School direct (fee funded)
+7769677,HM3654,Jacobson,Patti,2021 to 2022,"School direct (fee funded)
 Physical education",10/06/2022
-8748026,CG8977,Quiéta,Jacquet,2021 to 2022,"School direct (fee funded)
+8748026,CG8977,Jacquet,Quiéta,2021 to 2022,"School direct (fee funded)
 Primary",10/06/2022
-9350282,MH3891,Terry,Jast,2021 to 2022,"Provider-led (postgrad)
+9350282,MH3891,Jast,Terry,2021 to 2022,"Provider-led (postgrad)
 Latin",24/06/2022
-6780890,PM5795,Randall,Kerluke,2021 to 2022,"Provider-led (postgrad)
+6780890,PM5795,Kerluke,Randall,2021 to 2022,"Provider-led (postgrad)
 Modern languages",10/06/2022
-4337728,SH0505,Grant,Kirlin,2021 to 2022,"Provider-led (postgrad)
+4337728,SH0505,Kirlin,Grant,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",10/06/2022
-3865944,GX0521,Merle,Klocko,2021 to 2022,"School direct (fee funded)
+3865944,GX0521,Klocko,Merle,2021 to 2022,"School direct (fee funded)
 Classics with English",10/06/2022
-9919650,PM7014,Winston,Kohler,2021 to 2022,"Provider-led (postgrad)
+9919650,PM7014,Kohler,Winston,2021 to 2022,"Provider-led (postgrad)
 Primary",10/06/2022
-6198842,TD9870,Kerry,Konopelski,2021 to 2022,"Teaching apprenticeship (postgrad)
+6198842,TD9870,Konopelski,Kerry,2021 to 2022,"Teaching apprenticeship (postgrad)
 Modern languages",10/06/2022
-2177277,DQ8137,Oliver,Kovacek,2021 to 2022,"Provider-led (postgrad)
+2177277,DQ8137,Kovacek,Oliver,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",24/06/2022
-4073732,QS6710,Vital,Lacroix,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",05/02/2022
-5999712,LX1542,Christina,Langosh,2021 to 2022,"Provider-led (postgrad)
+4073732,QS6710,Lacroix,Vital,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",02/05/2022
+5999712,LX1542,Langosh,Christina,2021 to 2022,"Provider-led (postgrad)
 Primary",10/06/2022
-9888335,AB9131,Fidèle,Laurent,2021 to 2022,"Provider-led (postgrad)
+9888335,AB9131,Laurent,Fidèle,2021 to 2022,"Provider-led (postgrad)
 Primary with physical education",24/06/2022
-2086024,QD7026,Sylvie,Laurent,2021 to 2022,"Provider-led (postgrad)
+2086024,QD7026,Laurent,Sylvie,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",10/06/2022
-7646286,WA3900,Whitney,Lehner,2021 to 2022,"Provider-led (postgrad)
+7646286,WA3900,Lehner,Whitney,2021 to 2022,"Provider-led (postgrad)
 Latin",24/06/2022
-7882048,FW4161,Victorin,Lemaire,2021 to 2022,"Provider-led (postgrad)
+7882048,FW4161,Lemaire,Victorin,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
-7347971,PY7485,Stanislas,Lemoine,2021 to 2022,"Provider-led (postgrad)
+7347971,PY7485,Lemoine,Stanislas,2021 to 2022,"Provider-led (postgrad)
 Design and technology",24/06/2022
-1484766,RB6215,Jessica,Lubowitz,2021 to 2022,"Provider-led (postgrad)
+1484766,RB6215,Lubowitz,Jessica,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022
-6638309,GW6401,Antoinette,Lueilwitz,2021 to 2022,"Provider-led (postgrad)
-Latin",07/05/2022
-4236028,CR0592,Olive,Mante,2021 to 2022,"Provider-led (postgrad)
+6638309,GW6401,Lueilwitz,Antoinette,2021 to 2022,"Provider-led (postgrad)
+Latin",07/03/2022
+4236028,CR0592,Mante,Olive,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022
-5597817,CY1368,Marlène,Marie,2021 to 2022,"Provider-led (postgrad)
+5597817,CY1368,Marie,Marlène,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
-5410523,ZW5355,Aliette,Meunier,2021 to 2022,"Provider-led (postgrad)
+5410523,ZW5355,Meunier,Aliette,2021 to 2022,"Provider-led (postgrad)
 Design and technology",24/06/2022
-5536974,BB3367,Moses,Miller,2021 to 2022,"Provider-led (postgrad)
+5536974,BB3367,Miller,Moses,2021 to 2022,"Provider-led (postgrad)
 Latin",24/06/2022
-6851156,EY3088,Victor,Mills,2021 to 2022,"Provider-led (postgrad)
+6851156,EY3088,Mills,Victor,2021 to 2022,"Provider-led (postgrad)
 Latin",24/06/2022
-5617199,GY0902,Arthaud,Moreau,2021 to 2022,"Provider-led (postgrad)
+5617199,GY0902,Moreau,Arthaud,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022
-1389975,HB0070,Amber,Mosciski,2021 to 2022,"Provider-led (postgrad)
+1389975,HB0070,Mosciski,Amber,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
-4876485,TA1426,Ora,Mosciski,2021 to 2022,Provider-led (undergrad),10/06/2022
-8215464,ER6952,Cassien,Moulin,2021 to 2022,"Provider-led (postgrad)
+4876485,TA1426,Mosciski,Ora,2021 to 2022,Provider-led (undergrad),10/06/2022
+8215464,ER6952,Moulin,Cassien,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
-7900821,FM9996,David,Nitzsche,2021 to 2022,"Provider-led (postgrad)
+7900821,FM9996,Nitzsche,David,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
-8273630,TM7395,Aubrey,O'Kon,2021 to 2022,"Provider-led (postgrad)
+8273630,TM7395,O'Kon,Aubrey,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
-3860744,HT5730,Orlando,O'Reilly,2021 to 2022,"Provider-led (postgrad)
+3860744,HT5730,O'Reilly,Orlando,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",10/06/2022
-8384234,BH1454,Annette,Pacocha,2021 to 2022,"Provider-led (postgrad)
-Latin",03/04/2022
-1204048,BH9051,Angélina,Perrot,2021 to 2022,"Provider-led (postgrad)
+8384234,BH1454,Pacocha,Annette,2021 to 2022,"Provider-led (postgrad)
+Latin",04/03/2022
+1204048,BH9051,Perrot,Angélina,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022
-6088600,NT0340,Léonne,Petit,2021 to 2022,"Provider-led (postgrad)
+6088600,NT0340,Petit,Léonne,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022
-4185941,YG1496,Saul,Pfannerstill,2021 to 2022,"Provider-led (postgrad)
+4185941,YG1496,Pfannerstill,Saul,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
-4828006,YK9994,Harold,Pfeffer,2021 to 2022,"Provider-led (postgrad)
+4828006,YK9994,Pfeffer,Harold,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",24/06/2022
-3329403,GC7042,Erik,Pollich,2021 to 2022,"Provider-led (postgrad)
+3329403,GC7042,Pollich,Erik,2021 to 2022,"Provider-led (postgrad)
 Primary with physical education",10/06/2022
-5684508,XE4315,Martha,Pouros,2021 to 2022,"Provider-led (postgrad)
+5684508,XE4315,Pouros,Martha,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022
-3232248,BA0386,Germaine,Prevost,2021 to 2022,"Provider-led (postgrad)
+3232248,BA0386,Prevost,Germaine,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022
-7371200,CS3377,Annabelle,Prevost,2021 to 2022,"Provider-led (postgrad)
+7371200,CS3377,Prevost,Annabelle,2021 to 2022,"Provider-led (postgrad)
 Latin",24/06/2022
-4922124,DS9993,Pat,Rempel,2021 to 2022,"Provider-led (postgrad)
+4922124,DS9993,Rempel,Pat,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022
-7109771,WF0871,Avigaëlle,Remy,2021 to 2022,"Provider-led (postgrad)
+7109771,WF0871,Remy,Avigaëlle,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022
-4817751,NL3209,Céleste,Renaud,2021 to 2022,"Provider-led (postgrad)
+4817751,NL3209,Renaud,Céleste,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",10/06/2022
-8668206,QW3812,Russell,Renner,2021 to 2022,"Provider-led (postgrad)
+8668206,QW3812,Renner,Russell,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
-4788104,AD8428,Gautier,Rey,2021 to 2022,"Provider-led (postgrad)
+4788104,AD8428,Rey,Gautier,2021 to 2022,"Provider-led (postgrad)
 Modern languages",10/06/2022
-3960844,SH6489,Gatien,Robert,2021 to 2022,"Provider-led (postgrad)
+3960844,SH6489,Robert,Gatien,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",17/06/2022
-3889585,WW9157,Daphné,Robert,2021 to 2022,"Provider-led (postgrad)
+3889585,WW9157,Robert,Daphné,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022
-7311560,MN8220,Amalthée,Roger,2021 to 2022,"Provider-led (postgrad)
+7311560,MN8220,Roger,Amalthée,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",10/06/2022
-1767139,CS1630,Kelly,Rolfson,2021 to 2022,"Teaching apprenticeship (postgrad)
-Biology with chemistry",03/03/2022
-4966948,MD2264,Yolanda,Runolfsdottir,2021 to 2022,"Provider-led (postgrad)
+1767139,CS1630,Rolfson,Kelly,2021 to 2022,"Teaching apprenticeship (postgrad)
+Biology with chemistry",24/02/2022
+4966948,MD2264,Runolfsdottir,Yolanda,2021 to 2022,"Provider-led (postgrad)
 Modern languages",10/06/2022
-3081702,AM9800,Lee,Sawayn,2021 to 2022,Provider-led (undergrad),10/06/2022
-7030285,EX9838,Andre,Schaefer,2021 to 2022,"Provider-led (postgrad)
+3081702,AM9800,Sawayn,Lee,2021 to 2022,Provider-led (undergrad),10/06/2022
+7030285,EX9838,Schaefer,Andre,2021 to 2022,"Provider-led (postgrad)
 Primary",24/06/2022
-2260987,NF7094,Jody,Schneider,2021 to 2022,"Provider-led (postgrad)
+2260987,NF7094,Schneider,Jody,2021 to 2022,"Provider-led (postgrad)
 Primary with physical education",10/06/2022
-2693809,DN2616,Mabel,Schroeder,2021 to 2022,"Provider-led (postgrad)
-Modern languages",26/01/2022
-8675815,TX1993,Gwen,Shields,2021 to 2022,"Provider-led (postgrad)
+2693809,DN2616,Schroeder,Mabel,2021 to 2022,"Provider-led (postgrad)
+Modern languages",09/04/2022
+8675815,TX1993,Shields,Gwen,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",10/06/2022
-1723973,DK3273,Alfred,Sipes,2021 to 2022,Provider-led (undergrad),24/06/2022
-7438582,FY0149,Rogelio,Stanton,2021 to 2022,"Provider-led (postgrad)
+1723973,DK3273,Sipes,Alfred,2021 to 2022,Provider-led (undergrad),24/06/2022
+7438582,FY0149,Stanton,Rogelio,2021 to 2022,"Provider-led (postgrad)
 Primary with physical education",10/06/2022
-3456627,EK8893,Carol,Stark,2021 to 2022,"Provider-led (postgrad)
+3456627,EK8893,Stark,Carol,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",24/06/2022
-9800306,BE6825,Dwight,Steuber,2021 to 2022,Provider-led (undergrad),10/06/2022
-5061918,BE0921,Victor,Stoltenberg,2021 to 2022,"Provider-led (postgrad)
+9800306,BE6825,Steuber,Dwight,2021 to 2022,Provider-led (undergrad),10/06/2022
+5061918,BE0921,Stoltenberg,Victor,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022
-6423079,MC9068,Randal,Stracke,2021 to 2022,"Provider-led (postgrad)
+6423079,MC9068,Stracke,Randal,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",17/06/2022
-5609184,QH2562,Sheldon,Swaniawski,2021 to 2022,"School direct (fee funded)
-Primary",02/02/2022
-8802182,TC8129,Nathan,Swift,2021 to 2022,"Provider-led (postgrad)
-Latin",11/05/2022
-2008753,AT3764,Héloïse,Thomas,2021 to 2022,"Teaching apprenticeship (postgrad)
+5609184,QH2562,Swaniawski,Sheldon,2021 to 2022,"School direct (fee funded)
+Primary",11/04/2022
+8802182,TC8129,Swift,Nathan,2021 to 2022,"Provider-led (postgrad)
+Latin",08/05/2022
+2008753,AT3764,Thomas,Héloïse,2021 to 2022,"Teaching apprenticeship (postgrad)
 Design and technology",10/06/2022
-5507441,LA5215,Drew,Tillman,2021 to 2022,"Provider-led (postgrad)
+5507441,LA5215,Tillman,Drew,2021 to 2022,"Provider-led (postgrad)
 Modern languages",24/06/2022
-5536522,MR6798,Ethel,Volkman,2021 to 2022,"Provider-led (postgrad)
+5536522,MR6798,Volkman,Ethel,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",10/06/2022
-6146464,DL2085,Max,Von,2021 to 2022,Opt-in (undergrad),24/06/2022
-2763733,FM7612,Winston,Walsh,2021 to 2022,"School direct (salaried)
+6146464,DL2085,Von,Max,2021 to 2022,Opt-in (undergrad),24/06/2022
+2763733,FM7612,Walsh,Winston,2021 to 2022,"School direct (salaried)
 Music with art and design",24/06/2022
-8621661,GE6621,Jimmie,Wuckert,2021 to 2022,"Provider-led (postgrad)
+8621661,GE6621,Wuckert,Jimmie,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",17/06/2022
-1715621,LT5293,Luke,Wyman,2021 to 2022,"Provider-led (postgrad)
+1715621,LT5293,Wyman,Luke,2021 to 2022,"Provider-led (postgrad)
 Primary",17/06/2022

--- a/app/assets/downloads/recommendOnly-with-data.csv
+++ b/app/assets/downloads/recommendOnly-with-data.csv
@@ -1,253 +1,253 @@
-TRN,Trainee ID,Start academic year,Route and course,Date standards met
+TRN,Trainee ID,Trainee name,Start academic year,Route and course,Date standards met,
 "Must contain a trainee's TRN, or be empty.
 Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
-Delete or add trainees as necessary.",For reference only.,For reference only.,"Add the date when the trainee met QTS or EYTS standards.
+Delete or add trainees as necessary.",For reference only,For reference only,For reference only,"Add the date when the trainee met QTS or EYTS standards.
 Must be written DD/MM/YYYY.
 For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.
 The date must be in the past.
-If the trainee has not met the QTS, leave the cell empty or delete the row."
-9837500,RN4482,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",22/05/2022
-5609184,QH2562,2021 to 2022,"School direct (fee funded)
-Primary",17/03/2022
-8273630,TM7395,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-7311560,MN8220,2021 to 2022,"Provider-led (postgrad)
+If the trainee has not met the QTS, leave the cell empty or delete the row.",
+6666531,GD6448,Jack,Abshire,2021 to 2022,"School direct (fee funded)
 Biology with chemistry",10/06/2022
-6896165,CG5580,2021 to 2022,"School direct (fee funded)
-Design and technology with English",24/06/2022
-7009193,HH3355,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",10/06/2022
-9457054,RT7878,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-5054746,AW3371,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",17/06/2022
-8957378,GM5727,2021 to 2022,Provider-led (undergrad),10/06/2022
-4073732,QS6710,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",27/02/2022
-8675815,TX1993,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",10/06/2022
-3960844,SH6489,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",17/06/2022
-7646286,WA3900,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022
-8832625,HD9024,2021 to 2022,"School direct (fee funded)
+4912274,PD4888,Terrence,Altenwerth,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",08/03/2022
+1995355,BC3735,Al,Auer,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022
+7004997,XX4142,Angelo,Auer,2021 to 2022,"School direct (fee funded)
 Physical education",10/06/2022
-8668206,QW3812,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-9729520,BT0697,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",17/06/2022
-6198842,TD9870,2021 to 2022,"Teaching apprenticeship (postgrad)
-Modern languages",10/06/2022
-5578493,XR1159,2021 to 2022,"Provider-led (postgrad)
+8260100,SK3817,Joanne,Aufderhar,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",10/05/2022
+1069262,YM8630,June,Bailey,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022
-3379589,EM2761,2021 to 2022,"School direct (salaried)
-Primary",24/06/2022
-9800306,BE6825,2021 to 2022,Provider-led (undergrad),10/06/2022
-4930476,EC6238,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022
-5061918,BE0921,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-8748026,CG8977,2021 to 2022,"School direct (fee funded)
-Primary",10/06/2022
-7900821,FM9996,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-2493764,EQ2692,2021 to 2022,"Provider-led (postgrad)
-Primary",17/06/2022
-9888335,AB9131,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",24/06/2022
-8260100,SK3817,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",22/05/2022
-3073808,QB3717,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",24/06/2022
-7347971,PY7485,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022
-7851957,NH4668,2021 to 2022,"Provider-led (postgrad)
+3417658,DN8645,Yolanda,Barrows,2021 to 2022,"Provider-led (postgrad)
+Design and technology",05/01/2022
+4078189,AC7745,Isaac,Barton,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022
-4912274,PD4888,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",03/05/2022
-3007806,LY3676,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022
-5410523,ZW5355,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022
-1389975,HB0070,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-3329403,GC7042,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",10/06/2022
-2008753,AT3764,2021 to 2022,"Teaching apprenticeship (postgrad)
-Design and technology",10/06/2022
-6780890,PM5795,2021 to 2022,"Provider-led (postgrad)
-Modern languages",10/06/2022
-8262628,DS2628,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022
-3860744,HT5730,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",10/06/2022
-7769677,HM3654,2021 to 2022,"School direct (fee funded)
-Physical education",10/06/2022
-5684508,XE4315,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-5597817,CY1368,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-3232248,BA0386,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-3904024,SK9525,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-5598145,ZZ0654,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",17/06/2022
-7438582,FY0149,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",10/06/2022
-8537680,YM1278,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-2732947,RS1429,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022
-1204048,BH9051,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022
-2763733,FM7612,2021 to 2022,"School direct (salaried)
-Music with art and design",24/06/2022
-4876485,TA1426,2021 to 2022,Provider-led (undergrad),10/06/2022
-4456200,SP9485,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",24/06/2022
-4966948,MD2264,2021 to 2022,"Provider-led (postgrad)
-Modern languages",10/06/2022
-6784447,SH2853,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022
-9956721,FC3909,2021 to 2022,"Provider-led (postgrad)
-Modern languages",10/06/2022
-9919650,PM7014,2021 to 2022,"Provider-led (postgrad)
-Primary",10/06/2022
-4922124,DS9993,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-7900253,ST6988,2021 to 2022,"Provider-led (postgrad)
+7900253,ST6988,Jose,Batz,2021 to 2022,"Provider-led (postgrad)
 Primary",17/06/2022
-8384234,BH1454,2021 to 2022,"Provider-led (postgrad)
-Latin",12/03/2022
-1995355,BC3735,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022
-2177277,DQ8137,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",24/06/2022
-1069262,YM8630,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-2953057,YY3036,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-5536974,BB3367,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022
-4371388,ZW8916,2021 to 2022,Provider-led (undergrad),10/06/2022
-7004997,XX4142,2021 to 2022,"School direct (fee funded)
-Physical education",10/06/2022
-2086024,QD7026,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",10/06/2022
-4185941,YG1496,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-8457026,CH1495,2021 to 2022,"School direct (salaried)
-Primary with modern languages",24/06/2022
-5843544,DG6419,2021 to 2022,"Teaching apprenticeship (postgrad)
-Primary with mathematics",14/03/2022
-6146464,DL2085,2021 to 2022,Opt-in (undergrad),24/06/2022
-5617199,GY0902,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022
-1785167,NL7535,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-8215464,ER6952,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-4041145,RY2137,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022
-4700830,HG4569,2021 to 2022,"Provider-led (postgrad)
-Modern languages",17/06/2022
-8569621,WX3307,2021 to 2022,Provider-led (undergrad),10/06/2022
-3081702,AM9800,2021 to 2022,Provider-led (undergrad),10/06/2022
-5536522,MR6798,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",10/06/2022
-5646510,RC3608,2021 to 2022,"School direct (salaried)
+5646510,RC3608,Rafael,Beatty,2021 to 2022,"School direct (salaried)
 Italian",17/06/2022
-6851156,EY3088,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022
-9719346,PB6404,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022
-7030285,EX9838,2021 to 2022,"Provider-led (postgrad)
-Primary",24/06/2022
-4337728,SH0505,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",10/06/2022
-8691476,DM8266,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022
-6638309,GW6401,2021 to 2022,"Provider-led (postgrad)
-Latin",19/04/2022
-6666531,GD6448,2021 to 2022,"School direct (fee funded)
-Biology with chemistry",10/06/2022
-2260987,NF7094,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",10/06/2022
-6861505,LY4803,2021 to 2022,"Provider-led (postgrad)
-Latin",17/06/2022
-1767139,CS1630,2021 to 2022,"Teaching apprenticeship (postgrad)
-Biology with chemistry",22/02/2022
-2693809,DN2616,2021 to 2022,"Provider-led (postgrad)
-Modern languages",11/05/2022
-3456627,EK8893,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",24/06/2022
-1715621,LT5293,2021 to 2022,"Provider-led (postgrad)
-Primary",17/06/2022
-6088600,NT0340,2021 to 2022,"Provider-led (postgrad)
+8744159,HL2974,Lester,Beer,2021 to 2022,Provider-led (undergrad),24/06/2022
+2732947,RS1429,Jaime,Beier,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022
-1484766,RB6215,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-6423079,MC9068,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",17/06/2022
-3969536,HK1030,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",10/06/2022
-7279498,RT3004,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022
-7999914,DQ9717,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-9410956,AF9403,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",10/06/2022
-9350282,MH3891,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022
-8441731,GM2375,2021 to 2022,"Provider-led (postgrad)
-Modern languages",10/06/2022
-4817751,NL3209,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",10/06/2022
-1723973,DK3273,2021 to 2022,Provider-led (undergrad),24/06/2022
-8744159,HL2974,2021 to 2022,Provider-led (undergrad),24/06/2022
-5507441,LA5215,2021 to 2022,"Provider-led (postgrad)
-Modern languages",24/06/2022
-7109771,WF0871,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-7371200,CS3377,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022
-6408379,LM5954,2021 to 2022,Provider-led (undergrad),04/05/2022
-9150187,HB3671,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",10/06/2022
-3889585,WW9157,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-3865944,GX0521,2021 to 2022,"School direct (fee funded)
-Classics with English",10/06/2022
-7882048,FW4161,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022
-2827462,CN4219,2021 to 2022,Provider-led (undergrad),24/06/2022
-1455999,BK4097,2021 to 2022,Provider-led (undergrad),24/06/2022
-3417658,DN8645,2021 to 2022,"Provider-led (postgrad)
-Design and technology",21/05/2022
-1256500,MQ9676,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",24/06/2022
-4828006,YK9994,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",24/06/2022
-9055186,GG9603,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022
-8621661,GE6621,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",17/06/2022
-4641293,QB7031,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",17/06/2022
-5077067,WP3275,2021 to 2022,Provider-led (undergrad),24/06/2022
-3738544,NZ7230,2021 to 2022,"Provider-led (postgrad)
+9837500,RN4482,Olive,Benoit,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",15/04/2022
+7851957,NH4668,Émeric,Bertrand,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022
-4788104,AD8428,2021 to 2022,"Provider-led (postgrad)
+9956721,FC3909,Irving,Boehm,2021 to 2022,"Provider-led (postgrad)
 Modern languages",10/06/2022
-5999712,LX1542,2021 to 2022,"Provider-led (postgrad)
-Primary",10/06/2022
-8802182,TC8129,2021 to 2022,"Provider-led (postgrad)
-Latin",06/03/2022
-4236028,CR0592,2021 to 2022,"Provider-led (postgrad)
+4641293,QB7031,Mario,Borer,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",17/06/2022
+5578493,XR1159,Doris,Botsford,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+8691476,DM8266,Vickie,Bradtke,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022
-4078189,AC7745,2021 to 2022,"Provider-led (postgrad)
+4930476,EC6238,Laureline,Caron,2021 to 2022,"Provider-led (postgrad)
+Design and technology",17/06/2022
+6408379,LM5954,Eudoxe,Caron,2021 to 2022,Provider-led (undergrad),03/03/2022
+8537680,YM1278,Raoul,Carpentier,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+5751332,LP2348,Pearl,Champlin,2021 to 2022,"School direct (fee funded)
+Primary",17/06/2022
+9719346,PB6404,Christine,Chevalier,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022
+8457026,CH1495,Gary,Collier,2021 to 2022,"School direct (salaried)
+Primary with modern languages",24/06/2022
+3904024,SK9525,Patty,Collins,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+9457054,RT7878,Francisco,Considine,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+6896165,CG5580,Alcyone,Da silva,2021 to 2022,"School direct (fee funded)
+Design and technology with English",24/06/2022
+8832625,HD9024,Max,Deckow,2021 to 2022,"School direct (fee funded)
+Physical education",10/06/2022
+7999914,DQ9717,Carla,Deckow,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+3007806,LY3676,Shannon,Dickens,2021 to 2022,"Provider-led (postgrad)
+Design and technology",17/06/2022
+9410956,AF9403,Omar,Donnelly,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",10/06/2022
+1256500,MQ9676,Lucien,Dupuis,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",24/06/2022
+8441731,GM2375,Gene,Durgan,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022
+3738544,NZ7230,Jacqueline,Durgan,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022
-5751332,LP2348,2021 to 2022,"School direct (fee funded)
+2827462,CN4219,Julia,Erdman,2021 to 2022,Provider-led (undergrad),24/06/2022
+3073808,QB3717,Theresa,Fahey,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",24/06/2022
+4700830,HG4569,Marion,Flatley,2021 to 2022,"Provider-led (postgrad)
+Modern languages",17/06/2022
+3379589,EM2761,Angélina,Fournier,2021 to 2022,"School direct (salaried)
+Primary",24/06/2022
+5054746,AW3371,Margie,Frami,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",17/06/2022
+4041145,RY2137,Lorena,Franey,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022
+8569621,WX3307,Mamie,Funk,2021 to 2022,Provider-led (undergrad),10/06/2022
+9055186,GG9603,Margarita,Funk,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+4371388,ZW8916,Aphélie,Garcia,2021 to 2022,Provider-led (undergrad),10/06/2022
+5843544,DG6419,Elena,Gibson,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary with mathematics",22/01/2022
+3969536,HK1030,Byron,Gottlieb,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",10/06/2022
+9150187,HB3671,Isabelle,Guerin,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",10/06/2022
+7279498,RT3004,Blake,Gulgowski,2021 to 2022,"Provider-led (postgrad)
+Design and technology",24/06/2022
+1785167,NL7535,Alison,Hagenes,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+7009193,HH3355,Rodney,Halvorson,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",10/06/2022
+4456200,SP9485,Woodrow,Hartmann,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",24/06/2022
+8957378,GM5727,Benny,Harvey,2021 to 2022,Provider-led (undergrad),10/06/2022
+5598145,ZZ0654,Stuart,Hauck,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",17/06/2022
+2493764,EQ2692,Kim,Heathcote,2021 to 2022,"Provider-led (postgrad)
+Primary",17/06/2022
+9729520,BT0697,Nick,Heller,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",17/06/2022
+1455999,BK4097,Jacquelyn,Herman,2021 to 2022,Provider-led (undergrad),24/06/2022
+8262628,DS2628,Phyllis,Hermann,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022
+2953057,YY3036,Cameron,Hermann,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+5077067,WP3275,Brandy,Hilll,2021 to 2022,Provider-led (undergrad),24/06/2022
+6861505,LY4803,Edna,Hills,2021 to 2022,"Provider-led (postgrad)
+Latin",17/06/2022
+6784447,SH2853,Katrina,Hodkiewicz,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022
+7769677,HM3654,Patti,Jacobson,2021 to 2022,"School direct (fee funded)
+Physical education",10/06/2022
+8748026,CG8977,Quiéta,Jacquet,2021 to 2022,"School direct (fee funded)
+Primary",10/06/2022
+9350282,MH3891,Terry,Jast,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022
+6780890,PM5795,Randall,Kerluke,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022
+4337728,SH0505,Grant,Kirlin,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",10/06/2022
+3865944,GX0521,Merle,Klocko,2021 to 2022,"School direct (fee funded)
+Classics with English",10/06/2022
+9919650,PM7014,Winston,Kohler,2021 to 2022,"Provider-led (postgrad)
+Primary",10/06/2022
+6198842,TD9870,Kerry,Konopelski,2021 to 2022,"Teaching apprenticeship (postgrad)
+Modern languages",10/06/2022
+2177277,DQ8137,Oliver,Kovacek,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",24/06/2022
+4073732,QS6710,Vital,Lacroix,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",06/02/2022
+5999712,LX1542,Christina,Langosh,2021 to 2022,"Provider-led (postgrad)
+Primary",10/06/2022
+9888335,AB9131,Fidèle,Laurent,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",24/06/2022
+2086024,QD7026,Sylvie,Laurent,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",10/06/2022
+7646286,WA3900,Whitney,Lehner,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022
+7882048,FW4161,Victorin,Lemaire,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+7347971,PY7485,Stanislas,Lemoine,2021 to 2022,"Provider-led (postgrad)
+Design and technology",24/06/2022
+1484766,RB6215,Jessica,Lubowitz,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+6638309,GW6401,Antoinette,Lueilwitz,2021 to 2022,"Provider-led (postgrad)
+Latin",03/03/2022
+4236028,CR0592,Olive,Mante,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022
+5597817,CY1368,Marlène,Marie,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+5410523,ZW5355,Aliette,Meunier,2021 to 2022,"Provider-led (postgrad)
+Design and technology",24/06/2022
+5536974,BB3367,Moses,Miller,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022
+6851156,EY3088,Victor,Mills,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022
+5617199,GY0902,Arthaud,Moreau,2021 to 2022,"Provider-led (postgrad)
+Design and technology",17/06/2022
+1389975,HB0070,Amber,Mosciski,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+4876485,TA1426,Ora,Mosciski,2021 to 2022,Provider-led (undergrad),10/06/2022
+8215464,ER6952,Cassien,Moulin,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+7900821,FM9996,David,Nitzsche,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+8273630,TM7395,Aubrey,O'Kon,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+3860744,HT5730,Orlando,O'Reilly,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",10/06/2022
+8384234,BH1454,Annette,Pacocha,2021 to 2022,"Provider-led (postgrad)
+Latin",13/02/2022
+1204048,BH9051,Angélina,Perrot,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022
+6088600,NT0340,Léonne,Petit,2021 to 2022,"Provider-led (postgrad)
+Design and technology",17/06/2022
+4185941,YG1496,Saul,Pfannerstill,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+4828006,YK9994,Harold,Pfeffer,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",24/06/2022
+3329403,GC7042,Erik,Pollich,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",10/06/2022
+5684508,XE4315,Martha,Pouros,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+3232248,BA0386,Germaine,Prevost,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+7371200,CS3377,Annabelle,Prevost,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022
+4922124,DS9993,Pat,Rempel,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+7109771,WF0871,Avigaëlle,Remy,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+4817751,NL3209,Céleste,Renaud,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",10/06/2022
+8668206,QW3812,Russell,Renner,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+4788104,AD8428,Gautier,Rey,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022
+3960844,SH6489,Gatien,Robert,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",17/06/2022
+3889585,WW9157,Daphné,Robert,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022
+7311560,MN8220,Amalthée,Roger,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",10/06/2022
+1767139,CS1630,Kelly,Rolfson,2021 to 2022,"Teaching apprenticeship (postgrad)
+Biology with chemistry",08/03/2022
+4966948,MD2264,Yolanda,Runolfsdottir,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022
+3081702,AM9800,Lee,Sawayn,2021 to 2022,Provider-led (undergrad),10/06/2022
+7030285,EX9838,Andre,Schaefer,2021 to 2022,"Provider-led (postgrad)
+Primary",24/06/2022
+2260987,NF7094,Jody,Schneider,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",10/06/2022
+2693809,DN2616,Mabel,Schroeder,2021 to 2022,"Provider-led (postgrad)
+Modern languages",18/04/2022
+8675815,TX1993,Gwen,Shields,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",10/06/2022
+1723973,DK3273,Alfred,Sipes,2021 to 2022,Provider-led (undergrad),24/06/2022
+7438582,FY0149,Rogelio,Stanton,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",10/06/2022
+3456627,EK8893,Carol,Stark,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",24/06/2022
+9800306,BE6825,Dwight,Steuber,2021 to 2022,Provider-led (undergrad),10/06/2022
+5061918,BE0921,Victor,Stoltenberg,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022
+6423079,MC9068,Randal,Stracke,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",17/06/2022
+5609184,QH2562,Sheldon,Swaniawski,2021 to 2022,"School direct (fee funded)
+Primary",24/02/2022
+8802182,TC8129,Nathan,Swift,2021 to 2022,"Provider-led (postgrad)
+Latin",08/03/2022
+2008753,AT3764,Héloïse,Thomas,2021 to 2022,"Teaching apprenticeship (postgrad)
+Design and technology",10/06/2022
+5507441,LA5215,Drew,Tillman,2021 to 2022,"Provider-led (postgrad)
+Modern languages",24/06/2022
+5536522,MR6798,Ethel,Volkman,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",10/06/2022
+6146464,DL2085,Max,Von,2021 to 2022,Opt-in (undergrad),24/06/2022
+2763733,FM7612,Winston,Walsh,2021 to 2022,"School direct (salaried)
+Music with art and design",24/06/2022
+8621661,GE6621,Jimmie,Wuckert,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",17/06/2022
+1715621,LT5293,Luke,Wyman,2021 to 2022,"Provider-led (postgrad)
 Primary",17/06/2022

--- a/app/assets/downloads/recommendOnly-with-errors.csv
+++ b/app/assets/downloads/recommendOnly-with-errors.csv
@@ -1,253 +1,253 @@
-TRN,Trainee ID,Start academic year,Route and course,Date standards met,Error
+TRN,Trainee ID,Trainee name,Start academic year,Route and course,Date standards met,Error,
 "Must contain a trainee's TRN, or be empty.
 Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
-Delete or add trainees as necessary.",For reference only.,For reference only.,"Add the date when the trainee met QTS or EYTS standards.
+Delete or add trainees as necessary.",For reference only,For reference only,For reference only,"Add the date when the trainee met QTS or EYTS standards.
 Must be written DD/MM/YYYY.
 For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.
 The date must be in the past.
-If the trainee has not met the QTS, leave the cell empty or delete the row.",For reference only.
-9837500,RN4482,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",22/05/2022,
-5609184,QH2562,2021 to 2022,"School direct (fee funded)
-Primary",17/03/2022,
-8273630,TM7395,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-7311560,MN8220,2021 to 2022,"Provider-led (postgrad)
+If the trainee has not met the QTS, leave the cell empty or delete the row.",For reference only.,
+6666531,GD6448,Jack,Abshire,2021 to 2022,"School direct (fee funded)
 Biology with chemistry",10/06/2022,
-6896165,CG5580,2021 to 2022,"School direct (fee funded)
-Design and technology with English",24/06/2022,
-7009193,HH3355,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",10/06/2022,
-9457054,RT7878,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-5054746,AW3371,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",17/06/2022,
-8957378,GM5727,2021 to 2022,Provider-led (undergrad),10/06/2022,
-4073732,QS6710,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",27/02/2022,
-8675815,TX1993,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",20/09/2023,Date standards met: '20/09/2023' - date standards met must be in the past
-3960844,SH6489,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",17/06/2022,
-7646286,WA3900,2021 to 2022,"Provider-led (postgrad)
-Latin",20/09/2023,Date standards met: '20/09/2023' - date standards met must be in the past
-8832625,HD9024,2021 to 2022,"School direct (fee funded)
+4912274,PD4888,Terrence,Altenwerth,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",08/03/2022,
+1995355,BC3735,Al,Auer,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022,
+7004997,XX4142,Angelo,Auer,2021 to 2022,"School direct (fee funded)
 Physical education",10/06/2022,
-8668206,QW3812,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-9729520,BT0697,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",17/06/2022,
-6198842,TD9870,2021 to 2022,"Teaching apprenticeship (postgrad)
-Modern languages",10/06/2022,
-5578493,XR1159,2021 to 2022,"Provider-led (postgrad)
+8260100,SK3817,Joanne,Aufderhar,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",10/05/2022,TRN and Trainee ID are not for the same trainee
+1069262,YM8630,June,Bailey,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022,
-3379589,EM2761,2021 to 2022,"School direct (salaried)
-Primary",24/06/2022,
-9800306,BE6825,2021 to 2022,Provider-led (undergrad),10/06/2022,
-4930476,EC6238,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022,
-5061918,BE0921,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-8748026,CG8977,2021 to 2022,"School direct (fee funded)
-Primary",10/06/2022,
-7900821,FM9996,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-2493764,EQ2692,2021 to 2022,"Provider-led (postgrad)
-Primary",17/06/2022,
-9888335,AB9131,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",24/06/2022,
-8260100,SK3817,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",22/05/2022,TRN and Trainee ID are not for the same trainee
-3073808,QB3717,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",24/06/2022,
-7347971,PY7485,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022,
-7851957,NH4668,2021 to 2022,"Provider-led (postgrad)
+3417658,DN8645,Yolanda,Barrows,2021 to 2022,"Provider-led (postgrad)
+Design and technology",05/01/2022,
+4078189,AC7745,Isaac,Barton,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022,
-4912274,PD4888,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",03/05/2022,
-3007806,LY3676,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022,
-5410523,ZW5355,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022,Date standards met provided without a TRN or Trainee ID - add a TRN or Trainee ID or remove the date standards met
-1389975,HB0070,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-3329403,GC7042,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",10/06/2022,
-2008753,AT3764,2021 to 2022,"Teaching apprenticeship (postgrad)
-Design and technology",10/06/2022,
-6780890,PM5795,2021 to 2022,"Provider-led (postgrad)
-Modern languages",10/06/2022,
-8262628,DS2628,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022,
-3860744,HT5730,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",10/06/2022,
-7769677,HM3654,2021 to 2022,"School direct (fee funded)
-Physical education",10/06/2022,
-5684508,XE4315,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-5597817,CY1368,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-3232248,BA0386,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-3904024,SK9525,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-5598145,ZZ0654,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",17/06/2022,
-7438582,FY0149,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",10/06/2022,
-8537680,YM1278,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-2732947,RS1429,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022,
-1204048,BH9051,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022,
-2763733,FM7612,2021 to 2022,"School direct (salaried)
-Music with art and design",24/06/2022,
-4876485,TA1426,2021 to 2022,Provider-led (undergrad),10/06/2022,
-4456200,SP9485,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",24/06/2022,
-4966948,MD2264,2021 to 2022,"Provider-led (postgrad)
-Modern languages",10/06/2022,
-6784447,SH2853,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022,
-9956721,FC3909,2021 to 2022,"Provider-led (postgrad)
-Modern languages",10/06/2022,
-9919650,PM7014,2021 to 2022,"Provider-led (postgrad)
-Primary",10/06/2022,
-4922124,DS9993,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-7900253,ST6988,2021 to 2022,"Provider-led (postgrad)
+7900253,ST6988,Jose,Batz,2021 to 2022,"Provider-led (postgrad)
 Primary",17/06/2022,
-8384234,BH1454,2021 to 2022,"Provider-led (postgrad)
-Latin",12/03/2022,
-1995355,BC3735,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022,
-2177277,DQ8137,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",24/06/2022,
-1069262,YM8630,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-2953057,YY3036,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-5536974,BB3367,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022,
-4371388,ZW8916,2021 to 2022,Provider-led (undergrad),10/06/2022,
-7004997,XX4142,2021 to 2022,"School direct (fee funded)
-Physical education",10/06/2022,
-2086024,QD7026,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",10/06/2022,
-4185941,YG1496,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-8457026,CH1495,2021 to 2022,"School direct (salaried)
-Primary with modern languages",24/06/2022,
-5843544,DG6419,2021 to 2022,"Teaching apprenticeship (postgrad)
-Primary with mathematics",14/03/2022,
-6146464,DL2085,2021 to 2022,Opt-in (undergrad),24/06/2022,Date standards met provided without a TRN or Trainee ID - add a TRN or Trainee ID or remove the date standards met
-5617199,GY0902,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022,
-1785167,NL7535,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-8215464,ER6952,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-4041145,RY2137,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022,
-4700830,HG4569,2021 to 2022,"Provider-led (postgrad)
-Modern languages",17/06/2022,
-8569621,WX3307,2021 to 2022,Provider-led (undergrad),10/06/2022,
-3081702,AM9800,2021 to 2022,Provider-led (undergrad),10/06/2022,
-5536522,MR6798,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",10/06/2022,
-5646510,RC3608,2021 to 2022,"School direct (salaried)
+5646510,RC3608,Rafael,Beatty,2021 to 2022,"School direct (salaried)
 Italian",17/06/2022,
-6851156,EY3088,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022,
-9719346,PB6404,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022,
-7030285,EX9838,2021 to 2022,"Provider-led (postgrad)
-Primary",24/06/2022,
-4337728,SH0505,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",10/06/2022,
-8691476,DM8266,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022,
-6638309,GW6401,2021 to 2022,"Provider-led (postgrad)
-Latin",19/04/2022,
-6666531,GD6448,2021 to 2022,"School direct (fee funded)
-Biology with chemistry",10/06/2022,
-2260987,NF7094,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",10/06/2022,
-6861505,LY4803,2021 to 2022,"Provider-led (postgrad)
-Latin",17/06/2022,
-1767139,CS1630,2021 to 2022,"Teaching apprenticeship (postgrad)
-Biology with chemistry",22/02/2022,
-2693809,DN2616,2021 to 2022,"Provider-led (postgrad)
-Modern languages",11/05/2022,
-3456627,EK8893,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",24/06/2022,
-1715621,LT5293,2021 to 2022,"Provider-led (postgrad)
-Primary",17/06/2022,
-6088600,NT0340,2021 to 2022,"Provider-led (postgrad)
+8744159,HL2974,Lester,Beer,2021 to 2022,Provider-led (undergrad),24/06/2022,
+2732947,RS1429,Jaime,Beier,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022,
-1484766,RB6215,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-6423079,MC9068,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",17/06/2022,
-3969536,HK1030,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",10/06/2022,
-7279498,RT3004,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022,
-7999914,DQ9717,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-9410956,AF9403,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",10/06/2022,
-9350282,MH3891,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022,
-8441731,GM2375,2021 to 2022,"Provider-led (postgrad)
-Modern languages",10/06/2022,
-4817751,NL3209,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",10/06/2022,
-1723973,DK3273,2021 to 2022,Provider-led (undergrad),24/06/2022,
-8744159,HL2974,2021 to 2022,Provider-led (undergrad),24/06/2022,
-5507441,LA5215,2021 to 2022,"Provider-led (postgrad)
-Modern languages",24/06/2022,
-7109771,WF0871,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-7371200,CS3377,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022,
-6408379,LM5954,2021 to 2022,Provider-led (undergrad),04/05/2022,
-9150187,HB3671,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",10/06/2022,
-3889585,WW9157,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-3865944,GX0521,2021 to 2022,"School direct (fee funded)
-Classics with English",10/06/2022,
-7882048,FW4161,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-2827462,CN4219,2021 to 2022,Provider-led (undergrad),24/06/2022,
-1455999,BK4097,2021 to 2022,Provider-led (undergrad),24/06/2022,
-3417658,DN8645,2021 to 2022,"Provider-led (postgrad)
-Design and technology",21/05/2022,
-1256500,MQ9676,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",24/06/2022,
-4828006,YK9994,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",24/06/2022,
-9055186,GG9603,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-8621661,GE6621,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",17/06/2022,
-4641293,QB7031,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",17/06/2022,
-5077067,WP3275,2021 to 2022,Provider-led (undergrad),24/06/2022,
-3738544,NZ7230,2021 to 2022,"Provider-led (postgrad)
+9837500,RN4482,Olive,Benoit,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",15/04/2022,
+7851957,NH4668,Émeric,Bertrand,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022,
-4788104,AD8428,2021 to 2022,"Provider-led (postgrad)
+9956721,FC3909,Irving,Boehm,2021 to 2022,"Provider-led (postgrad)
 Modern languages",10/06/2022,
-5999712,LX1542,2021 to 2022,"Provider-led (postgrad)
-Primary",10/06/2022,
-8802182,TC8129,2021 to 2022,"Provider-led (postgrad)
-Latin",06/03/2022,
-4236028,CR0592,2021 to 2022,"Provider-led (postgrad)
+4641293,QB7031,Mario,Borer,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",17/06/2022,
+5578493,XR1159,Doris,Botsford,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+8691476,DM8266,Vickie,Bradtke,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022,
-4078189,AC7745,2021 to 2022,"Provider-led (postgrad)
+4930476,EC6238,Laureline,Caron,2021 to 2022,"Provider-led (postgrad)
+Design and technology",17/06/2022,
+6408379,LM5954,Eudoxe,Caron,2021 to 2022,Provider-led (undergrad),03/03/2022,
+8537680,YM1278,Raoul,Carpentier,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+5751332,LP2348,Pearl,Champlin,2021 to 2022,"School direct (fee funded)
+Primary",17/06/2022,
+9719346,PB6404,Christine,Chevalier,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022,
+8457026,CH1495,Gary,Collier,2021 to 2022,"School direct (salaried)
+Primary with modern languages",24/06/2022,
+3904024,SK9525,Patty,Collins,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+9457054,RT7878,Francisco,Considine,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+6896165,CG5580,Alcyone,Da silva,2021 to 2022,"School direct (fee funded)
+Design and technology with English",24/06/2022,
+8832625,HD9024,Max,Deckow,2021 to 2022,"School direct (fee funded)
+Physical education",10/06/2022,
+7999914,DQ9717,Carla,Deckow,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+3007806,LY3676,Shannon,Dickens,2021 to 2022,"Provider-led (postgrad)
+Design and technology",17/06/2022,
+9410956,AF9403,Omar,Donnelly,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",10/06/2022,
+1256500,MQ9676,Lucien,Dupuis,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",24/06/2022,
+8441731,GM2375,Gene,Durgan,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022,
+3738544,NZ7230,Jacqueline,Durgan,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022,
-5751332,LP2348,2021 to 2022,"School direct (fee funded)
+2827462,CN4219,Julia,Erdman,2021 to 2022,Provider-led (undergrad),24/06/2022,
+3073808,QB3717,Theresa,Fahey,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",24/06/2022,
+4700830,HG4569,Marion,Flatley,2021 to 2022,"Provider-led (postgrad)
+Modern languages",17/06/2022,
+3379589,EM2761,Angélina,Fournier,2021 to 2022,"School direct (salaried)
+Primary",24/06/2022,
+5054746,AW3371,Margie,Frami,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",17/06/2022,
+4041145,RY2137,Lorena,Franey,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022,
+8569621,WX3307,Mamie,Funk,2021 to 2022,Provider-led (undergrad),10/06/2022,
+9055186,GG9603,Margarita,Funk,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+4371388,ZW8916,Aphélie,Garcia,2021 to 2022,Provider-led (undergrad),10/06/2022,
+5843544,DG6419,Elena,Gibson,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary with mathematics",22/01/2022,
+3969536,HK1030,Byron,Gottlieb,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",10/06/2022,
+9150187,HB3671,Isabelle,Guerin,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",10/06/2022,
+7279498,RT3004,Blake,Gulgowski,2021 to 2022,"Provider-led (postgrad)
+Design and technology",24/06/2022,
+1785167,NL7535,Alison,Hagenes,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+7009193,HH3355,Rodney,Halvorson,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",10/06/2022,
+4456200,SP9485,Woodrow,Hartmann,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",24/06/2022,
+8957378,GM5727,Benny,Harvey,2021 to 2022,Provider-led (undergrad),10/06/2022,
+5598145,ZZ0654,Stuart,Hauck,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",17/06/2022,
+2493764,EQ2692,Kim,Heathcote,2021 to 2022,"Provider-led (postgrad)
+Primary",17/06/2022,
+9729520,BT0697,Nick,Heller,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",17/06/2022,
+1455999,BK4097,Jacquelyn,Herman,2021 to 2022,Provider-led (undergrad),24/06/2022,
+8262628,DS2628,Phyllis,Hermann,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022,
+2953057,YY3036,Cameron,Hermann,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+5077067,WP3275,Brandy,Hilll,2021 to 2022,Provider-led (undergrad),24/06/2022,
+6861505,LY4803,Edna,Hills,2021 to 2022,"Provider-led (postgrad)
+Latin",17/06/2022,
+6784447,SH2853,Katrina,Hodkiewicz,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022,
+7769677,HM3654,Patti,Jacobson,2021 to 2022,"School direct (fee funded)
+Physical education",10/06/2022,
+8748026,CG8977,Quiéta,Jacquet,2021 to 2022,"School direct (fee funded)
+Primary",10/06/2022,
+9350282,MH3891,Terry,Jast,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022,
+6780890,PM5795,Randall,Kerluke,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022,
+4337728,SH0505,Grant,Kirlin,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",10/06/2022,
+3865944,GX0521,Merle,Klocko,2021 to 2022,"School direct (fee funded)
+Classics with English",10/06/2022,
+9919650,PM7014,Winston,Kohler,2021 to 2022,"Provider-led (postgrad)
+Primary",10/06/2022,
+6198842,TD9870,Kerry,Konopelski,2021 to 2022,"Teaching apprenticeship (postgrad)
+Modern languages",10/06/2022,
+2177277,DQ8137,Oliver,Kovacek,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",24/06/2022,
+4073732,QS6710,Vital,Lacroix,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",06/02/2022,
+5999712,LX1542,Christina,Langosh,2021 to 2022,"Provider-led (postgrad)
+Primary",10/06/2022,
+9888335,AB9131,Fidèle,Laurent,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",24/06/2022,
+2086024,QD7026,Sylvie,Laurent,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",10/06/2022,
+7646286,WA3900,Whitney,Lehner,2021 to 2022,"Provider-led (postgrad)
+Latin",20/09/2023,Date standards met: '20/09/2023' - date standards met must be in the past
+7882048,FW4161,Victorin,Lemaire,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+7347971,PY7485,Stanislas,Lemoine,2021 to 2022,"Provider-led (postgrad)
+Design and technology",24/06/2022,
+1484766,RB6215,Jessica,Lubowitz,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+6638309,GW6401,Antoinette,Lueilwitz,2021 to 2022,"Provider-led (postgrad)
+Latin",03/03/2022,
+4236028,CR0592,Olive,Mante,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022,
+5597817,CY1368,Marlène,Marie,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+5410523,ZW5355,Aliette,Meunier,2021 to 2022,"Provider-led (postgrad)
+Design and technology",24/06/2022,Date standards met provided without a TRN or Trainee ID - add a TRN or Trainee ID or remove the date standards met
+5536974,BB3367,Moses,Miller,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022,
+6851156,EY3088,Victor,Mills,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022,
+5617199,GY0902,Arthaud,Moreau,2021 to 2022,"Provider-led (postgrad)
+Design and technology",17/06/2022,
+1389975,HB0070,Amber,Mosciski,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+4876485,TA1426,Ora,Mosciski,2021 to 2022,Provider-led (undergrad),10/06/2022,
+8215464,ER6952,Cassien,Moulin,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+7900821,FM9996,David,Nitzsche,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+8273630,TM7395,Aubrey,O'Kon,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+3860744,HT5730,Orlando,O'Reilly,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",10/06/2022,
+8384234,BH1454,Annette,Pacocha,2021 to 2022,"Provider-led (postgrad)
+Latin",13/02/2022,
+1204048,BH9051,Angélina,Perrot,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022,
+6088600,NT0340,Léonne,Petit,2021 to 2022,"Provider-led (postgrad)
+Design and technology",17/06/2022,
+4185941,YG1496,Saul,Pfannerstill,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+4828006,YK9994,Harold,Pfeffer,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",24/06/2022,
+3329403,GC7042,Erik,Pollich,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",10/06/2022,
+5684508,XE4315,Martha,Pouros,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+3232248,BA0386,Germaine,Prevost,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+7371200,CS3377,Annabelle,Prevost,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022,
+4922124,DS9993,Pat,Rempel,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+7109771,WF0871,Avigaëlle,Remy,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+4817751,NL3209,Céleste,Renaud,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",10/06/2022,
+8668206,QW3812,Russell,Renner,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+4788104,AD8428,Gautier,Rey,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022,
+3960844,SH6489,Gatien,Robert,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",17/06/2022,
+3889585,WW9157,Daphné,Robert,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+7311560,MN8220,Amalthée,Roger,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",10/06/2022,
+1767139,CS1630,Kelly,Rolfson,2021 to 2022,"Teaching apprenticeship (postgrad)
+Biology with chemistry",08/03/2022,
+4966948,MD2264,Yolanda,Runolfsdottir,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022,
+3081702,AM9800,Lee,Sawayn,2021 to 2022,Provider-led (undergrad),10/06/2022,
+7030285,EX9838,Andre,Schaefer,2021 to 2022,"Provider-led (postgrad)
+Primary",24/06/2022,
+2260987,NF7094,Jody,Schneider,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",10/06/2022,
+2693809,DN2616,Mabel,Schroeder,2021 to 2022,"Provider-led (postgrad)
+Modern languages",18/04/2022,
+8675815,TX1993,Gwen,Shields,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",20/09/2023,Date standards met: '20/09/2023' - date standards met must be in the past
+1723973,DK3273,Alfred,Sipes,2021 to 2022,Provider-led (undergrad),24/06/2022,
+7438582,FY0149,Rogelio,Stanton,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",10/06/2022,
+3456627,EK8893,Carol,Stark,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",24/06/2022,
+9800306,BE6825,Dwight,Steuber,2021 to 2022,Provider-led (undergrad),10/06/2022,
+5061918,BE0921,Victor,Stoltenberg,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+6423079,MC9068,Randal,Stracke,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",17/06/2022,
+5609184,QH2562,Sheldon,Swaniawski,2021 to 2022,"School direct (fee funded)
+Primary",24/02/2022,
+8802182,TC8129,Nathan,Swift,2021 to 2022,"Provider-led (postgrad)
+Latin",08/03/2022,
+2008753,AT3764,Héloïse,Thomas,2021 to 2022,"Teaching apprenticeship (postgrad)
+Design and technology",10/06/2022,
+5507441,LA5215,Drew,Tillman,2021 to 2022,"Provider-led (postgrad)
+Modern languages",24/06/2022,
+5536522,MR6798,Ethel,Volkman,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",10/06/2022,
+6146464,DL2085,Max,Von,2021 to 2022,Opt-in (undergrad),24/06/2022,Date standards met provided without a TRN or Trainee ID - add a TRN or Trainee ID or remove the date standards met
+2763733,FM7612,Winston,Walsh,2021 to 2022,"School direct (salaried)
+Music with art and design",24/06/2022,
+8621661,GE6621,Jimmie,Wuckert,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",17/06/2022,
+1715621,LT5293,Luke,Wyman,2021 to 2022,"Provider-led (postgrad)
 Primary",17/06/2022,

--- a/app/assets/downloads/recommendOnly-with-errors.csv
+++ b/app/assets/downloads/recommendOnly-with-errors.csv
@@ -1,6 +1,6 @@
 TRN,Provider trainee ID,Last names,First names,Start academic year,Route and course,Date standards met,Error
 "Must contain a trainee's TRN, or be empty.
-Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
+Delete or add trainees as necessary.","Must contain your trainee ID or be empty.
 Delete or add trainees as necessary.",For reference only,For reference only,For reference only,"Add the date when the trainee met QTS or EYTS standards.
 Must be written DD/MM/YYYY.
 For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.

--- a/app/assets/downloads/recommendOnly-with-errors.csv
+++ b/app/assets/downloads/recommendOnly-with-errors.csv
@@ -1,4 +1,4 @@
-TRN,Provider trainee ID,First names,Last names,Start academic year,Route and course,Date standards met,Error
+TRN,Provider trainee ID,Last names,First names,Start academic year,Route and course,Date standards met,Error
 "Must contain a trainee's TRN, or be empty.
 Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
 Delete or add trainees as necessary.",For reference only,For reference only,For reference only,"Add the date when the trainee met QTS or EYTS standards.
@@ -6,246 +6,248 @@ Must be written DD/MM/YYYY.
 For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.
 The date must be in the past.
 If the trainee has not met the QTS, leave the cell empty or delete the row.",For reference only.,
-6666531,GD6448,Jack,Abshire,2021 to 2022,"School direct (fee funded)
+6666531,GD6448,Abshire,Jack,2021 to 2022,"School direct (fee funded)
 Biology with chemistry",10/06/2022,
-4912274,PD4888,Terrence,Altenwerth,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",25/02/2022,
-1995355,BC3735,Al,Auer,2021 to 2022,"Provider-led (postgrad)
+4912274,PD4888,Altenwerth,Terrence,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",22/01/2022,
+1995355,BC3735,Auer,Al,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022,
-7004997,XX4142,Angelo,Auer,2021 to 2022,"School direct (fee funded)
+7004997,XX4142,Auer,Angelo,2021 to 2022,"School direct (fee funded)
 Physical education",10/06/2022,
-8260100,SK3817,Joanne,Aufderhar,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",09/03/2022,TRN and Trainee ID are not for the same trainee
-1069262,YM8630,June,Bailey,2021 to 2022,"Provider-led (postgrad)
+8260100,SK3817,Aufderhar,Joanne,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",03/02/2022,TRN and Provider trainee ID are not for the same trainee
+1069262,YM8630,Bailey,June,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022,
-3417658,DN8645,Yolanda,Barrows,2021 to 2022,"Provider-led (postgrad)
-Design and technology",03/03/2022,
-4078189,AC7745,Isaac,Barton,2021 to 2022,"Provider-led (postgrad)
+3417658,DN8645,Barrows,Yolanda,2021 to 2022,"Provider-led (postgrad)
+Design and technology",04/03/2022,
+4078189,AC7745,Barton,Isaac,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022,
-7900253,ST6988,Jose,Batz,2021 to 2022,"Provider-led (postgrad)
+7900253,ST6988,Batz,Jose,2021 to 2022,"Provider-led (postgrad)
 Primary",17/06/2022,
-5646510,RC3608,Rafael,Beatty,2021 to 2022,"School direct (salaried)
+5646510,RC3608,Beatty,Rafael,2021 to 2022,"School direct (salaried)
 Italian",17/06/2022,
-8744159,HL2974,Lester,Beer,2021 to 2022,Provider-led (undergrad),24/06/2022,
-2732947,RS1429,Jaime,Beier,2021 to 2022,"Provider-led (postgrad)
+8744159,HL2974,Beer,Lester,2021 to 2022,Provider-led (undergrad),24/06/2022,
+2732947,RS1429,Beier,Jaime,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022,
-9837500,RN4482,Olive,Benoit,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",20/04/2022,
-7851957,NH4668,Émeric,Bertrand,2021 to 2022,"Provider-led (postgrad)
+9837500,RN4482,Benoit,Olive,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",26/01/2022,
+7851957,NH4668,Bertrand,Émeric,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022,
-9956721,FC3909,Irving,Boehm,2021 to 2022,"Provider-led (postgrad)
+9956721,FC3909,Boehm,Irving,2021 to 2022,"Provider-led (postgrad)
 Modern languages",10/06/2022,
-4641293,QB7031,Mario,Borer,2021 to 2022,"Provider-led (postgrad)
+4641293,QB7031,Borer,Mario,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",17/06/2022,
-5578493,XR1159,Doris,Botsford,2021 to 2022,"Provider-led (postgrad)
+5578493,XR1159,Botsford,Doris,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022,
-8691476,DM8266,Vickie,Bradtke,2021 to 2022,"Provider-led (postgrad)
+8691476,DM8266,Bradtke,Vickie,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022,
-4930476,EC6238,Laureline,Caron,2021 to 2022,"Provider-led (postgrad)
+4930476,EC6238,Caron,Laureline,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022,
-6408379,LM5954,Eudoxe,Caron,2021 to 2022,Provider-led (undergrad),09/03/2022,
-8537680,YM1278,Raoul,Carpentier,2021 to 2022,"Provider-led (postgrad)
+6408379,LM5954,Caron,Eudoxe,2021 to 2022,Provider-led (undergrad),20/04/2022,
+8537680,YM1278,Carpentier,Raoul,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
-5751332,LP2348,Pearl,Champlin,2021 to 2022,"School direct (fee funded)
+5751332,LP2348,Champlin,Pearl,2021 to 2022,"School direct (fee funded)
 Primary",17/06/2022,
-9719346,PB6404,Christine,Chevalier,2021 to 2022,"Provider-led (postgrad)
+9719346,PB6404,Chevalier,Christine,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022,
-8457026,CH1495,Gary,Collier,2021 to 2022,"School direct (salaried)
+8457026,CH1495,Collier,Gary,2021 to 2022,"School direct (salaried)
 Primary with modern languages",24/06/2022,
-3904024,SK9525,Patty,Collins,2021 to 2022,"Provider-led (postgrad)
+3904024,SK9525,Collins,Patty,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022,
-9457054,RT7878,Francisco,Considine,2021 to 2022,"Provider-led (postgrad)
+9457054,RT7878,Considine,Francisco,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
-6896165,CG5580,Alcyone,Da silva,2021 to 2022,"School direct (fee funded)
+6896165,CG5580,Da silva,Alcyone,2021 to 2022,"School direct (fee funded)
 Design and technology with English",24/06/2022,
-8832625,HD9024,Max,Deckow,2021 to 2022,"School direct (fee funded)
+8832625,HD9024,Deckow,Max,2021 to 2022,"School direct (fee funded)
 Physical education",10/06/2022,
-7999914,DQ9717,Carla,Deckow,2021 to 2022,"Provider-led (postgrad)
+7999914,DQ9717,Deckow,Carla,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
-3007806,LY3676,Shannon,Dickens,2021 to 2022,"Provider-led (postgrad)
+3007806,LY3676,Dickens,Shannon,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022,
-9410956,AF9403,Omar,Donnelly,2021 to 2022,"Provider-led (postgrad)
+9410956,AF9403,Donnelly,Omar,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",10/06/2022,
-1256500,MQ9676,Lucien,Dupuis,2021 to 2022,"Provider-led (postgrad)
+1256500,MQ9676,Dupuis,Lucien,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",24/06/2022,
-8441731,GM2375,Gene,Durgan,2021 to 2022,"Provider-led (postgrad)
+8441731,GM2375,Durgan,Gene,2021 to 2022,"Provider-led (postgrad)
 Modern languages",10/06/2022,
-3738544,NZ7230,Jacqueline,Durgan,2021 to 2022,"Provider-led (postgrad)
+3738544,NZ7230,Durgan,Jacqueline,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022,
-2827462,CN4219,Julia,Erdman,2021 to 2022,Provider-led (undergrad),24/06/2022,
-3073808,QB3717,Theresa,Fahey,2021 to 2022,"Provider-led (postgrad)
+2827462,CN4219,Erdman,Julia,2021 to 2022,Provider-led (undergrad),24/06/2022,
+3073808,QB3717,Fahey,Theresa,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",24/06/2022,
-4700830,HG4569,Marion,Flatley,2021 to 2022,"Provider-led (postgrad)
+4700830,HG4569,Flatley,Marion,2021 to 2022,"Provider-led (postgrad)
 Modern languages",17/06/2022,
-3379589,EM2761,Angélina,Fournier,2021 to 2022,"School direct (salaried)
+3379589,EM2761,Fournier,Angélina,2021 to 2022,"School direct (salaried)
 Primary",24/06/2022,
-5054746,AW3371,Margie,Frami,2021 to 2022,"Provider-led (postgrad)
+5054746,AW3371,Frami,Margie,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",17/06/2022,
-4041145,RY2137,Lorena,Franey,2021 to 2022,"Provider-led (postgrad)
+4041145,RY2137,Franey,Lorena,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022,
-8569621,WX3307,Mamie,Funk,2021 to 2022,Provider-led (undergrad),10/06/2022,
-9055186,GG9603,Margarita,Funk,2021 to 2022,"Provider-led (postgrad)
+8569621,WX3307,Funk,Mamie,2021 to 2022,Provider-led (undergrad),10/06/2022,
+9055186,GG9603,Funk,Margarita,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022,
-4371388,ZW8916,Aphélie,Garcia,2021 to 2022,Provider-led (undergrad),10/06/2022,
-5843544,DG6419,Elena,Gibson,2021 to 2022,"Teaching apprenticeship (postgrad)
-Primary with mathematics",11/05/2022,
-3969536,HK1030,Byron,Gottlieb,2021 to 2022,"Provider-led (postgrad)
+4371388,ZW8916,Garcia,Aphélie,2021 to 2022,Provider-led (undergrad),10/06/2022,
+5843544,DG6419,Gibson,Elena,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary with mathematics",14/03/2022,
+3969536,HK1030,Gottlieb,Byron,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",10/06/2022,
-9150187,HB3671,Isabelle,Guerin,2021 to 2022,"Provider-led (postgrad)
+9150187,HB3671,Guerin,Isabelle,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",10/06/2022,
-7279498,RT3004,Blake,Gulgowski,2021 to 2022,"Provider-led (postgrad)
+7279498,RT3004,Gulgowski,Blake,2021 to 2022,"Provider-led (postgrad)
 Design and technology",24/06/2022,
-1785167,NL7535,Alison,Hagenes,2021 to 2022,"Provider-led (postgrad)
+1785167,NL7535,Hagenes,Alison,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
-7009193,HH3355,Rodney,Halvorson,2021 to 2022,"Provider-led (postgrad)
+7009193,HH3355,Halvorson,Rodney,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",10/06/2022,
-4456200,SP9485,Woodrow,Hartmann,2021 to 2022,"Provider-led (postgrad)
+4456200,SP9485,Hartmann,Woodrow,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",24/06/2022,
-8957378,GM5727,Benny,Harvey,2021 to 2022,Provider-led (undergrad),10/06/2022,
-5598145,ZZ0654,Stuart,Hauck,2021 to 2022,"Provider-led (postgrad)
+8957378,GM5727,Harvey,Benny,2021 to 2022,Provider-led (undergrad),10/06/2022,
+5598145,ZZ0654,Hauck,Stuart,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",17/06/2022,
-2493764,EQ2692,Kim,Heathcote,2021 to 2022,"Provider-led (postgrad)
+2493764,EQ2692,Heathcote,Kim,2021 to 2022,"Provider-led (postgrad)
 Primary",17/06/2022,
-9729520,BT0697,Nick,Heller,2021 to 2022,"Provider-led (postgrad)
+9729520,BT0697,Heller,Nick,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",17/06/2022,
-1455999,BK4097,Jacquelyn,Herman,2021 to 2022,Provider-led (undergrad),24/06/2022,
-8262628,DS2628,Phyllis,Hermann,2021 to 2022,"Provider-led (postgrad)
+1455999,BK4097,Herman,Jacquelyn,2021 to 2022,Provider-led (undergrad),24/06/2022,
+8262628,DS2628,Hermann,Phyllis,2021 to 2022,"Provider-led (postgrad)
 Latin",24/06/2022,
-2953057,YY3036,Cameron,Hermann,2021 to 2022,"Provider-led (postgrad)
+2953057,YY3036,Hermann,Cameron,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
-5077067,WP3275,Brandy,Hilll,2021 to 2022,Provider-led (undergrad),24/06/2022,
-6861505,LY4803,Edna,Hills,2021 to 2022,"Provider-led (postgrad)
+5077067,WP3275,Hilll,Brandy,2021 to 2022,Provider-led (undergrad),24/06/2022,
+6861505,LY4803,Hills,Edna,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022,
-6784447,SH2853,Katrina,Hodkiewicz,2021 to 2022,"Provider-led (postgrad)
+6784447,SH2853,Hodkiewicz,Katrina,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022,
-7769677,HM3654,Patti,Jacobson,2021 to 2022,"School direct (fee funded)
+7769677,HM3654,Jacobson,Patti,2021 to 2022,"School direct (fee funded)
 Physical education",10/06/2022,
-8748026,CG8977,Quiéta,Jacquet,2021 to 2022,"School direct (fee funded)
+8748026,CG8977,Jacquet,Quiéta,2021 to 2022,"School direct (fee funded)
 Primary",10/06/2022,
-9350282,MH3891,Terry,Jast,2021 to 2022,"Provider-led (postgrad)
+9350282,MH3891,Jast,Terry,2021 to 2022,"Provider-led (postgrad)
 Latin",24/06/2022,
-6780890,PM5795,Randall,Kerluke,2021 to 2022,"Provider-led (postgrad)
+6780890,PM5795,Kerluke,Randall,2021 to 2022,"Provider-led (postgrad)
 Modern languages",10/06/2022,
-4337728,SH0505,Grant,Kirlin,2021 to 2022,"Provider-led (postgrad)
+4337728,SH0505,Kirlin,Grant,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",10/06/2022,
-3865944,GX0521,Merle,Klocko,2021 to 2022,"School direct (fee funded)
+3865944,GX0521,Klocko,Merle,2021 to 2022,"School direct (fee funded)
 Classics with English",10/06/2022,
-9919650,PM7014,Winston,Kohler,2021 to 2022,"Provider-led (postgrad)
+9919650,PM7014,Kohler,Winston,2021 to 2022,"Provider-led (postgrad)
 Primary",10/06/2022,
-6198842,TD9870,Kerry,Konopelski,2021 to 2022,"Teaching apprenticeship (postgrad)
+6198842,TD9870,Konopelski,Kerry,2021 to 2022,"Teaching apprenticeship (postgrad)
 Modern languages",10/06/2022,
-2177277,DQ8137,Oliver,Kovacek,2021 to 2022,"Provider-led (postgrad)
+2177277,DQ8137,Kovacek,Oliver,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",24/06/2022,
-4073732,QS6710,Vital,Lacroix,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",05/02/2022,
-5999712,LX1542,Christina,Langosh,2021 to 2022,"Provider-led (postgrad)
+4073732,QS6710,Lacroix,Vital,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",02/05/2022,
+5999712,LX1542,Langosh,Christina,2021 to 2022,"Provider-led (postgrad)
 Primary",10/06/2022,
-9888335,AB9131,Fidèle,Laurent,2021 to 2022,"Provider-led (postgrad)
+9888335,AB9131,Laurent,Fidèle,2021 to 2022,"Provider-led (postgrad)
 Primary with physical education",24/06/2022,
-2086024,QD7026,Sylvie,Laurent,2021 to 2022,"Provider-led (postgrad)
+2086024,QD7026,Laurent,Sylvie,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",10/06/2022,
-7646286,WA3900,Whitney,Lehner,2021 to 2022,"Provider-led (postgrad)
+7646286,WA3900,Lehner,Whitney,2021 to 2022,"Provider-led (postgrad)
 Latin",20/09/2023,Date standards met: '20/09/2023' - date standards met must be in the past
-7882048,FW4161,Victorin,Lemaire,2021 to 2022,"Provider-led (postgrad)
+7882048,FW4161,Lemaire,Victorin,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
-7347971,PY7485,Stanislas,Lemoine,2021 to 2022,"Provider-led (postgrad)
+7347971,PY7485,Lemoine,Stanislas,2021 to 2022,"Provider-led (postgrad)
 Design and technology",24/06/2022,
-1484766,RB6215,Jessica,Lubowitz,2021 to 2022,"Provider-led (postgrad)
+1484766,RB6215,Lubowitz,Jessica,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022,
-6638309,GW6401,Antoinette,Lueilwitz,2021 to 2022,"Provider-led (postgrad)
-Latin",07/05/2022,
-4236028,CR0592,Olive,Mante,2021 to 2022,"Provider-led (postgrad)
+6638309,GW6401,Lueilwitz,Antoinette,2021 to 2022,"Provider-led (postgrad)
+Latin",07/03/2022,
+4236028,CR0592,Mante,Olive,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022,
-5597817,CY1368,Marlène,Marie,2021 to 2022,"Provider-led (postgrad)
+5597817,CY1368,Marie,Marlène,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
-5410523,ZW5355,Aliette,Meunier,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022,Date standards met provided without a TRN or Trainee ID - add a TRN or Trainee ID or remove the date standards met
-5536974,BB3367,Moses,Miller,2021 to 2022,"Provider-led (postgrad)
+5410523,ZW5355,Meunier,Aliette,2021 to 2022,"Provider-led (postgrad)
+Design and technology",24/06/2022,Date standards met provided without a TRN or Provider trainee ID - add a TRN or Provider trainee ID or remove the date standards met
+5536974,BB3367,Miller,Moses,2021 to 2022,"Provider-led (postgrad)
 Latin",24/06/2022,
-6851156,EY3088,Victor,Mills,2021 to 2022,"Provider-led (postgrad)
+6851156,EY3088,Mills,Victor,2021 to 2022,"Provider-led (postgrad)
 Latin",24/06/2022,
-5617199,GY0902,Arthaud,Moreau,2021 to 2022,"Provider-led (postgrad)
+5617199,GY0902,Moreau,Arthaud,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022,
-1389975,HB0070,Amber,Mosciski,2021 to 2022,"Provider-led (postgrad)
+1389975,HB0070,Mosciski,Amber,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
-4876485,TA1426,Ora,Mosciski,2021 to 2022,Provider-led (undergrad),10/06/2022,
-8215464,ER6952,Cassien,Moulin,2021 to 2022,"Provider-led (postgrad)
+4876485,TA1426,Mosciski,Ora,2021 to 2022,Provider-led (undergrad),10/06/2022,
+8215464,ER6952,Moulin,Cassien,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
-7900821,FM9996,David,Nitzsche,2021 to 2022,"Provider-led (postgrad)
+7900821,FM9996,Nitzsche,David,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
-8273630,TM7395,Aubrey,O'Kon,2021 to 2022,"Provider-led (postgrad)
+8273630,TM7395,O'Kon,Aubrey,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
-3860744,HT5730,Orlando,O'Reilly,2021 to 2022,"Provider-led (postgrad)
+3860744,HT5730,O'Reilly,Orlando,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",10/06/2022,
-8384234,BH1454,Annette,Pacocha,2021 to 2022,"Provider-led (postgrad)
-Latin",03/04/2022,
-1204048,BH9051,Angélina,Perrot,2021 to 2022,"Provider-led (postgrad)
+8384234,BH1454,Pacocha,Annette,2021 to 2022,"Provider-led (postgrad)
+Latin",04/03/2022,
+1204048,BH9051,Perrot,Angélina,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022,
-6088600,NT0340,Léonne,Petit,2021 to 2022,"Provider-led (postgrad)
+6088600,NT0340,Petit,Léonne,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022,
-4185941,YG1496,Saul,Pfannerstill,2021 to 2022,"Provider-led (postgrad)
+4185941,YG1496,Pfannerstill,Saul,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
-4828006,YK9994,Harold,Pfeffer,2021 to 2022,"Provider-led (postgrad)
+4828006,YK9994,Pfeffer,Harold,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",24/06/2022,
-3329403,GC7042,Erik,Pollich,2021 to 2022,"Provider-led (postgrad)
+3329403,GC7042,Pollich,Erik,2021 to 2022,"Provider-led (postgrad)
 Primary with physical education",10/06/2022,
-5684508,XE4315,Martha,Pouros,2021 to 2022,"Provider-led (postgrad)
+5684508,XE4315,Pouros,Martha,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022,
-3232248,BA0386,Germaine,Prevost,2021 to 2022,"Provider-led (postgrad)
+3232248,BA0386,Prevost,Germaine,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022,
-7371200,CS3377,Annabelle,Prevost,2021 to 2022,"Provider-led (postgrad)
+7371200,CS3377,Prevost,Annabelle,2021 to 2022,"Provider-led (postgrad)
 Latin",24/06/2022,
-4922124,DS9993,Pat,Rempel,2021 to 2022,"Provider-led (postgrad)
+4922124,DS9993,Rempel,Pat,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022,
-7109771,WF0871,Avigaëlle,Remy,2021 to 2022,"Provider-led (postgrad)
+7109771,WF0871,Remy,Avigaëlle,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022,
-4817751,NL3209,Céleste,Renaud,2021 to 2022,"Provider-led (postgrad)
+4817751,NL3209,Renaud,Céleste,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",10/06/2022,
-8668206,QW3812,Russell,Renner,2021 to 2022,"Provider-led (postgrad)
+8668206,QW3812,Renner,Russell,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
-4788104,AD8428,Gautier,Rey,2021 to 2022,"Provider-led (postgrad)
+4788104,AD8428,Rey,Gautier,2021 to 2022,"Provider-led (postgrad)
 Modern languages",10/06/2022,
-3960844,SH6489,Gatien,Robert,2021 to 2022,"Provider-led (postgrad)
+3960844,SH6489,Robert,Gatien,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",17/06/2022,
-3889585,WW9157,Daphné,Robert,2021 to 2022,"Provider-led (postgrad)
+3889585,WW9157,Robert,Daphné,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022,
-7311560,MN8220,Amalthée,Roger,2021 to 2022,"Provider-led (postgrad)
+7311560,MN8220,Roger,Amalthée,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",10/06/2022,
-1767139,CS1630,Kelly,Rolfson,2021 to 2022,"Teaching apprenticeship (postgrad)
-Biology with chemistry",03/03/2022,
-4966948,MD2264,Yolanda,Runolfsdottir,2021 to 2022,"Provider-led (postgrad)
+1767139,CS1630,Rolfson,Kelly,2021 to 2022,"Teaching apprenticeship (postgrad)
+Biology with chemistry",24/02/2022,
+4966948,MD2264,Runolfsdottir,Yolanda,2021 to 2022,"Provider-led (postgrad)
 Modern languages",10/06/2022,
-3081702,AM9800,Lee,Sawayn,2021 to 2022,Provider-led (undergrad),10/06/2022,
-7030285,EX9838,Andre,Schaefer,2021 to 2022,"Provider-led (postgrad)
+3081702,AM9800,Sawayn,Lee,2021 to 2022,Provider-led (undergrad),10/06/2022,
+7030285,EX9838,Schaefer,Andre,2021 to 2022,"Provider-led (postgrad)
 Primary",24/06/2022,
-2260987,NF7094,Jody,Schneider,2021 to 2022,"Provider-led (postgrad)
+2260987,NF7094,Schneider,Jody,2021 to 2022,"Provider-led (postgrad)
 Primary with physical education",10/06/2022,
-2693809,DN2616,Mabel,Schroeder,2021 to 2022,"Provider-led (postgrad)
-Modern languages",26/01/2022,
-8675815,TX1993,Gwen,Shields,2021 to 2022,"Provider-led (postgrad)
+2693809,DN2616,Schroeder,Mabel,2021 to 2022,"Provider-led (postgrad)
+Modern languages",09/04/2022,
+8675815,TX1993,Shields,Gwen,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",20/09/2023,Date standards met: '20/09/2023' - date standards met must be in the past
-1723973,DK3273,Alfred,Sipes,2021 to 2022,Provider-led (undergrad),24/06/2022,
-7438582,FY0149,Rogelio,Stanton,2021 to 2022,"Provider-led (postgrad)
+1723973,DK3273,Sipes,Alfred,2021 to 2022,Provider-led (undergrad),24/06/2022,
+7438582,FY0149,Stanton,Rogelio,2021 to 2022,"Provider-led (postgrad)
 Primary with physical education",10/06/2022,
-3456627,EK8893,Carol,Stark,2021 to 2022,"Provider-led (postgrad)
+3456627,EK8893,Stark,Carol,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",24/06/2022,
-9800306,BE6825,Dwight,Steuber,2021 to 2022,Provider-led (undergrad),10/06/2022,
-5061918,BE0921,Victor,Stoltenberg,2021 to 2022,"Provider-led (postgrad)
+9800306,BE6825,Steuber,Dwight,2021 to 2022,Provider-led (undergrad),10/06/2022,
+5061918,BE0921,Stoltenberg,Victor,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
-6423079,MC9068,Randal,Stracke,2021 to 2022,"Provider-led (postgrad)
+6423079,MC9068,Stracke,Randal,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",17/06/2022,
-5609184,QH2562,Sheldon,Swaniawski,2021 to 2022,"School direct (fee funded)
-Primary",02/02/2022,
-8802182,TC8129,Nathan,Swift,2021 to 2022,"Provider-led (postgrad)
-Latin",11/05/2022,
-2008753,AT3764,Héloïse,Thomas,2021 to 2022,"Teaching apprenticeship (postgrad)
+5609184,QH2562,Swaniawski,Sheldon,2021 to 2022,"School direct (fee funded)
+Primary",11/04/2022,
+8802182,TC8129,Swift,Nathan,2021 to 2022,"Provider-led (postgrad)
+Latin",08/05/2022,
+2008753,AT3764,Thomas,Héloïse,2021 to 2022,"Teaching apprenticeship (postgrad)
 Design and technology",10/06/2022,
-5507441,LA5215,Drew,Tillman,2021 to 2022,"Provider-led (postgrad)
+5507441,LA5215,Tillman,Drew,2021 to 2022,"Provider-led (postgrad)
 Modern languages",24/06/2022,
-5536522,MR6798,Ethel,Volkman,2021 to 2022,"Provider-led (postgrad)
+5536522,MR6798,Volkman,Ethel,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",10/06/2022,
-6146464,DL2085,Max,Von,2021 to 2022,Opt-in (undergrad),24/06/2022,Date standards met provided without a TRN or Trainee ID - add a TRN or Trainee ID or remove the date standards met
-2763733,FM7612,Winston,Walsh,2021 to 2022,"School direct (salaried)
+6146464,DL2085,Von,Max,2021 to 2022,Opt-in (undergrad),24/06/2022,Date standards met provided without a TRN or Provider trainee ID - add a TRN or Provider trainee ID or remove the date standards met
+2763733,FM7612,Walsh,Winston,2021 to 2022,"School direct (salaried)
 Music with art and design",24/06/2022,
-8621661,GE6621,Jimmie,Wuckert,2021 to 2022,"Provider-led (postgrad)
+8621661,GE6621,Wuckert,Jimmie,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",17/06/2022,
+1715621,LT5293,Wyman,Luke,2021 to 2022,"Provider-led (postgrad)
+Primary",17/06/2022,

--- a/app/assets/downloads/recommendOnly-with-errors.csv
+++ b/app/assets/downloads/recommendOnly-with-errors.csv
@@ -1,4 +1,4 @@
-TRN,Trainee ID,Trainee name,Start academic year,Route and course,Date standards met,Error,
+TRN,Trainee ID,First names,Last names,Start academic year,Route and course,Date standards met,Error
 "Must contain a trainee's TRN, or be empty.
 Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
 Delete or add trainees as necessary.",For reference only,For reference only,For reference only,"Add the date when the trainee met QTS or EYTS standards.
@@ -9,17 +9,17 @@ If the trainee has not met the QTS, leave the cell empty or delete the row.",For
 6666531,GD6448,Jack,Abshire,2021 to 2022,"School direct (fee funded)
 Biology with chemistry",10/06/2022,
 4912274,PD4888,Terrence,Altenwerth,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",08/03/2022,
+Primary with physical education",25/02/2022,
 1995355,BC3735,Al,Auer,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022,
 7004997,XX4142,Angelo,Auer,2021 to 2022,"School direct (fee funded)
 Physical education",10/06/2022,
 8260100,SK3817,Joanne,Aufderhar,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",10/05/2022,TRN and Trainee ID are not for the same trainee
+Biology with chemistry",09/03/2022,TRN and Trainee ID are not for the same trainee
 1069262,YM8630,June,Bailey,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022,
 3417658,DN8645,Yolanda,Barrows,2021 to 2022,"Provider-led (postgrad)
-Design and technology",05/01/2022,
+Design and technology",03/03/2022,
 4078189,AC7745,Isaac,Barton,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022,
 7900253,ST6988,Jose,Batz,2021 to 2022,"Provider-led (postgrad)
@@ -30,7 +30,7 @@ Italian",17/06/2022,
 2732947,RS1429,Jaime,Beier,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022,
 9837500,RN4482,Olive,Benoit,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",15/04/2022,
+Physical education with physics",20/04/2022,
 7851957,NH4668,Émeric,Bertrand,2021 to 2022,"Provider-led (postgrad)
 Latin",17/06/2022,
 9956721,FC3909,Irving,Boehm,2021 to 2022,"Provider-led (postgrad)
@@ -43,7 +43,7 @@ Latin",10/06/2022,
 Physical education with physics",10/06/2022,
 4930476,EC6238,Laureline,Caron,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022,
-6408379,LM5954,Eudoxe,Caron,2021 to 2022,Provider-led (undergrad),03/03/2022,
+6408379,LM5954,Eudoxe,Caron,2021 to 2022,Provider-led (undergrad),09/03/2022,
 8537680,YM1278,Raoul,Carpentier,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
 5751332,LP2348,Pearl,Champlin,2021 to 2022,"School direct (fee funded)
@@ -88,7 +88,7 @@ Physical education with physics",10/06/2022,
 Latin",10/06/2022,
 4371388,ZW8916,Aphélie,Garcia,2021 to 2022,Provider-led (undergrad),10/06/2022,
 5843544,DG6419,Elena,Gibson,2021 to 2022,"Teaching apprenticeship (postgrad)
-Primary with mathematics",22/01/2022,
+Primary with mathematics",11/05/2022,
 3969536,HK1030,Byron,Gottlieb,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",10/06/2022,
 9150187,HB3671,Isabelle,Guerin,2021 to 2022,"Provider-led (postgrad)
@@ -137,7 +137,7 @@ Modern languages",10/06/2022,
 2177277,DQ8137,Oliver,Kovacek,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",24/06/2022,
 4073732,QS6710,Vital,Lacroix,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",06/02/2022,
+Biology with chemistry",05/02/2022,
 5999712,LX1542,Christina,Langosh,2021 to 2022,"Provider-led (postgrad)
 Primary",10/06/2022,
 9888335,AB9131,Fidèle,Laurent,2021 to 2022,"Provider-led (postgrad)
@@ -153,7 +153,7 @@ Design and technology",24/06/2022,
 1484766,RB6215,Jessica,Lubowitz,2021 to 2022,"Provider-led (postgrad)
 Latin",10/06/2022,
 6638309,GW6401,Antoinette,Lueilwitz,2021 to 2022,"Provider-led (postgrad)
-Latin",03/03/2022,
+Latin",07/05/2022,
 4236028,CR0592,Olive,Mante,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022,
 5597817,CY1368,Marlène,Marie,2021 to 2022,"Provider-led (postgrad)
@@ -178,7 +178,7 @@ Design and technology",10/06/2022,
 3860744,HT5730,Orlando,O'Reilly,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",10/06/2022,
 8384234,BH1454,Annette,Pacocha,2021 to 2022,"Provider-led (postgrad)
-Latin",13/02/2022,
+Latin",03/04/2022,
 1204048,BH9051,Angélina,Perrot,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",10/06/2022,
 6088600,NT0340,Léonne,Petit,2021 to 2022,"Provider-led (postgrad)
@@ -212,7 +212,7 @@ Latin",10/06/2022,
 7311560,MN8220,Amalthée,Roger,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",10/06/2022,
 1767139,CS1630,Kelly,Rolfson,2021 to 2022,"Teaching apprenticeship (postgrad)
-Biology with chemistry",08/03/2022,
+Biology with chemistry",03/03/2022,
 4966948,MD2264,Yolanda,Runolfsdottir,2021 to 2022,"Provider-led (postgrad)
 Modern languages",10/06/2022,
 3081702,AM9800,Lee,Sawayn,2021 to 2022,Provider-led (undergrad),10/06/2022,
@@ -221,7 +221,7 @@ Primary",24/06/2022,
 2260987,NF7094,Jody,Schneider,2021 to 2022,"Provider-led (postgrad)
 Primary with physical education",10/06/2022,
 2693809,DN2616,Mabel,Schroeder,2021 to 2022,"Provider-led (postgrad)
-Modern languages",18/04/2022,
+Modern languages",26/01/2022,
 8675815,TX1993,Gwen,Shields,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",20/09/2023,Date standards met: '20/09/2023' - date standards met must be in the past
 1723973,DK3273,Alfred,Sipes,2021 to 2022,Provider-led (undergrad),24/06/2022,
@@ -235,9 +235,9 @@ Design and technology",10/06/2022,
 6423079,MC9068,Randal,Stracke,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",17/06/2022,
 5609184,QH2562,Sheldon,Swaniawski,2021 to 2022,"School direct (fee funded)
-Primary",24/02/2022,
+Primary",02/02/2022,
 8802182,TC8129,Nathan,Swift,2021 to 2022,"Provider-led (postgrad)
-Latin",08/03/2022,
+Latin",11/05/2022,
 2008753,AT3764,Héloïse,Thomas,2021 to 2022,"Teaching apprenticeship (postgrad)
 Design and technology",10/06/2022,
 5507441,LA5215,Drew,Tillman,2021 to 2022,"Provider-led (postgrad)
@@ -249,5 +249,3 @@ Primary with modern languages",10/06/2022,
 Music with art and design",24/06/2022,
 8621661,GE6621,Jimmie,Wuckert,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",17/06/2022,
-1715621,LT5293,Luke,Wyman,2021 to 2022,"Provider-led (postgrad)
-Primary",17/06/2022,

--- a/app/assets/downloads/recommendOnly-with-errors.csv
+++ b/app/assets/downloads/recommendOnly-with-errors.csv
@@ -1,4 +1,4 @@
-TRN,Trainee ID,First names,Last names,Start academic year,Route and course,Date standards met,Error
+TRN,Provider trainee ID,First names,Last names,Start academic year,Route and course,Date standards met,Error
 "Must contain a trainee's TRN, or be empty.
 Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
 Delete or add trainees as necessary.",For reference only,For reference only,For reference only,"Add the date when the trainee met QTS or EYTS standards.

--- a/app/assets/downloads/recommendOnly-with-errors.csv
+++ b/app/assets/downloads/recommendOnly-with-errors.csv
@@ -1,252 +1,253 @@
-TRN,Start academic year,Route and course,Date standards met,Error
-"Must contain a trainee's TRN. Delete or add trainees as necessary.
-TRNs must be 7 digits.",For reference only.,For reference only.,"Add the date when the trainee met QTS or EYTS standards.
+TRN,Trainee ID,Start academic year,Route and course,Date standards met,Error
+"Must contain a trainee's TRN, or be empty.
+Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
+Delete or add trainees as necessary.",For reference only.,For reference only.,"Add the date when the trainee met QTS or EYTS standards.
 Must be written DD/MM/YYYY.
 For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.
 The date must be in the past.
 If the trainee has not met the QTS, leave the cell empty or delete the row.",For reference only.
-6666531,2021 to 2022,"School direct (fee funded)
+9837500,RN4482,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",22/05/2022,
+5609184,QH2562,2021 to 2022,"School direct (fee funded)
+Primary",17/03/2022,
+8273630,TM7395,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+7311560,MN8220,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",10/06/2022,
-4912274,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",09/02/2022,
-1995355,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022,
-7004997,2021 to 2022,"School direct (fee funded)
-Physical education",17/06/2022,
-8260100,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",20/09/2023,Date standards met: '20/09/2023' - date standards met must be in the past
-1069262,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-3417658,2021 to 2022,"Provider-led (postgrad)
-Design and technology",03/02/2022,
-4078189,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022,
-7900253,2021 to 2022,"Provider-led (postgrad)
-Primary",17/06/2022,
-5646510,2021 to 2022,"School direct (salaried)
-Italian",17/06/2022,
-8744159,2021 to 2022,Provider-led (undergrad),24/06/2022,
-2732947,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022,
-9837500,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",12/02/2022,
-7851957,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022,
-9956721,2021 to 2022,"Provider-led (postgrad)
-Modern languages",10/06/2022,
-4641293,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",24/06/2022,
-5578493,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022,
-8691476,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022,
-,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022,Date standards met provided without a TRN - add a TRN or remove the date standards met
-6408379,2021 to 2022,Provider-led (undergrad),24/06/2022,
-8537680,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022,
-5751332,2021 to 2022,"School direct (fee funded)
-Primary",24/06/2022,
-9719346,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022,
-8457026,2021 to 2022,"School direct (salaried)
-Primary with modern languages",24/06/2022,
-3904024,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-9457054,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022,
-6896165,2021 to 2022,"School direct (fee funded)
+6896165,CG5580,2021 to 2022,"School direct (fee funded)
 Design and technology with English",24/06/2022,
-8832625,2021 to 2022,"School direct (fee funded)
-Physical education",17/06/2022,
-7999914,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-3007806,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022,
-9410956,2021 to 2022,"Provider-led (postgrad)
+7009193,HH3355,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",10/06/2022,
-1256500,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",24/06/2022,
-8441731,2021 to 2022,"Provider-led (postgrad)
-Modern languages",10/06/2022,
-3738544,2021 to 2022,"Provider-led (postgrad)
-Latin",17/06/2022,
-2827462,2021 to 2022,Provider-led (undergrad),24/06/2022,
-3073808,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",24/06/2022,
-4700830,2021 to 2022,"Provider-led (postgrad)
-Modern languages",17/06/2022,
-3379589,2021 to 2022,"School direct (salaried)
-Primary",17/06/2022,
-5054746,2021 to 2022,"Provider-led (postgrad)
+9457054,RT7878,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+5054746,AW3371,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",17/06/2022,
-4041145,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022,
-8569621,2021 to 2022,Provider-led (undergrad),17/06/2022,
-9055186,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-4371388,2021 to 2022,Provider-led (undergrad),10/06/2022,
-5843544,2021 to 2022,"Teaching apprenticeship (postgrad)
-Primary with mathematics",24/06/2022,
-3969536,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",10/06/2022,
-9150187,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",10/06/2022,
-7279498,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022,
-1785167,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-7009193,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",10/06/2022,
-4456200,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",24/06/2022,
-8957378,2021 to 2022,Provider-led (undergrad),10/06/2022,
-5598145,2021 to 2022,"Provider-led (postgrad)
+8957378,GM5727,2021 to 2022,Provider-led (undergrad),10/06/2022,
+4073732,QS6710,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",27/02/2022,
+8675815,TX1993,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",20/09/2023,Date standards met: '20/09/2023' - date standards met must be in the past
+3960844,SH6489,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",17/06/2022,
-2493764,2021 to 2022,"Provider-led (postgrad)
-Primary",17/06/2022,
-9729520,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",17/06/2022,
-1455999,2021 to 2022,Provider-led (undergrad),24/06/2022,
-8262628,2021 to 2022,"Provider-led (postgrad)
+7646286,WA3900,2021 to 2022,"Provider-led (postgrad)
 Latin",20/09/2023,Date standards met: '20/09/2023' - date standards met must be in the past
-2953057,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022,
-5077067,2021 to 2022,Provider-led (undergrad),24/06/2022,
-6861505,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022,
-6784447,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022,
-7769677,2021 to 2022,"School direct (fee funded)
-Physical education",17/06/2022,
-8748026,2021 to 2022,"School direct (fee funded)
-Primary",17/06/2022,
-9350282,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022,
-6780890,2021 to 2022,"Provider-led (postgrad)
-Modern languages",10/06/2022,
-4337728,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",10/06/2022,
-3865944,2021 to 2022,"School direct (fee funded)
-Classics with English",10/06/2022,
-9919650,2021 to 2022,"Provider-led (postgrad)
-Primary",17/06/2022,
-6198842,2021 to 2022,"Teaching apprenticeship (postgrad)
-Modern languages",10/06/2022,
-2177277,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",24/06/2022,
-4073732,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",09/03/2022,
-5999712,2021 to 2022,"Provider-led (postgrad)
-Primary",10/06/2022,
-9888335,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",24/06/2022,
-2086024,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",10/06/2022,
-7646286,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022,
-7882048,2021 to 2022,"Provider-led (postgrad)
+8832625,HD9024,2021 to 2022,"School direct (fee funded)
+Physical education",10/06/2022,
+8668206,QW3812,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
-7347971,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022,
-1484766,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-6638309,2021 to 2022,"Provider-led (postgrad)
-Latin",14/04/2022,
-4236028,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022,
-5597817,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022,
-5410523,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022,
-5536974,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022,
-6851156,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022,
-,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,Date standards met provided without a TRN - add a TRN or remove the date standards met
-1389975,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-4876485,2021 to 2022,Provider-led (undergrad),17/06/2022,
-8215464,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-7900821,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022,
-8273630,2021 to 2022,"Provider-led (postgrad)
-Design and technology",10/06/2022,
-3860744,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",10/06/2022,
-8384234,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022,
-1204048,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",10/06/2022,
-6088600,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022,
-4185941,2021 to 2022,"Provider-led (postgrad)
-Design and technology",17/06/2022,
-4828006,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",24/06/2022,
-3329403,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",24/06/2022,
-5684508,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-3232248,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-7371200,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022,
-4922124,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-7109771,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-4817751,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",10/06/2022,
-8668206,2021 to 2022,"Provider-led (postgrad)
-Design and technology",24/06/2022,
-4788104,2021 to 2022,"Provider-led (postgrad)
-Modern languages",17/06/2022,
-3960844,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",17/06/2022,
-3889585,2021 to 2022,"Provider-led (postgrad)
-Latin",10/06/2022,
-7311560,2021 to 2022,"Provider-led (postgrad)
+9729520,BT0697,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",17/06/2022,
-1767139,2021 to 2022,"Teaching apprenticeship (postgrad)
-Biology with chemistry",24/06/2022,
-4966948,2021 to 2022,"Provider-led (postgrad)
+6198842,TD9870,2021 to 2022,"Teaching apprenticeship (postgrad)
 Modern languages",10/06/2022,
-3081702,2021 to 2022,Provider-led (undergrad),10/06/2022,
-7030285,2021 to 2022,"Provider-led (postgrad)
+5578493,XR1159,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+3379589,EM2761,2021 to 2022,"School direct (salaried)
 Primary",24/06/2022,
-2260987,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",10/06/2022,
-2693809,2021 to 2022,"Provider-led (postgrad)
-Modern languages",24/06/2022,
-,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",17/06/2022,Date standards met provided without a TRN - add a TRN or remove the date standards met
-1723973,2021 to 2022,Provider-led (undergrad),24/06/2022,
-7438582,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",10/06/2022,
-3456627,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",24/06/2022,
-9800306,2021 to 2022,Provider-led (undergrad),17/06/2022,
-5061918,2021 to 2022,"Provider-led (postgrad)
+9800306,BE6825,2021 to 2022,Provider-led (undergrad),10/06/2022,
+4930476,EC6238,2021 to 2022,"Provider-led (postgrad)
 Design and technology",17/06/2022,
-6423079,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",24/06/2022,
-5609184,2021 to 2022,"School direct (fee funded)
-Primary",24/06/2022,
-8802182,2021 to 2022,"Provider-led (postgrad)
-Latin",24/06/2022,
-2008753,2021 to 2022,"Teaching apprenticeship (postgrad)
+5061918,BE0921,2021 to 2022,"Provider-led (postgrad)
 Design and technology",10/06/2022,
-5507441,2021 to 2022,"Provider-led (postgrad)
-Modern languages",24/06/2022,
-5536522,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",10/06/2022,
-6146464,2021 to 2022,Opt-in (undergrad),24/06/2022,
-2763733,2021 to 2022,"School direct (salaried)
-Music with art and design",24/06/2022,
-8621661,2021 to 2022,"Provider-led (postgrad)
+8748026,CG8977,2021 to 2022,"School direct (fee funded)
+Primary",10/06/2022,
+7900821,FM9996,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+2493764,EQ2692,2021 to 2022,"Provider-led (postgrad)
+Primary",17/06/2022,
+9888335,AB9131,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",24/06/2022,
+8260100,SK3817,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",22/05/2022,TRN and Trainee ID are not for the same trainee
+3073808,QB3717,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",24/06/2022,
+7347971,PY7485,2021 to 2022,"Provider-led (postgrad)
+Design and technology",24/06/2022,
+7851957,NH4668,2021 to 2022,"Provider-led (postgrad)
+Latin",17/06/2022,
+4912274,PD4888,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",03/05/2022,
+3007806,LY3676,2021 to 2022,"Provider-led (postgrad)
+Design and technology",17/06/2022,
+5410523,ZW5355,2021 to 2022,"Provider-led (postgrad)
+Design and technology",24/06/2022,Date standards met provided without a TRN or Trainee ID - add a TRN or Trainee ID or remove the date standards met
+1389975,HB0070,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+3329403,GC7042,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",10/06/2022,
+2008753,AT3764,2021 to 2022,"Teaching apprenticeship (postgrad)
+Design and technology",10/06/2022,
+6780890,PM5795,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022,
+8262628,DS2628,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022,
+3860744,HT5730,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",10/06/2022,
+7769677,HM3654,2021 to 2022,"School direct (fee funded)
+Physical education",10/06/2022,
+5684508,XE4315,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+5597817,CY1368,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+3232248,BA0386,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+3904024,SK9525,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+5598145,ZZ0654,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",17/06/2022,
-1715621,2021 to 2022,"Provider-led (postgrad)
+7438582,FY0149,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",10/06/2022,
+8537680,YM1278,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+2732947,RS1429,2021 to 2022,"Provider-led (postgrad)
+Design and technology",17/06/2022,
+1204048,BH9051,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022,
+2763733,FM7612,2021 to 2022,"School direct (salaried)
+Music with art and design",24/06/2022,
+4876485,TA1426,2021 to 2022,Provider-led (undergrad),10/06/2022,
+4456200,SP9485,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",24/06/2022,
+4966948,MD2264,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022,
+6784447,SH2853,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022,
+9956721,FC3909,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022,
+9919650,PM7014,2021 to 2022,"Provider-led (postgrad)
+Primary",10/06/2022,
+4922124,DS9993,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+7900253,ST6988,2021 to 2022,"Provider-led (postgrad)
+Primary",17/06/2022,
+8384234,BH1454,2021 to 2022,"Provider-led (postgrad)
+Latin",12/03/2022,
+1995355,BC3735,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022,
+2177277,DQ8137,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",24/06/2022,
+1069262,YM8630,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+2953057,YY3036,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+5536974,BB3367,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022,
+4371388,ZW8916,2021 to 2022,Provider-led (undergrad),10/06/2022,
+7004997,XX4142,2021 to 2022,"School direct (fee funded)
+Physical education",10/06/2022,
+2086024,QD7026,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",10/06/2022,
+4185941,YG1496,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+8457026,CH1495,2021 to 2022,"School direct (salaried)
+Primary with modern languages",24/06/2022,
+5843544,DG6419,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary with mathematics",14/03/2022,
+6146464,DL2085,2021 to 2022,Opt-in (undergrad),24/06/2022,Date standards met provided without a TRN or Trainee ID - add a TRN or Trainee ID or remove the date standards met
+5617199,GY0902,2021 to 2022,"Provider-led (postgrad)
+Design and technology",17/06/2022,
+1785167,NL7535,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+8215464,ER6952,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+4041145,RY2137,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022,
+4700830,HG4569,2021 to 2022,"Provider-led (postgrad)
+Modern languages",17/06/2022,
+8569621,WX3307,2021 to 2022,Provider-led (undergrad),10/06/2022,
+3081702,AM9800,2021 to 2022,Provider-led (undergrad),10/06/2022,
+5536522,MR6798,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",10/06/2022,
+5646510,RC3608,2021 to 2022,"School direct (salaried)
+Italian",17/06/2022,
+6851156,EY3088,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022,
+9719346,PB6404,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022,
+7030285,EX9838,2021 to 2022,"Provider-led (postgrad)
+Primary",24/06/2022,
+4337728,SH0505,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",10/06/2022,
+8691476,DM8266,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022,
+6638309,GW6401,2021 to 2022,"Provider-led (postgrad)
+Latin",19/04/2022,
+6666531,GD6448,2021 to 2022,"School direct (fee funded)
+Biology with chemistry",10/06/2022,
+2260987,NF7094,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",10/06/2022,
+6861505,LY4803,2021 to 2022,"Provider-led (postgrad)
+Latin",17/06/2022,
+1767139,CS1630,2021 to 2022,"Teaching apprenticeship (postgrad)
+Biology with chemistry",22/02/2022,
+2693809,DN2616,2021 to 2022,"Provider-led (postgrad)
+Modern languages",11/05/2022,
+3456627,EK8893,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",24/06/2022,
+1715621,LT5293,2021 to 2022,"Provider-led (postgrad)
+Primary",17/06/2022,
+6088600,NT0340,2021 to 2022,"Provider-led (postgrad)
+Design and technology",17/06/2022,
+1484766,RB6215,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+6423079,MC9068,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",17/06/2022,
+3969536,HK1030,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",10/06/2022,
+7279498,RT3004,2021 to 2022,"Provider-led (postgrad)
+Design and technology",24/06/2022,
+7999914,DQ9717,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+9410956,AF9403,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",10/06/2022,
+9350282,MH3891,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022,
+8441731,GM2375,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022,
+4817751,NL3209,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",10/06/2022,
+1723973,DK3273,2021 to 2022,Provider-led (undergrad),24/06/2022,
+8744159,HL2974,2021 to 2022,Provider-led (undergrad),24/06/2022,
+5507441,LA5215,2021 to 2022,"Provider-led (postgrad)
+Modern languages",24/06/2022,
+7109771,WF0871,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+7371200,CS3377,2021 to 2022,"Provider-led (postgrad)
+Latin",24/06/2022,
+6408379,LM5954,2021 to 2022,Provider-led (undergrad),04/05/2022,
+9150187,HB3671,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",10/06/2022,
+3889585,WW9157,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+3865944,GX0521,2021 to 2022,"School direct (fee funded)
+Classics with English",10/06/2022,
+7882048,FW4161,2021 to 2022,"Provider-led (postgrad)
+Design and technology",10/06/2022,
+2827462,CN4219,2021 to 2022,Provider-led (undergrad),24/06/2022,
+1455999,BK4097,2021 to 2022,Provider-led (undergrad),24/06/2022,
+3417658,DN8645,2021 to 2022,"Provider-led (postgrad)
+Design and technology",21/05/2022,
+1256500,MQ9676,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",24/06/2022,
+4828006,YK9994,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",24/06/2022,
+9055186,GG9603,2021 to 2022,"Provider-led (postgrad)
+Latin",10/06/2022,
+8621661,GE6621,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",17/06/2022,
+4641293,QB7031,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",17/06/2022,
+5077067,WP3275,2021 to 2022,Provider-led (undergrad),24/06/2022,
+3738544,NZ7230,2021 to 2022,"Provider-led (postgrad)
+Latin",17/06/2022,
+4788104,AD8428,2021 to 2022,"Provider-led (postgrad)
+Modern languages",10/06/2022,
+5999712,LX1542,2021 to 2022,"Provider-led (postgrad)
+Primary",10/06/2022,
+8802182,TC8129,2021 to 2022,"Provider-led (postgrad)
+Latin",06/03/2022,
+4236028,CR0592,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",10/06/2022,
+4078189,AC7745,2021 to 2022,"Provider-led (postgrad)
+Latin",17/06/2022,
+5751332,LP2348,2021 to 2022,"School direct (fee funded)
 Primary",17/06/2022,

--- a/app/assets/downloads/recommendOnly.csv
+++ b/app/assets/downloads/recommendOnly.csv
@@ -1,4 +1,4 @@
-TRN,Trainee ID,First names,Last names,Start academic year,Route and course,Date standards met
+TRN,Provider trainee ID,First names,Last names,Start academic year,Route and course,Date standards met
 "Must contain a trainee's TRN, or be empty.
 Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
 Delete or add trainees as necessary.",For reference only,For reference only,For reference only,"Add the date when the trainee met QTS or EYTS standards.

--- a/app/assets/downloads/recommendOnly.csv
+++ b/app/assets/downloads/recommendOnly.csv
@@ -1,4 +1,4 @@
-TRN,Provider trainee ID,First names,Last names,Start academic year,Route and course,Date standards met
+TRN,Provider trainee ID,Last names,First names,Start academic year,Route and course,Date standards met
 "Must contain a trainee's TRN, or be empty.
 Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
 Delete or add trainees as necessary.",For reference only,For reference only,For reference only,"Add the date when the trainee met QTS or EYTS standards.
@@ -6,248 +6,248 @@ Must be written DD/MM/YYYY.
 For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.
 The date must be in the past.
 If the trainee has not met the QTS, leave the cell empty or delete the row.",
-6666531,GD6448,Jack,Abshire,2021 to 2022,"School direct (fee funded)
+6666531,GD6448,Abshire,Jack,2021 to 2022,"School direct (fee funded)
 Biology with chemistry",
-4912274,PD4888,Terrence,Altenwerth,2021 to 2022,"Provider-led (postgrad)
+4912274,PD4888,Altenwerth,Terrence,2021 to 2022,"Provider-led (postgrad)
 Primary with physical education",
-1995355,BC3735,Al,Auer,2021 to 2022,"Provider-led (postgrad)
+1995355,BC3735,Auer,Al,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-7004997,XX4142,Angelo,Auer,2021 to 2022,"School direct (fee funded)
+7004997,XX4142,Auer,Angelo,2021 to 2022,"School direct (fee funded)
 Physical education",
-8260100,SK3817,Joanne,Aufderhar,2021 to 2022,"Provider-led (postgrad)
+8260100,SK3817,Aufderhar,Joanne,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",
-1069262,YM8630,June,Bailey,2021 to 2022,"Provider-led (postgrad)
+1069262,YM8630,Bailey,June,2021 to 2022,"Provider-led (postgrad)
 Latin",
-3417658,DN8645,Yolanda,Barrows,2021 to 2022,"Provider-led (postgrad)
+3417658,DN8645,Barrows,Yolanda,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-4078189,AC7745,Isaac,Barton,2021 to 2022,"Provider-led (postgrad)
+4078189,AC7745,Barton,Isaac,2021 to 2022,"Provider-led (postgrad)
 Latin",
-7900253,ST6988,Jose,Batz,2021 to 2022,"Provider-led (postgrad)
+7900253,ST6988,Batz,Jose,2021 to 2022,"Provider-led (postgrad)
 Primary",
-5646510,RC3608,Rafael,Beatty,2021 to 2022,"School direct (salaried)
+5646510,RC3608,Beatty,Rafael,2021 to 2022,"School direct (salaried)
 Italian",
-8744159,HL2974,Lester,Beer,2021 to 2022,Provider-led (undergrad),
-2732947,RS1429,Jaime,Beier,2021 to 2022,"Provider-led (postgrad)
+8744159,HL2974,Beer,Lester,2021 to 2022,Provider-led (undergrad),
+2732947,RS1429,Beier,Jaime,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-9837500,RN4482,Olive,Benoit,2021 to 2022,"Provider-led (postgrad)
+9837500,RN4482,Benoit,Olive,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-7851957,NH4668,Émeric,Bertrand,2021 to 2022,"Provider-led (postgrad)
+7851957,NH4668,Bertrand,Émeric,2021 to 2022,"Provider-led (postgrad)
 Latin",
-9956721,FC3909,Irving,Boehm,2021 to 2022,"Provider-led (postgrad)
+9956721,FC3909,Boehm,Irving,2021 to 2022,"Provider-led (postgrad)
 Modern languages",
-4641293,QB7031,Mario,Borer,2021 to 2022,"Provider-led (postgrad)
+4641293,QB7031,Borer,Mario,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-5578493,XR1159,Doris,Botsford,2021 to 2022,"Provider-led (postgrad)
+5578493,XR1159,Botsford,Doris,2021 to 2022,"Provider-led (postgrad)
 Latin",
-8691476,DM8266,Vickie,Bradtke,2021 to 2022,"Provider-led (postgrad)
+8691476,DM8266,Bradtke,Vickie,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-4930476,EC6238,Laureline,Caron,2021 to 2022,"Provider-led (postgrad)
+4930476,EC6238,Caron,Laureline,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-6408379,LM5954,Eudoxe,Caron,2021 to 2022,Provider-led (undergrad),
-8537680,YM1278,Raoul,Carpentier,2021 to 2022,"Provider-led (postgrad)
+6408379,LM5954,Caron,Eudoxe,2021 to 2022,Provider-led (undergrad),
+8537680,YM1278,Carpentier,Raoul,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-5751332,LP2348,Pearl,Champlin,2021 to 2022,"School direct (fee funded)
+5751332,LP2348,Champlin,Pearl,2021 to 2022,"School direct (fee funded)
 Primary",
-9719346,PB6404,Christine,Chevalier,2021 to 2022,"Provider-led (postgrad)
+9719346,PB6404,Chevalier,Christine,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-8457026,CH1495,Gary,Collier,2021 to 2022,"School direct (salaried)
+8457026,CH1495,Collier,Gary,2021 to 2022,"School direct (salaried)
 Primary with modern languages",
-3904024,SK9525,Patty,Collins,2021 to 2022,"Provider-led (postgrad)
+3904024,SK9525,Collins,Patty,2021 to 2022,"Provider-led (postgrad)
 Latin",
-9457054,RT7878,Francisco,Considine,2021 to 2022,"Provider-led (postgrad)
+9457054,RT7878,Considine,Francisco,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-6896165,CG5580,Alcyone,Da silva,2021 to 2022,"School direct (fee funded)
+6896165,CG5580,Da silva,Alcyone,2021 to 2022,"School direct (fee funded)
 Design and technology with English",
-8832625,HD9024,Max,Deckow,2021 to 2022,"School direct (fee funded)
+8832625,HD9024,Deckow,Max,2021 to 2022,"School direct (fee funded)
 Physical education",
-7999914,DQ9717,Carla,Deckow,2021 to 2022,"Provider-led (postgrad)
+7999914,DQ9717,Deckow,Carla,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-3007806,LY3676,Shannon,Dickens,2021 to 2022,"Provider-led (postgrad)
+3007806,LY3676,Dickens,Shannon,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-9410956,AF9403,Omar,Donnelly,2021 to 2022,"Provider-led (postgrad)
+9410956,AF9403,Donnelly,Omar,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",
-1256500,MQ9676,Lucien,Dupuis,2021 to 2022,"Provider-led (postgrad)
+1256500,MQ9676,Dupuis,Lucien,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",
-8441731,GM2375,Gene,Durgan,2021 to 2022,"Provider-led (postgrad)
+8441731,GM2375,Durgan,Gene,2021 to 2022,"Provider-led (postgrad)
 Modern languages",
-3738544,NZ7230,Jacqueline,Durgan,2021 to 2022,"Provider-led (postgrad)
+3738544,NZ7230,Durgan,Jacqueline,2021 to 2022,"Provider-led (postgrad)
 Latin",
-2827462,CN4219,Julia,Erdman,2021 to 2022,Provider-led (undergrad),
-3073808,QB3717,Theresa,Fahey,2021 to 2022,"Provider-led (postgrad)
+2827462,CN4219,Erdman,Julia,2021 to 2022,Provider-led (undergrad),
+3073808,QB3717,Fahey,Theresa,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-4700830,HG4569,Marion,Flatley,2021 to 2022,"Provider-led (postgrad)
+4700830,HG4569,Flatley,Marion,2021 to 2022,"Provider-led (postgrad)
 Modern languages",
-3379589,EM2761,Angélina,Fournier,2021 to 2022,"School direct (salaried)
+3379589,EM2761,Fournier,Angélina,2021 to 2022,"School direct (salaried)
 Primary",
-5054746,AW3371,Margie,Frami,2021 to 2022,"Provider-led (postgrad)
+5054746,AW3371,Frami,Margie,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",
-4041145,RY2137,Lorena,Franey,2021 to 2022,"Provider-led (postgrad)
+4041145,RY2137,Franey,Lorena,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-8569621,WX3307,Mamie,Funk,2021 to 2022,Provider-led (undergrad),
-9055186,GG9603,Margarita,Funk,2021 to 2022,"Provider-led (postgrad)
+8569621,WX3307,Funk,Mamie,2021 to 2022,Provider-led (undergrad),
+9055186,GG9603,Funk,Margarita,2021 to 2022,"Provider-led (postgrad)
 Latin",
-4371388,ZW8916,Aphélie,Garcia,2021 to 2022,Provider-led (undergrad),
-5843544,DG6419,Elena,Gibson,2021 to 2022,"Teaching apprenticeship (postgrad)
+4371388,ZW8916,Garcia,Aphélie,2021 to 2022,Provider-led (undergrad),
+5843544,DG6419,Gibson,Elena,2021 to 2022,"Teaching apprenticeship (postgrad)
 Primary with mathematics",
-3969536,HK1030,Byron,Gottlieb,2021 to 2022,"Provider-led (postgrad)
+3969536,HK1030,Gottlieb,Byron,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",
-9150187,HB3671,Isabelle,Guerin,2021 to 2022,"Provider-led (postgrad)
+9150187,HB3671,Guerin,Isabelle,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",
-7279498,RT3004,Blake,Gulgowski,2021 to 2022,"Provider-led (postgrad)
+7279498,RT3004,Gulgowski,Blake,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-1785167,NL7535,Alison,Hagenes,2021 to 2022,"Provider-led (postgrad)
+1785167,NL7535,Hagenes,Alison,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-7009193,HH3355,Rodney,Halvorson,2021 to 2022,"Provider-led (postgrad)
+7009193,HH3355,Halvorson,Rodney,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",
-4456200,SP9485,Woodrow,Hartmann,2021 to 2022,"Provider-led (postgrad)
+4456200,SP9485,Hartmann,Woodrow,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",
-8957378,GM5727,Benny,Harvey,2021 to 2022,Provider-led (undergrad),
-5598145,ZZ0654,Stuart,Hauck,2021 to 2022,"Provider-led (postgrad)
+8957378,GM5727,Harvey,Benny,2021 to 2022,Provider-led (undergrad),
+5598145,ZZ0654,Hauck,Stuart,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-2493764,EQ2692,Kim,Heathcote,2021 to 2022,"Provider-led (postgrad)
+2493764,EQ2692,Heathcote,Kim,2021 to 2022,"Provider-led (postgrad)
 Primary",
-9729520,BT0697,Nick,Heller,2021 to 2022,"Provider-led (postgrad)
+9729520,BT0697,Heller,Nick,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",
-1455999,BK4097,Jacquelyn,Herman,2021 to 2022,Provider-led (undergrad),
-8262628,DS2628,Phyllis,Hermann,2021 to 2022,"Provider-led (postgrad)
+1455999,BK4097,Herman,Jacquelyn,2021 to 2022,Provider-led (undergrad),
+8262628,DS2628,Hermann,Phyllis,2021 to 2022,"Provider-led (postgrad)
 Latin",
-2953057,YY3036,Cameron,Hermann,2021 to 2022,"Provider-led (postgrad)
+2953057,YY3036,Hermann,Cameron,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-5077067,WP3275,Brandy,Hilll,2021 to 2022,Provider-led (undergrad),
-6861505,LY4803,Edna,Hills,2021 to 2022,"Provider-led (postgrad)
+5077067,WP3275,Hilll,Brandy,2021 to 2022,Provider-led (undergrad),
+6861505,LY4803,Hills,Edna,2021 to 2022,"Provider-led (postgrad)
 Latin",
-6784447,SH2853,Katrina,Hodkiewicz,2021 to 2022,"Provider-led (postgrad)
+6784447,SH2853,Hodkiewicz,Katrina,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-7769677,HM3654,Patti,Jacobson,2021 to 2022,"School direct (fee funded)
+7769677,HM3654,Jacobson,Patti,2021 to 2022,"School direct (fee funded)
 Physical education",
-8748026,CG8977,Quiéta,Jacquet,2021 to 2022,"School direct (fee funded)
+8748026,CG8977,Jacquet,Quiéta,2021 to 2022,"School direct (fee funded)
 Primary",
-9350282,MH3891,Terry,Jast,2021 to 2022,"Provider-led (postgrad)
+9350282,MH3891,Jast,Terry,2021 to 2022,"Provider-led (postgrad)
 Latin",
-6780890,PM5795,Randall,Kerluke,2021 to 2022,"Provider-led (postgrad)
+6780890,PM5795,Kerluke,Randall,2021 to 2022,"Provider-led (postgrad)
 Modern languages",
-4337728,SH0505,Grant,Kirlin,2021 to 2022,"Provider-led (postgrad)
+4337728,SH0505,Kirlin,Grant,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",
-3865944,GX0521,Merle,Klocko,2021 to 2022,"School direct (fee funded)
+3865944,GX0521,Klocko,Merle,2021 to 2022,"School direct (fee funded)
 Classics with English",
-9919650,PM7014,Winston,Kohler,2021 to 2022,"Provider-led (postgrad)
+9919650,PM7014,Kohler,Winston,2021 to 2022,"Provider-led (postgrad)
 Primary",
-6198842,TD9870,Kerry,Konopelski,2021 to 2022,"Teaching apprenticeship (postgrad)
+6198842,TD9870,Konopelski,Kerry,2021 to 2022,"Teaching apprenticeship (postgrad)
 Modern languages",
-2177277,DQ8137,Oliver,Kovacek,2021 to 2022,"Provider-led (postgrad)
+2177277,DQ8137,Kovacek,Oliver,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",
-4073732,QS6710,Vital,Lacroix,2021 to 2022,"Provider-led (postgrad)
+4073732,QS6710,Lacroix,Vital,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",
-5999712,LX1542,Christina,Langosh,2021 to 2022,"Provider-led (postgrad)
+5999712,LX1542,Langosh,Christina,2021 to 2022,"Provider-led (postgrad)
 Primary",
-9888335,AB9131,Fidèle,Laurent,2021 to 2022,"Provider-led (postgrad)
+9888335,AB9131,Laurent,Fidèle,2021 to 2022,"Provider-led (postgrad)
 Primary with physical education",
-2086024,QD7026,Sylvie,Laurent,2021 to 2022,"Provider-led (postgrad)
+2086024,QD7026,Laurent,Sylvie,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",
-7646286,WA3900,Whitney,Lehner,2021 to 2022,"Provider-led (postgrad)
+7646286,WA3900,Lehner,Whitney,2021 to 2022,"Provider-led (postgrad)
 Latin",
-7882048,FW4161,Victorin,Lemaire,2021 to 2022,"Provider-led (postgrad)
+7882048,FW4161,Lemaire,Victorin,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-7347971,PY7485,Stanislas,Lemoine,2021 to 2022,"Provider-led (postgrad)
+7347971,PY7485,Lemoine,Stanislas,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-1484766,RB6215,Jessica,Lubowitz,2021 to 2022,"Provider-led (postgrad)
+1484766,RB6215,Lubowitz,Jessica,2021 to 2022,"Provider-led (postgrad)
 Latin",
-6638309,GW6401,Antoinette,Lueilwitz,2021 to 2022,"Provider-led (postgrad)
+6638309,GW6401,Lueilwitz,Antoinette,2021 to 2022,"Provider-led (postgrad)
 Latin",
-4236028,CR0592,Olive,Mante,2021 to 2022,"Provider-led (postgrad)
+4236028,CR0592,Mante,Olive,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-5597817,CY1368,Marlène,Marie,2021 to 2022,"Provider-led (postgrad)
+5597817,CY1368,Marie,Marlène,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-5410523,ZW5355,Aliette,Meunier,2021 to 2022,"Provider-led (postgrad)
+5410523,ZW5355,Meunier,Aliette,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-5536974,BB3367,Moses,Miller,2021 to 2022,"Provider-led (postgrad)
+5536974,BB3367,Miller,Moses,2021 to 2022,"Provider-led (postgrad)
 Latin",
-6851156,EY3088,Victor,Mills,2021 to 2022,"Provider-led (postgrad)
+6851156,EY3088,Mills,Victor,2021 to 2022,"Provider-led (postgrad)
 Latin",
-5617199,GY0902,Arthaud,Moreau,2021 to 2022,"Provider-led (postgrad)
+5617199,GY0902,Moreau,Arthaud,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-1389975,HB0070,Amber,Mosciski,2021 to 2022,"Provider-led (postgrad)
+1389975,HB0070,Mosciski,Amber,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-4876485,TA1426,Ora,Mosciski,2021 to 2022,Provider-led (undergrad),
-8215464,ER6952,Cassien,Moulin,2021 to 2022,"Provider-led (postgrad)
+4876485,TA1426,Mosciski,Ora,2021 to 2022,Provider-led (undergrad),
+8215464,ER6952,Moulin,Cassien,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-7900821,FM9996,David,Nitzsche,2021 to 2022,"Provider-led (postgrad)
+7900821,FM9996,Nitzsche,David,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-8273630,TM7395,Aubrey,O'Kon,2021 to 2022,"Provider-led (postgrad)
+8273630,TM7395,O'Kon,Aubrey,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-3860744,HT5730,Orlando,O'Reilly,2021 to 2022,"Provider-led (postgrad)
+3860744,HT5730,O'Reilly,Orlando,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",
-8384234,BH1454,Annette,Pacocha,2021 to 2022,"Provider-led (postgrad)
+8384234,BH1454,Pacocha,Annette,2021 to 2022,"Provider-led (postgrad)
 Latin",
-1204048,BH9051,Angélina,Perrot,2021 to 2022,"Provider-led (postgrad)
+1204048,BH9051,Perrot,Angélina,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-6088600,NT0340,Léonne,Petit,2021 to 2022,"Provider-led (postgrad)
+6088600,NT0340,Petit,Léonne,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-4185941,YG1496,Saul,Pfannerstill,2021 to 2022,"Provider-led (postgrad)
+4185941,YG1496,Pfannerstill,Saul,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-4828006,YK9994,Harold,Pfeffer,2021 to 2022,"Provider-led (postgrad)
+4828006,YK9994,Pfeffer,Harold,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",
-3329403,GC7042,Erik,Pollich,2021 to 2022,"Provider-led (postgrad)
+3329403,GC7042,Pollich,Erik,2021 to 2022,"Provider-led (postgrad)
 Primary with physical education",
-5684508,XE4315,Martha,Pouros,2021 to 2022,"Provider-led (postgrad)
+5684508,XE4315,Pouros,Martha,2021 to 2022,"Provider-led (postgrad)
 Latin",
-3232248,BA0386,Germaine,Prevost,2021 to 2022,"Provider-led (postgrad)
+3232248,BA0386,Prevost,Germaine,2021 to 2022,"Provider-led (postgrad)
 Latin",
-7371200,CS3377,Annabelle,Prevost,2021 to 2022,"Provider-led (postgrad)
+7371200,CS3377,Prevost,Annabelle,2021 to 2022,"Provider-led (postgrad)
 Latin",
-4922124,DS9993,Pat,Rempel,2021 to 2022,"Provider-led (postgrad)
+4922124,DS9993,Rempel,Pat,2021 to 2022,"Provider-led (postgrad)
 Latin",
-7109771,WF0871,Avigaëlle,Remy,2021 to 2022,"Provider-led (postgrad)
+7109771,WF0871,Remy,Avigaëlle,2021 to 2022,"Provider-led (postgrad)
 Latin",
-4817751,NL3209,Céleste,Renaud,2021 to 2022,"Provider-led (postgrad)
+4817751,NL3209,Renaud,Céleste,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",
-8668206,QW3812,Russell,Renner,2021 to 2022,"Provider-led (postgrad)
+8668206,QW3812,Renner,Russell,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-4788104,AD8428,Gautier,Rey,2021 to 2022,"Provider-led (postgrad)
+4788104,AD8428,Rey,Gautier,2021 to 2022,"Provider-led (postgrad)
 Modern languages",
-3960844,SH6489,Gatien,Robert,2021 to 2022,"Provider-led (postgrad)
+3960844,SH6489,Robert,Gatien,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-3889585,WW9157,Daphné,Robert,2021 to 2022,"Provider-led (postgrad)
+3889585,WW9157,Robert,Daphné,2021 to 2022,"Provider-led (postgrad)
 Latin",
-7311560,MN8220,Amalthée,Roger,2021 to 2022,"Provider-led (postgrad)
+7311560,MN8220,Roger,Amalthée,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",
-1767139,CS1630,Kelly,Rolfson,2021 to 2022,"Teaching apprenticeship (postgrad)
+1767139,CS1630,Rolfson,Kelly,2021 to 2022,"Teaching apprenticeship (postgrad)
 Biology with chemistry",
-4966948,MD2264,Yolanda,Runolfsdottir,2021 to 2022,"Provider-led (postgrad)
+4966948,MD2264,Runolfsdottir,Yolanda,2021 to 2022,"Provider-led (postgrad)
 Modern languages",
-3081702,AM9800,Lee,Sawayn,2021 to 2022,Provider-led (undergrad),
-7030285,EX9838,Andre,Schaefer,2021 to 2022,"Provider-led (postgrad)
+3081702,AM9800,Sawayn,Lee,2021 to 2022,Provider-led (undergrad),
+7030285,EX9838,Schaefer,Andre,2021 to 2022,"Provider-led (postgrad)
 Primary",
-2260987,NF7094,Jody,Schneider,2021 to 2022,"Provider-led (postgrad)
+2260987,NF7094,Schneider,Jody,2021 to 2022,"Provider-led (postgrad)
 Primary with physical education",
-2693809,DN2616,Mabel,Schroeder,2021 to 2022,"Provider-led (postgrad)
+2693809,DN2616,Schroeder,Mabel,2021 to 2022,"Provider-led (postgrad)
 Modern languages",
-8675815,TX1993,Gwen,Shields,2021 to 2022,"Provider-led (postgrad)
+8675815,TX1993,Shields,Gwen,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",
-1723973,DK3273,Alfred,Sipes,2021 to 2022,Provider-led (undergrad),
-7438582,FY0149,Rogelio,Stanton,2021 to 2022,"Provider-led (postgrad)
+1723973,DK3273,Sipes,Alfred,2021 to 2022,Provider-led (undergrad),
+7438582,FY0149,Stanton,Rogelio,2021 to 2022,"Provider-led (postgrad)
 Primary with physical education",
-3456627,EK8893,Carol,Stark,2021 to 2022,"Provider-led (postgrad)
+3456627,EK8893,Stark,Carol,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",
-9800306,BE6825,Dwight,Steuber,2021 to 2022,Provider-led (undergrad),
-5061918,BE0921,Victor,Stoltenberg,2021 to 2022,"Provider-led (postgrad)
+9800306,BE6825,Steuber,Dwight,2021 to 2022,Provider-led (undergrad),
+5061918,BE0921,Stoltenberg,Victor,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-6423079,MC9068,Randal,Stracke,2021 to 2022,"Provider-led (postgrad)
+6423079,MC9068,Stracke,Randal,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",
-5609184,QH2562,Sheldon,Swaniawski,2021 to 2022,"School direct (fee funded)
+5609184,QH2562,Swaniawski,Sheldon,2021 to 2022,"School direct (fee funded)
 Primary",
-8802182,TC8129,Nathan,Swift,2021 to 2022,"Provider-led (postgrad)
+8802182,TC8129,Swift,Nathan,2021 to 2022,"Provider-led (postgrad)
 Latin",
-2008753,AT3764,Héloïse,Thomas,2021 to 2022,"Teaching apprenticeship (postgrad)
+2008753,AT3764,Thomas,Héloïse,2021 to 2022,"Teaching apprenticeship (postgrad)
 Design and technology",
-5507441,LA5215,Drew,Tillman,2021 to 2022,"Provider-led (postgrad)
+5507441,LA5215,Tillman,Drew,2021 to 2022,"Provider-led (postgrad)
 Modern languages",
-5536522,MR6798,Ethel,Volkman,2021 to 2022,"Provider-led (postgrad)
+5536522,MR6798,Volkman,Ethel,2021 to 2022,"Provider-led (postgrad)
 Primary with modern languages",
-6146464,DL2085,Max,Von,2021 to 2022,Opt-in (undergrad),
-2763733,FM7612,Winston,Walsh,2021 to 2022,"School direct (salaried)
+6146464,DL2085,Von,Max,2021 to 2022,Opt-in (undergrad),
+2763733,FM7612,Walsh,Winston,2021 to 2022,"School direct (salaried)
 Music with art and design",
-8621661,GE6621,Jimmie,Wuckert,2021 to 2022,"Provider-led (postgrad)
+8621661,GE6621,Wuckert,Jimmie,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-1715621,LT5293,Luke,Wyman,2021 to 2022,"Provider-led (postgrad)
+1715621,LT5293,Wyman,Luke,2021 to 2022,"Provider-led (postgrad)
 Primary",

--- a/app/assets/downloads/recommendOnly.csv
+++ b/app/assets/downloads/recommendOnly.csv
@@ -1,252 +1,253 @@
-TRN,Start academic year,Route and course,Date standards met
-"Must contain a trainee's TRN. Delete or add trainees as necessary.
-TRNs must be 7 digits.",For reference only.,For reference only.,"Add the date when the trainee met QTS or EYTS standards.
+TRN,Trainee ID,Start academic year,Route and course,Date standards met
+"Must contain a trainee's TRN, or be empty.
+Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
+Delete or add trainees as necessary.",For reference only.,For reference only.,"Add the date when the trainee met QTS or EYTS standards.
 Must be written DD/MM/YYYY.
 For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.
 The date must be in the past.
 If the trainee has not met the QTS, leave the cell empty or delete the row."
-6666531,2021 to 2022,"School direct (fee funded)
-Biology with chemistry",
-4912274,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",
-1995355,2021 to 2022,"Provider-led (postgrad)
+9837500,RN4482,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-7004997,2021 to 2022,"School direct (fee funded)
-Physical education",
-8260100,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-1069262,2021 to 2022,"Provider-led (postgrad)
-Latin",
-3417658,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-4078189,2021 to 2022,"Provider-led (postgrad)
-Latin",
-7900253,2021 to 2022,"Provider-led (postgrad)
+5609184,QH2562,2021 to 2022,"School direct (fee funded)
 Primary",
-5646510,2021 to 2022,"School direct (salaried)
-Italian",
-8744159,2021 to 2022,Provider-led (undergrad),
-2732947,2021 to 2022,"Provider-led (postgrad)
+8273630,TM7395,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-9837500,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-7851957,2021 to 2022,"Provider-led (postgrad)
-Latin",
-9956721,2021 to 2022,"Provider-led (postgrad)
-Modern languages",
-4641293,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-5578493,2021 to 2022,"Provider-led (postgrad)
-Latin",
-8691476,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-4930476,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-6408379,2021 to 2022,Provider-led (undergrad),
-8537680,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-5751332,2021 to 2022,"School direct (fee funded)
-Primary",
-9719346,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-8457026,2021 to 2022,"School direct (salaried)
-Primary with modern languages",
-3904024,2021 to 2022,"Provider-led (postgrad)
-Latin",
-9457054,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-6896165,2021 to 2022,"School direct (fee funded)
+7311560,MN8220,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+6896165,CG5580,2021 to 2022,"School direct (fee funded)
 Design and technology with English",
-8832625,2021 to 2022,"School direct (fee funded)
+7009193,HH3355,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",
+9457054,RT7878,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+5054746,AW3371,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+8957378,GM5727,2021 to 2022,Provider-led (undergrad),
+4073732,QS6710,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+8675815,TX1993,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",
+3960844,SH6489,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+7646286,WA3900,2021 to 2022,"Provider-led (postgrad)
+Latin",
+8832625,HD9024,2021 to 2022,"School direct (fee funded)
 Physical education",
-7999914,2021 to 2022,"Provider-led (postgrad)
+8668206,QW3812,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-3007806,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-9410956,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",
-1256500,2021 to 2022,"Provider-led (postgrad)
+9729520,BT0697,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",
-8441731,2021 to 2022,"Provider-led (postgrad)
+6198842,TD9870,2021 to 2022,"Teaching apprenticeship (postgrad)
 Modern languages",
-3738544,2021 to 2022,"Provider-led (postgrad)
+5578493,XR1159,2021 to 2022,"Provider-led (postgrad)
 Latin",
-2827462,2021 to 2022,Provider-led (undergrad),
-3073808,2021 to 2022,"Provider-led (postgrad)
+3379589,EM2761,2021 to 2022,"School direct (salaried)
+Primary",
+9800306,BE6825,2021 to 2022,Provider-led (undergrad),
+4930476,EC6238,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+5061918,BE0921,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+8748026,CG8977,2021 to 2022,"School direct (fee funded)
+Primary",
+7900821,FM9996,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+2493764,EQ2692,2021 to 2022,"Provider-led (postgrad)
+Primary",
+9888335,AB9131,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",
+8260100,SK3817,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+3073808,QB3717,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-4700830,2021 to 2022,"Provider-led (postgrad)
+7347971,PY7485,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+7851957,NH4668,2021 to 2022,"Provider-led (postgrad)
+Latin",
+4912274,PD4888,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",
+3007806,LY3676,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+5410523,ZW5355,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+1389975,HB0070,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+3329403,GC7042,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",
+2008753,AT3764,2021 to 2022,"Teaching apprenticeship (postgrad)
+Design and technology",
+6780890,PM5795,2021 to 2022,"Provider-led (postgrad)
 Modern languages",
-3379589,2021 to 2022,"School direct (salaried)
-Primary",
-5054746,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-4041145,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-8569621,2021 to 2022,Provider-led (undergrad),
-9055186,2021 to 2022,"Provider-led (postgrad)
+8262628,DS2628,2021 to 2022,"Provider-led (postgrad)
 Latin",
-4371388,2021 to 2022,Provider-led (undergrad),
-5843544,2021 to 2022,"Teaching apprenticeship (postgrad)
-Primary with mathematics",
-3969536,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",
-9150187,2021 to 2022,"Provider-led (postgrad)
+3860744,HT5730,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",
-7279498,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-1785167,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-7009193,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",
-4456200,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",
-8957378,2021 to 2022,Provider-led (undergrad),
-5598145,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-2493764,2021 to 2022,"Provider-led (postgrad)
-Primary",
-9729520,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-1455999,2021 to 2022,Provider-led (undergrad),
-8262628,2021 to 2022,"Provider-led (postgrad)
-Latin",
-2953057,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-5077067,2021 to 2022,Provider-led (undergrad),
-6861505,2021 to 2022,"Provider-led (postgrad)
-Latin",
-6784447,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-7769677,2021 to 2022,"School direct (fee funded)
+7769677,HM3654,2021 to 2022,"School direct (fee funded)
 Physical education",
-8748026,2021 to 2022,"School direct (fee funded)
-Primary",
-9350282,2021 to 2022,"Provider-led (postgrad)
+5684508,XE4315,2021 to 2022,"Provider-led (postgrad)
 Latin",
-6780890,2021 to 2022,"Provider-led (postgrad)
-Modern languages",
-4337728,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-3865944,2021 to 2022,"School direct (fee funded)
-Classics with English",
-9919650,2021 to 2022,"Provider-led (postgrad)
-Primary",
-6198842,2021 to 2022,"Teaching apprenticeship (postgrad)
-Modern languages",
-2177277,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",
-4073732,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-5999712,2021 to 2022,"Provider-led (postgrad)
-Primary",
-9888335,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",
-2086024,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",
-7646286,2021 to 2022,"Provider-led (postgrad)
-Latin",
-7882048,2021 to 2022,"Provider-led (postgrad)
+5597817,CY1368,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-7347971,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-1484766,2021 to 2022,"Provider-led (postgrad)
+3232248,BA0386,2021 to 2022,"Provider-led (postgrad)
 Latin",
-6638309,2021 to 2022,"Provider-led (postgrad)
+3904024,SK9525,2021 to 2022,"Provider-led (postgrad)
 Latin",
-4236028,2021 to 2022,"Provider-led (postgrad)
+5598145,ZZ0654,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-5597817,2021 to 2022,"Provider-led (postgrad)
+7438582,FY0149,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",
+8537680,YM1278,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-5410523,2021 to 2022,"Provider-led (postgrad)
+2732947,RS1429,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-5536974,2021 to 2022,"Provider-led (postgrad)
-Latin",
-6851156,2021 to 2022,"Provider-led (postgrad)
-Latin",
-5617199,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-1389975,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-4876485,2021 to 2022,Provider-led (undergrad),
-8215464,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-7900821,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-8273630,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-3860744,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-8384234,2021 to 2022,"Provider-led (postgrad)
-Latin",
-1204048,2021 to 2022,"Provider-led (postgrad)
+1204048,BH9051,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-6088600,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-4185941,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-4828006,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-3329403,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",
-5684508,2021 to 2022,"Provider-led (postgrad)
-Latin",
-3232248,2021 to 2022,"Provider-led (postgrad)
-Latin",
-7371200,2021 to 2022,"Provider-led (postgrad)
-Latin",
-4922124,2021 to 2022,"Provider-led (postgrad)
-Latin",
-7109771,2021 to 2022,"Provider-led (postgrad)
-Latin",
-4817751,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",
-8668206,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-4788104,2021 to 2022,"Provider-led (postgrad)
-Modern languages",
-3960844,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-3889585,2021 to 2022,"Provider-led (postgrad)
-Latin",
-7311560,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-1767139,2021 to 2022,"Teaching apprenticeship (postgrad)
-Biology with chemistry",
-4966948,2021 to 2022,"Provider-led (postgrad)
-Modern languages",
-3081702,2021 to 2022,Provider-led (undergrad),
-7030285,2021 to 2022,"Provider-led (postgrad)
-Primary",
-2260987,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",
-2693809,2021 to 2022,"Provider-led (postgrad)
-Modern languages",
-8675815,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",
-1723973,2021 to 2022,Provider-led (undergrad),
-7438582,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",
-3456627,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",
-9800306,2021 to 2022,Provider-led (undergrad),
-5061918,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-6423079,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",
-5609184,2021 to 2022,"School direct (fee funded)
-Primary",
-8802182,2021 to 2022,"Provider-led (postgrad)
-Latin",
-2008753,2021 to 2022,"Teaching apprenticeship (postgrad)
-Design and technology",
-5507441,2021 to 2022,"Provider-led (postgrad)
-Modern languages",
-5536522,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",
-6146464,2021 to 2022,Opt-in (undergrad),
-2763733,2021 to 2022,"School direct (salaried)
+2763733,FM7612,2021 to 2022,"School direct (salaried)
 Music with art and design",
-8621661,2021 to 2022,"Provider-led (postgrad)
+4876485,TA1426,2021 to 2022,Provider-led (undergrad),
+4456200,SP9485,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",
+4966948,MD2264,2021 to 2022,"Provider-led (postgrad)
+Modern languages",
+6784447,SH2853,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-1715621,2021 to 2022,"Provider-led (postgrad)
+9956721,FC3909,2021 to 2022,"Provider-led (postgrad)
+Modern languages",
+9919650,PM7014,2021 to 2022,"Provider-led (postgrad)
+Primary",
+4922124,DS9993,2021 to 2022,"Provider-led (postgrad)
+Latin",
+7900253,ST6988,2021 to 2022,"Provider-led (postgrad)
+Primary",
+8384234,BH1454,2021 to 2022,"Provider-led (postgrad)
+Latin",
+1995355,BC3735,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+2177277,DQ8137,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",
+1069262,YM8630,2021 to 2022,"Provider-led (postgrad)
+Latin",
+2953057,YY3036,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+5536974,BB3367,2021 to 2022,"Provider-led (postgrad)
+Latin",
+4371388,ZW8916,2021 to 2022,Provider-led (undergrad),
+7004997,XX4142,2021 to 2022,"School direct (fee funded)
+Physical education",
+2086024,QD7026,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",
+4185941,YG1496,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+8457026,CH1495,2021 to 2022,"School direct (salaried)
+Primary with modern languages",
+5843544,DG6419,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary with mathematics",
+6146464,DL2085,2021 to 2022,Opt-in (undergrad),
+5617199,GY0902,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+1785167,NL7535,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+8215464,ER6952,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+4041145,RY2137,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+4700830,HG4569,2021 to 2022,"Provider-led (postgrad)
+Modern languages",
+8569621,WX3307,2021 to 2022,Provider-led (undergrad),
+3081702,AM9800,2021 to 2022,Provider-led (undergrad),
+5536522,MR6798,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",
+5646510,RC3608,2021 to 2022,"School direct (salaried)
+Italian",
+6851156,EY3088,2021 to 2022,"Provider-led (postgrad)
+Latin",
+9719346,PB6404,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+7030285,EX9838,2021 to 2022,"Provider-led (postgrad)
+Primary",
+4337728,SH0505,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+8691476,DM8266,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+6638309,GW6401,2021 to 2022,"Provider-led (postgrad)
+Latin",
+6666531,GD6448,2021 to 2022,"School direct (fee funded)
+Biology with chemistry",
+2260987,NF7094,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",
+6861505,LY4803,2021 to 2022,"Provider-led (postgrad)
+Latin",
+1767139,CS1630,2021 to 2022,"Teaching apprenticeship (postgrad)
+Biology with chemistry",
+2693809,DN2616,2021 to 2022,"Provider-led (postgrad)
+Modern languages",
+3456627,EK8893,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",
+1715621,LT5293,2021 to 2022,"Provider-led (postgrad)
+Primary",
+6088600,NT0340,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+1484766,RB6215,2021 to 2022,"Provider-led (postgrad)
+Latin",
+6423079,MC9068,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",
+3969536,HK1030,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",
+7279498,RT3004,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+7999914,DQ9717,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+9410956,AF9403,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",
+9350282,MH3891,2021 to 2022,"Provider-led (postgrad)
+Latin",
+8441731,GM2375,2021 to 2022,"Provider-led (postgrad)
+Modern languages",
+4817751,NL3209,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",
+1723973,DK3273,2021 to 2022,Provider-led (undergrad),
+8744159,HL2974,2021 to 2022,Provider-led (undergrad),
+5507441,LA5215,2021 to 2022,"Provider-led (postgrad)
+Modern languages",
+7109771,WF0871,2021 to 2022,"Provider-led (postgrad)
+Latin",
+7371200,CS3377,2021 to 2022,"Provider-led (postgrad)
+Latin",
+6408379,LM5954,2021 to 2022,Provider-led (undergrad),
+9150187,HB3671,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+3889585,WW9157,2021 to 2022,"Provider-led (postgrad)
+Latin",
+3865944,GX0521,2021 to 2022,"School direct (fee funded)
+Classics with English",
+7882048,FW4161,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+2827462,CN4219,2021 to 2022,Provider-led (undergrad),
+1455999,BK4097,2021 to 2022,Provider-led (undergrad),
+3417658,DN8645,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+1256500,MQ9676,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+4828006,YK9994,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+9055186,GG9603,2021 to 2022,"Provider-led (postgrad)
+Latin",
+8621661,GE6621,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+4641293,QB7031,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+5077067,WP3275,2021 to 2022,Provider-led (undergrad),
+3738544,NZ7230,2021 to 2022,"Provider-led (postgrad)
+Latin",
+4788104,AD8428,2021 to 2022,"Provider-led (postgrad)
+Modern languages",
+5999712,LX1542,2021 to 2022,"Provider-led (postgrad)
+Primary",
+8802182,TC8129,2021 to 2022,"Provider-led (postgrad)
+Latin",
+4236028,CR0592,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+4078189,AC7745,2021 to 2022,"Provider-led (postgrad)
+Latin",
+5751332,LP2348,2021 to 2022,"School direct (fee funded)
 Primary",

--- a/app/assets/downloads/recommendOnly.csv
+++ b/app/assets/downloads/recommendOnly.csv
@@ -1,253 +1,253 @@
-TRN,Trainee ID,Start academic year,Route and course,Date standards met
+TRN,Trainee ID,First names,Last names,Start academic year,Route and course,Date standards met
 "Must contain a trainee's TRN, or be empty.
 Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
-Delete or add trainees as necessary.",For reference only.,For reference only.,"Add the date when the trainee met QTS or EYTS standards.
+Delete or add trainees as necessary.",For reference only,For reference only,For reference only,"Add the date when the trainee met QTS or EYTS standards.
 Must be written DD/MM/YYYY.
 For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.
 The date must be in the past.
-If the trainee has not met the QTS, leave the cell empty or delete the row."
-9837500,RN4482,2021 to 2022,"Provider-led (postgrad)
+If the trainee has not met the QTS, leave the cell empty or delete the row.",
+6666531,GD6448,Jack,Abshire,2021 to 2022,"School direct (fee funded)
+Biology with chemistry",
+4912274,PD4888,Terrence,Altenwerth,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",
+1995355,BC3735,Al,Auer,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-5609184,QH2562,2021 to 2022,"School direct (fee funded)
-Primary",
-8273630,TM7395,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-7311560,MN8220,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-6896165,CG5580,2021 to 2022,"School direct (fee funded)
-Design and technology with English",
-7009193,HH3355,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",
-9457054,RT7878,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-5054746,AW3371,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-8957378,GM5727,2021 to 2022,Provider-led (undergrad),
-4073732,QS6710,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-8675815,TX1993,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",
-3960844,SH6489,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-7646286,WA3900,2021 to 2022,"Provider-led (postgrad)
-Latin",
-8832625,HD9024,2021 to 2022,"School direct (fee funded)
+7004997,XX4142,Angelo,Auer,2021 to 2022,"School direct (fee funded)
 Physical education",
-8668206,QW3812,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-9729520,BT0697,2021 to 2022,"Provider-led (postgrad)
+8260100,SK3817,Joanne,Aufderhar,2021 to 2022,"Provider-led (postgrad)
 Biology with chemistry",
-6198842,TD9870,2021 to 2022,"Teaching apprenticeship (postgrad)
-Modern languages",
-5578493,XR1159,2021 to 2022,"Provider-led (postgrad)
+1069262,YM8630,June,Bailey,2021 to 2022,"Provider-led (postgrad)
 Latin",
-3379589,EM2761,2021 to 2022,"School direct (salaried)
+3417658,DN8645,Yolanda,Barrows,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+4078189,AC7745,Isaac,Barton,2021 to 2022,"Provider-led (postgrad)
+Latin",
+7900253,ST6988,Jose,Batz,2021 to 2022,"Provider-led (postgrad)
 Primary",
-9800306,BE6825,2021 to 2022,Provider-led (undergrad),
-4930476,EC6238,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-5061918,BE0921,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-8748026,CG8977,2021 to 2022,"School direct (fee funded)
-Primary",
-7900821,FM9996,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-2493764,EQ2692,2021 to 2022,"Provider-led (postgrad)
-Primary",
-9888335,AB9131,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",
-8260100,SK3817,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-3073808,QB3717,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-7347971,PY7485,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-7851957,NH4668,2021 to 2022,"Provider-led (postgrad)
-Latin",
-4912274,PD4888,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",
-3007806,LY3676,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-5410523,ZW5355,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-1389975,HB0070,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-3329403,GC7042,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",
-2008753,AT3764,2021 to 2022,"Teaching apprenticeship (postgrad)
-Design and technology",
-6780890,PM5795,2021 to 2022,"Provider-led (postgrad)
-Modern languages",
-8262628,DS2628,2021 to 2022,"Provider-led (postgrad)
-Latin",
-3860744,HT5730,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-7769677,HM3654,2021 to 2022,"School direct (fee funded)
-Physical education",
-5684508,XE4315,2021 to 2022,"Provider-led (postgrad)
-Latin",
-5597817,CY1368,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-3232248,BA0386,2021 to 2022,"Provider-led (postgrad)
-Latin",
-3904024,SK9525,2021 to 2022,"Provider-led (postgrad)
-Latin",
-5598145,ZZ0654,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-7438582,FY0149,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",
-8537680,YM1278,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-2732947,RS1429,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-1204048,BH9051,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-2763733,FM7612,2021 to 2022,"School direct (salaried)
-Music with art and design",
-4876485,TA1426,2021 to 2022,Provider-led (undergrad),
-4456200,SP9485,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",
-4966948,MD2264,2021 to 2022,"Provider-led (postgrad)
-Modern languages",
-6784447,SH2853,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-9956721,FC3909,2021 to 2022,"Provider-led (postgrad)
-Modern languages",
-9919650,PM7014,2021 to 2022,"Provider-led (postgrad)
-Primary",
-4922124,DS9993,2021 to 2022,"Provider-led (postgrad)
-Latin",
-7900253,ST6988,2021 to 2022,"Provider-led (postgrad)
-Primary",
-8384234,BH1454,2021 to 2022,"Provider-led (postgrad)
-Latin",
-1995355,BC3735,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-2177277,DQ8137,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",
-1069262,YM8630,2021 to 2022,"Provider-led (postgrad)
-Latin",
-2953057,YY3036,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-5536974,BB3367,2021 to 2022,"Provider-led (postgrad)
-Latin",
-4371388,ZW8916,2021 to 2022,Provider-led (undergrad),
-7004997,XX4142,2021 to 2022,"School direct (fee funded)
-Physical education",
-2086024,QD7026,2021 to 2022,"Provider-led (postgrad)
-Primary with mathematics",
-4185941,YG1496,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-8457026,CH1495,2021 to 2022,"School direct (salaried)
-Primary with modern languages",
-5843544,DG6419,2021 to 2022,"Teaching apprenticeship (postgrad)
-Primary with mathematics",
-6146464,DL2085,2021 to 2022,Opt-in (undergrad),
-5617199,GY0902,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-1785167,NL7535,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-8215464,ER6952,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-4041145,RY2137,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-4700830,HG4569,2021 to 2022,"Provider-led (postgrad)
-Modern languages",
-8569621,WX3307,2021 to 2022,Provider-led (undergrad),
-3081702,AM9800,2021 to 2022,Provider-led (undergrad),
-5536522,MR6798,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",
-5646510,RC3608,2021 to 2022,"School direct (salaried)
+5646510,RC3608,Rafael,Beatty,2021 to 2022,"School direct (salaried)
 Italian",
-6851156,EY3088,2021 to 2022,"Provider-led (postgrad)
-Latin",
-9719346,PB6404,2021 to 2022,"Provider-led (postgrad)
+8744159,HL2974,Lester,Beer,2021 to 2022,Provider-led (undergrad),
+2732947,RS1429,Jaime,Beier,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+9837500,RN4482,Olive,Benoit,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-7030285,EX9838,2021 to 2022,"Provider-led (postgrad)
-Primary",
-4337728,SH0505,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-8691476,DM8266,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-6638309,GW6401,2021 to 2022,"Provider-led (postgrad)
+7851957,NH4668,Émeric,Bertrand,2021 to 2022,"Provider-led (postgrad)
 Latin",
-6666531,GD6448,2021 to 2022,"School direct (fee funded)
-Biology with chemistry",
-2260987,NF7094,2021 to 2022,"Provider-led (postgrad)
-Primary with physical education",
-6861505,LY4803,2021 to 2022,"Provider-led (postgrad)
-Latin",
-1767139,CS1630,2021 to 2022,"Teaching apprenticeship (postgrad)
-Biology with chemistry",
-2693809,DN2616,2021 to 2022,"Provider-led (postgrad)
+9956721,FC3909,Irving,Boehm,2021 to 2022,"Provider-led (postgrad)
 Modern languages",
-3456627,EK8893,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",
-1715621,LT5293,2021 to 2022,"Provider-led (postgrad)
-Primary",
-6088600,NT0340,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-1484766,RB6215,2021 to 2022,"Provider-led (postgrad)
+4641293,QB7031,Mario,Borer,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+5578493,XR1159,Doris,Botsford,2021 to 2022,"Provider-led (postgrad)
 Latin",
-6423079,MC9068,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",
-3969536,HK1030,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",
-7279498,RT3004,2021 to 2022,"Provider-led (postgrad)
+8691476,DM8266,Vickie,Bradtke,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+4930476,EC6238,Laureline,Caron,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-7999914,DQ9717,2021 to 2022,"Provider-led (postgrad)
+6408379,LM5954,Eudoxe,Caron,2021 to 2022,Provider-led (undergrad),
+8537680,YM1278,Raoul,Carpentier,2021 to 2022,"Provider-led (postgrad)
 Design and technology",
-9410956,AF9403,2021 to 2022,"Provider-led (postgrad)
+5751332,LP2348,Pearl,Champlin,2021 to 2022,"School direct (fee funded)
+Primary",
+9719346,PB6404,Christine,Chevalier,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+8457026,CH1495,Gary,Collier,2021 to 2022,"School direct (salaried)
+Primary with modern languages",
+3904024,SK9525,Patty,Collins,2021 to 2022,"Provider-led (postgrad)
+Latin",
+9457054,RT7878,Francisco,Considine,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+6896165,CG5580,Alcyone,Da silva,2021 to 2022,"School direct (fee funded)
+Design and technology with English",
+8832625,HD9024,Max,Deckow,2021 to 2022,"School direct (fee funded)
+Physical education",
+7999914,DQ9717,Carla,Deckow,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+3007806,LY3676,Shannon,Dickens,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+9410956,AF9403,Omar,Donnelly,2021 to 2022,"Provider-led (postgrad)
 Primary with mathematics",
-9350282,MH3891,2021 to 2022,"Provider-led (postgrad)
-Latin",
-8441731,GM2375,2021 to 2022,"Provider-led (postgrad)
+1256500,MQ9676,Lucien,Dupuis,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+8441731,GM2375,Gene,Durgan,2021 to 2022,"Provider-led (postgrad)
 Modern languages",
-4817751,NL3209,2021 to 2022,"Provider-led (postgrad)
-Primary with modern languages",
-1723973,DK3273,2021 to 2022,Provider-led (undergrad),
-8744159,HL2974,2021 to 2022,Provider-led (undergrad),
-5507441,LA5215,2021 to 2022,"Provider-led (postgrad)
-Modern languages",
-7109771,WF0871,2021 to 2022,"Provider-led (postgrad)
+3738544,NZ7230,Jacqueline,Durgan,2021 to 2022,"Provider-led (postgrad)
 Latin",
-7371200,CS3377,2021 to 2022,"Provider-led (postgrad)
-Latin",
-6408379,LM5954,2021 to 2022,Provider-led (undergrad),
-9150187,HB3671,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-3889585,WW9157,2021 to 2022,"Provider-led (postgrad)
-Latin",
-3865944,GX0521,2021 to 2022,"School direct (fee funded)
-Classics with English",
-7882048,FW4161,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-2827462,CN4219,2021 to 2022,Provider-led (undergrad),
-1455999,BK4097,2021 to 2022,Provider-led (undergrad),
-3417658,DN8645,2021 to 2022,"Provider-led (postgrad)
-Design and technology",
-1256500,MQ9676,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-4828006,YK9994,2021 to 2022,"Provider-led (postgrad)
-Biology with chemistry",
-9055186,GG9603,2021 to 2022,"Provider-led (postgrad)
-Latin",
-8621661,GE6621,2021 to 2022,"Provider-led (postgrad)
+2827462,CN4219,Julia,Erdman,2021 to 2022,Provider-led (undergrad),
+3073808,QB3717,Theresa,Fahey,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-4641293,QB7031,2021 to 2022,"Provider-led (postgrad)
-Physical education with physics",
-5077067,WP3275,2021 to 2022,Provider-led (undergrad),
-3738544,NZ7230,2021 to 2022,"Provider-led (postgrad)
-Latin",
-4788104,AD8428,2021 to 2022,"Provider-led (postgrad)
+4700830,HG4569,Marion,Flatley,2021 to 2022,"Provider-led (postgrad)
 Modern languages",
-5999712,LX1542,2021 to 2022,"Provider-led (postgrad)
+3379589,EM2761,Angélina,Fournier,2021 to 2022,"School direct (salaried)
 Primary",
-8802182,TC8129,2021 to 2022,"Provider-led (postgrad)
-Latin",
-4236028,CR0592,2021 to 2022,"Provider-led (postgrad)
+5054746,AW3371,Margie,Frami,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+4041145,RY2137,Lorena,Franey,2021 to 2022,"Provider-led (postgrad)
 Physical education with physics",
-4078189,AC7745,2021 to 2022,"Provider-led (postgrad)
+8569621,WX3307,Mamie,Funk,2021 to 2022,Provider-led (undergrad),
+9055186,GG9603,Margarita,Funk,2021 to 2022,"Provider-led (postgrad)
 Latin",
-5751332,LP2348,2021 to 2022,"School direct (fee funded)
+4371388,ZW8916,Aphélie,Garcia,2021 to 2022,Provider-led (undergrad),
+5843544,DG6419,Elena,Gibson,2021 to 2022,"Teaching apprenticeship (postgrad)
+Primary with mathematics",
+3969536,HK1030,Byron,Gottlieb,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",
+9150187,HB3671,Isabelle,Guerin,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+7279498,RT3004,Blake,Gulgowski,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+1785167,NL7535,Alison,Hagenes,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+7009193,HH3355,Rodney,Halvorson,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",
+4456200,SP9485,Woodrow,Hartmann,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",
+8957378,GM5727,Benny,Harvey,2021 to 2022,Provider-led (undergrad),
+5598145,ZZ0654,Stuart,Hauck,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+2493764,EQ2692,Kim,Heathcote,2021 to 2022,"Provider-led (postgrad)
+Primary",
+9729520,BT0697,Nick,Heller,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+1455999,BK4097,Jacquelyn,Herman,2021 to 2022,Provider-led (undergrad),
+8262628,DS2628,Phyllis,Hermann,2021 to 2022,"Provider-led (postgrad)
+Latin",
+2953057,YY3036,Cameron,Hermann,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+5077067,WP3275,Brandy,Hilll,2021 to 2022,Provider-led (undergrad),
+6861505,LY4803,Edna,Hills,2021 to 2022,"Provider-led (postgrad)
+Latin",
+6784447,SH2853,Katrina,Hodkiewicz,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+7769677,HM3654,Patti,Jacobson,2021 to 2022,"School direct (fee funded)
+Physical education",
+8748026,CG8977,Quiéta,Jacquet,2021 to 2022,"School direct (fee funded)
+Primary",
+9350282,MH3891,Terry,Jast,2021 to 2022,"Provider-led (postgrad)
+Latin",
+6780890,PM5795,Randall,Kerluke,2021 to 2022,"Provider-led (postgrad)
+Modern languages",
+4337728,SH0505,Grant,Kirlin,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+3865944,GX0521,Merle,Klocko,2021 to 2022,"School direct (fee funded)
+Classics with English",
+9919650,PM7014,Winston,Kohler,2021 to 2022,"Provider-led (postgrad)
+Primary",
+6198842,TD9870,Kerry,Konopelski,2021 to 2022,"Teaching apprenticeship (postgrad)
+Modern languages",
+2177277,DQ8137,Oliver,Kovacek,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",
+4073732,QS6710,Vital,Lacroix,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+5999712,LX1542,Christina,Langosh,2021 to 2022,"Provider-led (postgrad)
+Primary",
+9888335,AB9131,Fidèle,Laurent,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",
+2086024,QD7026,Sylvie,Laurent,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",
+7646286,WA3900,Whitney,Lehner,2021 to 2022,"Provider-led (postgrad)
+Latin",
+7882048,FW4161,Victorin,Lemaire,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+7347971,PY7485,Stanislas,Lemoine,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+1484766,RB6215,Jessica,Lubowitz,2021 to 2022,"Provider-led (postgrad)
+Latin",
+6638309,GW6401,Antoinette,Lueilwitz,2021 to 2022,"Provider-led (postgrad)
+Latin",
+4236028,CR0592,Olive,Mante,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+5597817,CY1368,Marlène,Marie,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+5410523,ZW5355,Aliette,Meunier,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+5536974,BB3367,Moses,Miller,2021 to 2022,"Provider-led (postgrad)
+Latin",
+6851156,EY3088,Victor,Mills,2021 to 2022,"Provider-led (postgrad)
+Latin",
+5617199,GY0902,Arthaud,Moreau,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+1389975,HB0070,Amber,Mosciski,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+4876485,TA1426,Ora,Mosciski,2021 to 2022,Provider-led (undergrad),
+8215464,ER6952,Cassien,Moulin,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+7900821,FM9996,David,Nitzsche,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+8273630,TM7395,Aubrey,O'Kon,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+3860744,HT5730,Orlando,O'Reilly,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+8384234,BH1454,Annette,Pacocha,2021 to 2022,"Provider-led (postgrad)
+Latin",
+1204048,BH9051,Angélina,Perrot,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+6088600,NT0340,Léonne,Petit,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+4185941,YG1496,Saul,Pfannerstill,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+4828006,YK9994,Harold,Pfeffer,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+3329403,GC7042,Erik,Pollich,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",
+5684508,XE4315,Martha,Pouros,2021 to 2022,"Provider-led (postgrad)
+Latin",
+3232248,BA0386,Germaine,Prevost,2021 to 2022,"Provider-led (postgrad)
+Latin",
+7371200,CS3377,Annabelle,Prevost,2021 to 2022,"Provider-led (postgrad)
+Latin",
+4922124,DS9993,Pat,Rempel,2021 to 2022,"Provider-led (postgrad)
+Latin",
+7109771,WF0871,Avigaëlle,Remy,2021 to 2022,"Provider-led (postgrad)
+Latin",
+4817751,NL3209,Céleste,Renaud,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",
+8668206,QW3812,Russell,Renner,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+4788104,AD8428,Gautier,Rey,2021 to 2022,"Provider-led (postgrad)
+Modern languages",
+3960844,SH6489,Gatien,Robert,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+3889585,WW9157,Daphné,Robert,2021 to 2022,"Provider-led (postgrad)
+Latin",
+7311560,MN8220,Amalthée,Roger,2021 to 2022,"Provider-led (postgrad)
+Biology with chemistry",
+1767139,CS1630,Kelly,Rolfson,2021 to 2022,"Teaching apprenticeship (postgrad)
+Biology with chemistry",
+4966948,MD2264,Yolanda,Runolfsdottir,2021 to 2022,"Provider-led (postgrad)
+Modern languages",
+3081702,AM9800,Lee,Sawayn,2021 to 2022,Provider-led (undergrad),
+7030285,EX9838,Andre,Schaefer,2021 to 2022,"Provider-led (postgrad)
+Primary",
+2260987,NF7094,Jody,Schneider,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",
+2693809,DN2616,Mabel,Schroeder,2021 to 2022,"Provider-led (postgrad)
+Modern languages",
+8675815,TX1993,Gwen,Shields,2021 to 2022,"Provider-led (postgrad)
+Primary with mathematics",
+1723973,DK3273,Alfred,Sipes,2021 to 2022,Provider-led (undergrad),
+7438582,FY0149,Rogelio,Stanton,2021 to 2022,"Provider-led (postgrad)
+Primary with physical education",
+3456627,EK8893,Carol,Stark,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",
+9800306,BE6825,Dwight,Steuber,2021 to 2022,Provider-led (undergrad),
+5061918,BE0921,Victor,Stoltenberg,2021 to 2022,"Provider-led (postgrad)
+Design and technology",
+6423079,MC9068,Randal,Stracke,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",
+5609184,QH2562,Sheldon,Swaniawski,2021 to 2022,"School direct (fee funded)
+Primary",
+8802182,TC8129,Nathan,Swift,2021 to 2022,"Provider-led (postgrad)
+Latin",
+2008753,AT3764,Héloïse,Thomas,2021 to 2022,"Teaching apprenticeship (postgrad)
+Design and technology",
+5507441,LA5215,Drew,Tillman,2021 to 2022,"Provider-led (postgrad)
+Modern languages",
+5536522,MR6798,Ethel,Volkman,2021 to 2022,"Provider-led (postgrad)
+Primary with modern languages",
+6146464,DL2085,Max,Von,2021 to 2022,Opt-in (undergrad),
+2763733,FM7612,Winston,Walsh,2021 to 2022,"School direct (salaried)
+Music with art and design",
+8621661,GE6621,Jimmie,Wuckert,2021 to 2022,"Provider-led (postgrad)
+Physical education with physics",
+1715621,LT5293,Luke,Wyman,2021 to 2022,"Provider-led (postgrad)
 Primary",

--- a/app/assets/downloads/recommendOnly.csv
+++ b/app/assets/downloads/recommendOnly.csv
@@ -1,6 +1,6 @@
 TRN,Provider trainee ID,Last names,First names,Start academic year,Route and course,Date standards met
 "Must contain a trainee's TRN, or be empty.
-Delete or add trainees as necessary.","Must contain your ID for the trainee, or be empty.
+Delete or add trainees as necessary.","Must contain your trainee ID or be empty.
 Delete or add trainees as necessary.",For reference only,For reference only,For reference only,"Add the date when the trainee met QTS or EYTS standards.
 Must be written DD/MM/YYYY.
 For example, if the trainee met the teaching standard on 20 July 2022, write '20/07/2022'.

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -226,7 +226,7 @@ span.summary-validation-symbol {
 
 // column widths for tables
 // app-table__column-xx
-$sizes: 70, 53, 35, 25, 20, 16, 15, 10, 5;
+$sizes: 70, 55, 53, 35, 30, 25, 20, 16, 15, 10, 5;
 
 @each $size in $sizes {
   .app-table__column-#{$size} {

--- a/app/routes/bulk-update-routes.js
+++ b/app/routes/bulk-update-routes.js
@@ -175,10 +175,10 @@ module.exports = router => {
     // Hiding these for research purposes
     // let templateErrors = [
     //   "TRN not recognised",
-    //   "TRN and Trainee ID are not for the same trainee",
+    //   "TRN and Provider trainee ID are not for the same trainee",
     //   "Trainee record is missing details and cannot be recommended",
     //   "Trainee has already been recommended for QTS",
-    //   "Date standards met provided without a TRN or Trainee ID - add a TRN or Trainee ID or remove the date standards met",
+    //   "Date standards met provided without a TRN or Provider trainee ID - add a TRN or Provider trainee ID or remove the date standards met",
     //   "Date standards met: '09/20/2023' — enter a valid date",
     //   "Date standards met: '20/09/2023' — Date standards met must be in the past"
     // ]
@@ -197,7 +197,6 @@ module.exports = router => {
       let wildCardDate = getRandomArbitrary(1, 6) + "/" + getRandomArbitrary(1, 28) + "/" + data.years.endOfCurrentCycle
 
       let row = {
-        rowNumber: index + 1,
         trainee,
         uploadStatus: weighted.select(["error", "unchanged", "updated"], [0.02, 0.02, 0.96], randomSeeded),
         assessmentDate: weighted.select(["06/10/" + data.years.endOfCurrentCycle, "06/17/" + data.years.endOfCurrentCycle, "06/24/" + data.years.endOfCurrentCycle, wildCardDate], [0.5, 0.2, 0.2, 0.1], randomSeeded),
@@ -206,9 +205,9 @@ module.exports = router => {
       if (row.uploadStatus == "error") {
         // row.errorMessage = utils.pickRandom(templateErrors, randomSeeded)
         row.errorMessage = weighted.select([
-            "Date standards met provided without a TRN or Trainee ID - add a TRN or Trainee ID or remove the date standards met", 
+            "Date standards met provided without a TRN or Provider trainee ID - add a TRN or Provider trainee ID or remove the date standards met", 
             "Date standards met: '20/09/2023' - date standards met must be in the past",
-            "TRN and Trainee ID are not for the same trainee",
+            "TRN and Provider trainee ID are not for the same trainee",
           ], 
           [0.25, 0.5, 0.25], randomSeeded)
       }
@@ -217,6 +216,10 @@ module.exports = router => {
     })
 
     processedRows.sort((a, b) => utils.sortAlphabetical(a.trainee.personalDetails.familyName, b.trainee.personalDetails.familyName))
+
+    processedRows.forEach((row, index) => {
+      row.rowNumber = index + 1
+    })
 
     data.bulkUpload = {
       processedRows

--- a/app/routes/bulk-update-routes.js
+++ b/app/routes/bulk-update-routes.js
@@ -74,12 +74,12 @@ module.exports = router => {
     let randomSeeded = seedRandom("update")
 
     let templateErrors = [
-      'TRN not recognised',
-      'TRN missing',
-      'Trainee start date: ‘07/20/2023’ — enter a valid start date',
-      'Trainee start date: ‘20/07/2023’ — trainee start date must be in the past',
-      'URN not recognised',
-      'school is closed'
+      "TRN not recognised",
+      "TRN missing",
+      "Trainee start date: '07/20/2023' — enter a valid start date",
+      "Trainee start date: '20/07/2023' — trainee start date must be in the past",
+      "URN not recognised",
+      "school is closed"
     ]
 
     /* For each record, randomly pick whether it's ok, in error, or unchanged. If in error, pick a random error */
@@ -102,9 +102,9 @@ module.exports = router => {
       if (row.errorMessage == "URN not recognised" || row.errorMessage == "school is closed") {
 
         if (row.trainee?.placement?.items && row.trainee?.placement?.items.length) {
-          row.errorMessage = "URN: ‘" + row.trainee.placement?.items[0]?.school?.urn + "’ — " + row.errorMessage
+          row.errorMessage = "URN: '" + row.trainee.placement?.items[0]?.school?.urn + "' — " + row.errorMessage
         } else {
-          row.errorMessage = "URN: ‘231231’ – URN not recognised"
+          row.errorMessage = "URN: '231231' – URN not recognised"
         }
       }
       return row
@@ -174,17 +174,20 @@ module.exports = router => {
 
     // Hiding these for research purposes
     // let templateErrors = [
-    //   'TRN not recognised',
-    //   'Date standards met provided without a TRN — add a TRN or remove the date standards met',
-    //   'Date standards met: ‘09/20/2023’ — enter a valid date',
-    //   'Date standards met: ‘20/09/2023’ — Date standards met must be in the past'
+    //   "TRN not recognised",
+    //   "TRN and Trainee ID are not for the same trainee",
+    //   "Trainee record is missing details and cannot be recommended",
+    //   "Trainee has already been recommended for QTS",
+    //   "Date standards met provided without a TRN or Trainee ID - add a TRN or Trainee ID or remove the date standards met",
+    //   "Date standards met: '09/20/2023' — enter a valid date",
+    //   "Date standards met: '20/09/2023' — Date standards met must be in the past"
     // ]
 
     // if (data.settings.bulkLinksInPrimaryNav != "Show bulk recommend") {
     //   templateErrors.push(
-    //     'Postgraduate qualification: ‘BA (Hons)’ — enter ‘PGCE’, ‘PGDE’ or ‘None’ for postgraduate qualification',
-    //     'Postgraduate qualification: ‘PGCE’ — trainees on undergraduate courses cannot be awarded a postgraduate qualification',
-    //     'Postgraduate qualification missing. If the trainee did not get a postgraduate qualification enter ‘None’'
+    //     "Postgraduate qualification: 'BA (Hons)' — enter 'PGCE', 'PGDE' or 'None' for postgraduate qualification",
+    //     "Postgraduate qualification: 'PGCE' — trainees on undergraduate courses cannot be awarded a postgraduate qualification",
+    //     "Postgraduate qualification missing. If the trainee did not get a postgraduate qualification enter 'None'"
     //   )
     // }
 
@@ -196,13 +199,18 @@ module.exports = router => {
       let row = {
         rowNumber: index + 1,
         trainee,
-        uploadStatus: weighted.select(["error", "unchanged", "updated"], [0.01, 0.02, 0.97], randomSeeded),
-        assessmentDate: weighted.select(["06/10/" + data.years.endOfCurrentCycle, "06/17/" + data.years.endOfCurrentCycle, "06/24/" + data.years.endOfCurrentCycle, wildCardDate], [0.325, 0.3, 0.325, 0.05], randomSeeded),
+        uploadStatus: weighted.select(["error", "unchanged", "updated"], [0.02, 0.02, 0.96], randomSeeded),
+        assessmentDate: weighted.select(["06/10/" + data.years.endOfCurrentCycle, "06/17/" + data.years.endOfCurrentCycle, "06/24/" + data.years.endOfCurrentCycle, wildCardDate], [0.5, 0.2, 0.2, 0.1], randomSeeded),
       }
 
       if (row.uploadStatus == "error") {
         // row.errorMessage = utils.pickRandom(templateErrors, randomSeeded)
-        row.errorMessage = weighted.select(["Date standards met provided without a TRN - add a TRN or remove the date standards met", "Date standards met: '20/09/2023' - date standards met must be in the past"], [0.75, 0.25], randomSeeded)
+        row.errorMessage = weighted.select([
+            "Date standards met provided without a TRN or Trainee ID - add a TRN or Trainee ID or remove the date standards met", 
+            "Date standards met: '20/09/2023' - date standards met must be in the past",
+            "TRN and Trainee ID are not for the same trainee",
+          ], 
+          [0.25, 0.5, 0.25], randomSeeded)
       }
 
       return row

--- a/app/routes/bulk-update-routes.js
+++ b/app/routes/bulk-update-routes.js
@@ -194,7 +194,7 @@ module.exports = router => {
     /* For each record, randomly pick whether it's ok, in error, or unchanged. If in error, pick a random error */
     let processedRows = uploadedTrainees.map((trainee, index) => {
 
-        let wildCardDate = getRandomArbitrary(1, 6) + "/" + getRandomArbitrary(1, 28) + "/" + data.years.endOfCurrentCycle
+      let wildCardDate = getRandomArbitrary(1, 6) + "/" + getRandomArbitrary(1, 28) + "/" + data.years.endOfCurrentCycle
 
       let row = {
         rowNumber: index + 1,

--- a/app/views/_includes/bulk-update/upload-summary.html
+++ b/app/views/_includes/bulk-update/upload-summary.html
@@ -34,7 +34,8 @@
   <div class="govuk-grid-column-full">
     {{ govukNotificationBanner({
       html: uploadSummaryHtml,
-      type: 'success'
+      type: 'success',
+      titleText: 'File uploaded'
     }) }}
   </div>
 </div>

--- a/app/views/bulk-update/add-details/check-pending-updates.html
+++ b/app/views/bulk-update/add-details/check-pending-updates.html
@@ -48,9 +48,11 @@
     <p class="govuk-body govuk-!-margin-bottom-1">
       {{ row.trainee.personalDetails.shortName }}
     </p>
+    <p class="govuk-body govuk-hint govuk-!-margin-bottom-1">
+      TRN: {{ row.trainee.trn }}
+    </p>
     <p class="govuk-body govuk-hint govuk-!-margin-bottom-0">
-      {# To do — don't only use TRNs to identify trainees #}
-      {{ row.trainee.trn if row.trainee.trn else 'Pending TRN' }}
+      Trainee ID: {{ row.trainee.reference }}
     </p>
   {% endset %}
   {# To do — set more shools in the data #}

--- a/app/views/bulk-update/recommend/check-pending-updates.html
+++ b/app/views/bulk-update/recommend/check-pending-updates.html
@@ -15,39 +15,47 @@
 {% if bulkOnly %}
   {% set tableHeadRow = [
       {
-        text: "Trainee",
-        classes: "app-table__column-25"
+        text: "Name",
+        classes: "app-table__column-20"
+      },
+      {
+        text: "ID",
+        classes: "app-table__column-20"
       },
       {
         text: "Start academic year",
-        classes: "app-table__column-25"
-      } if bulkOnly,
+        classes: "app-table__column-20"
+      },
       {
         text: "Route and course",
-        classes: "app-table__column-25"
+        classes: "app-table__column-20"
       },
       {
         text: "Date standards met",
-        classes: "app-table__column-25"
+        classes: "app-table__column-20"
       }
     ]%}
 {% else %}
     {% set tableHeadRow = [
       {
-        text: "Trainee",
-        classes: "app-table__column-25"
+        text: "Name",
+        classes: "app-table__column-20"
+      },
+      {
+        text: "ID",
+        classes: "app-table__column-20"
       },
       {
         text: "Route and course",
-        classes: "app-table__column-25"
+        classes: "app-table__column-20"
       },
       {
         text: "Postgraduate qualification",
-        classes: "app-table__column-25"
+        classes: "app-table__column-20"
       },
       {
         text: "Date standards met",
-        classes: "app-table__column-25"
+        classes: "app-table__column-20"
       }
     ]%}
 {% endif %}
@@ -70,12 +78,12 @@
 
 {% for row in processedRows %}
 
-  {% set traineeInfoHtml %}
-    <p class="govuk-body govuk-!-margin-bottom-1">
-      {{ row.trainee.personalDetails.shortName }}
+  {% set traineeIdHtml %}
+    <p class="govuk-body govuk-hint govuk-!-margin-bottom-1">
+      TRN: {{ row.trainee.trn }}
     </p>
     <p class="govuk-body govuk-hint govuk-!-margin-bottom-0">
-      {{ row.trainee.trn }}
+      Trainee ID: {{ row.trainee.reference }}
     </p>
   {% endset %}
 
@@ -101,10 +109,11 @@
 
     {% if bulkOnly %}
       {% set tableRow = [
-        { text: traineeInfoHtml    | safe },
-        { text: row.trainee.academicYear },
-        { text: routeAndCourseHtml | safe },
-        { text: row.assessmentDate | govukDate }
+        { text: row.trainee.personalDetails.shortName },
+        { text: traineeIdHtml                  | safe },
+        { text: row.trainee.academicYear              },
+        { text: routeAndCourseHtml             | safe },
+        { text: row.assessmentDate        | govukDate }
       ]%}
     {% else %}
       {% set tableRow = [

--- a/app/views/bulk-update/recommend/check-pending-updates.html
+++ b/app/views/bulk-update/recommend/check-pending-updates.html
@@ -61,8 +61,7 @@
 
 {# Combines errors and processed if the user has 'fixed the errors' #}
 {% if data.bulk.recommendFixErrors %}
-  {% set processedRows = data.bulkUpload.processedRows | where("uploadStatus", "error")  %}
-  {% set processedRows = processedRows | combineArrays(data.bulkUpload.processedRows | where("uploadStatus", "updated")) %}
+  {% set processedRows = data.bulkUpload.processedRows | removeWhere("uploadStatus", "unchanged")  %}
 {% else %}
   {% set processedRows = data.bulkUpload.processedRows | where("uploadStatus", "updated") %}
 {% endif %}

--- a/app/views/bulk-update/recommend/check-pending-updates.html
+++ b/app/views/bulk-update/recommend/check-pending-updates.html
@@ -79,10 +79,10 @@
 {% for row in processedRows %}
 
   {% set traineeIdHtml %}
-    <p class="govuk-body govuk-hint govuk-!-margin-bottom-1">
+    <p class="govuk-body govuk-!-margin-bottom-1">
       TRN: {{ row.trainee.trn }}
     </p>
-    <p class="govuk-body govuk-hint govuk-!-margin-bottom-0">
+    <p class="govuk-body govuk-!-margin-bottom-0">
       Trainee ID: {{ row.trainee.reference }}
     </p>
   {% endset %}

--- a/app/views/bulk-update/recommend/check-pending-updates.html
+++ b/app/views/bulk-update/recommend/check-pending-updates.html
@@ -15,20 +15,16 @@
 {% if bulkOnly %}
   {% set tableHeadRow = [
       {
-        text: "Name",
-        classes: "app-table__column-20"
-      },
-      {
-        text: "ID",
-        classes: "app-table__column-20"
-      },
-      {
-        text: "Start academic year",
-        classes: "app-table__column-20"
+        text: "Trainee",
+        classes: "app-table__column-30"
       },
       {
         text: "Route and course",
         classes: "app-table__column-20"
+      },
+      {
+        text: "Start academic year",
+        classes: "app-table__column-30"
       },
       {
         text: "Date standards met",
@@ -78,15 +74,6 @@
 
 {% for row in processedRows %}
 
-  {% set traineeIdHtml %}
-    <p class="govuk-body govuk-!-margin-bottom-1">
-      TRN: {{ row.trainee.trn }}
-    </p>
-    <p class="govuk-body govuk-!-margin-bottom-0">
-      Trainee ID: {{ row.trainee.reference }}
-    </p>
-  {% endset %}
-
   {% set routeAndCourseHtml %}
     <p class="govuk-body govuk-!-margin-bottom-1">
       {{ row.trainee.route }}
@@ -107,13 +94,25 @@
       {% set qualification = "—" %}
     {% endif %}
 
+    {% set traineeHtml %}
+      <p class="govuk-body govuk-!-margin-bottom-1">
+        {{ row.trainee.personalDetails.familyName }}, {{ row.trainee.personalDetails.givenName }}
+      </p>
+      <div class="app-trainee-ids"></div>
+      <p class="govuk-body govuk-!-margin-bottom-0 govuk-hint app-trainee-id">
+        TRN: {{ row.trainee.trn }}
+      </p>
+      <p class="govuk-body govuk-!-margin-bottom-0 govuk-hint app-trainee-id">
+        <span class="app-trainee-id">Provider trainee ID: {{ row.trainee.reference }}</span>
+      </p>
+    {% endset %}
+
     {% if bulkOnly %}
       {% set tableRow = [
-        { text: row.trainee.personalDetails.shortName },
-        { text: traineeIdHtml                  | safe },
-        { text: row.trainee.academicYear              },
-        { text: routeAndCourseHtml             | safe },
-        { text: row.assessmentDate        | govukDate }
+        { text: traineeHtml        | safe      },
+        { text: row.trainee.academicYear       },
+        { text: routeAndCourseHtml | safe      },
+        { text: row.assessmentDate | govukDate }
       ]%}
     {% else %}
       {% set tableRow = [

--- a/app/views/bulk-update/recommend/fix-errors.html
+++ b/app/views/bulk-update/recommend/fix-errors.html
@@ -24,8 +24,11 @@
     <p class="govuk-body govuk-!-margin-bottom-1">
       {{ row.trainee.personalDetails.shortName }}
     </p>
+    <p class="govuk-body govuk-hint govuk-!-margin-bottom-1">
+      TRN: {{ row.trainee.trn }}
+    </p>
     <p class="govuk-body govuk-hint govuk-!-margin-bottom-0">
-      {{ row.trainee.trn }}
+      Trainee ID: {{ row.trainee.reference }}
     </p>
   {% endset %}
   {% set errorMessage = row.errorMessage %}
@@ -35,6 +38,15 @@
     {% set errorMessage = 'TRN: ‘' + row.trainee.trn + '’, enter a valid TRN' %}
   {% elseif errorMessage == 'Date standards met provided without a TRN - add a TRN or remove the date standards met' %}
     {% set traineeInfoHtml = '–' %}
+  {% elseif errorMessage == 'TRN and Trainee ID are not for the same trainee' %}
+    {% set traineeInfoHtml %}
+      <p class="govuk-body govuk-!-margin-bottom-1">
+        TRN: {{ row.trainee.trn }}
+      </p>
+      <p class="govuk-body govuk-!-margin-bottom-0">
+        Trainee ID: {{ row.trainee.reference }}
+      </p>
+    {% endset %}
   {% endif %}
 
   {% set tableRow = [

--- a/app/views/bulk-update/recommend/fix-errors.html
+++ b/app/views/bulk-update/recommend/fix-errors.html
@@ -20,39 +20,34 @@
 
 {% for row in rowsWithErrors %}
 
-  {% set traineeInfoHtml %}
-    <p class="govuk-body govuk-!-margin-bottom-1">
-      {{ row.trainee.personalDetails.shortName }}
-    </p>
-    <p class="govuk-body govuk-hint govuk-!-margin-bottom-1">
-      TRN: {{ row.trainee.trn }}
-    </p>
-    <p class="govuk-body govuk-hint govuk-!-margin-bottom-0">
-      Trainee ID: {{ row.trainee.reference }}
-    </p>
-  {% endset %}
-  {% set errorMessage = row.errorMessage %}
+  {% set trn = row.trainee.trn %}
+  {% set providerTraineeId = row.trainee.reference %}
+  {% set firstName = row.trainee.personalDetails.givenName %}
+  {% set lastName = row.trainee.personalDetails.familyName %}
+  {% set dateStandardsMet = row.assessmentDate %}
 
-  {% if errorMessage == 'TRN not recognised' %}
-    {% set traineeInfoHtml = "–" %}
-    {% set errorMessage = 'TRN: ‘' + row.trainee.trn + '’, enter a valid TRN' %}
-  {% elseif errorMessage == 'Date standards met provided without a TRN - add a TRN or remove the date standards met' %}
-    {% set traineeInfoHtml = '–' %}
-  {% elseif errorMessage == 'TRN and Trainee ID are not for the same trainee' %}
-    {% set traineeInfoHtml %}
-      <p class="govuk-body govuk-!-margin-bottom-1">
-        TRN: {{ row.trainee.trn }}
-      </p>
-      <p class="govuk-body govuk-!-margin-bottom-0">
-        Trainee ID: {{ row.trainee.reference }}
-      </p>
-    {% endset %}
+  {% if row.errorMessage == "Date standards met provided without a TRN or Trainee ID - add a TRN or Trainee ID or remove the date standards met" %}
+    {% set trn  = "—" %}
+    {% set providerTraineeId  = "—" %}
+  {% endif %}
+
+  {% if row.errorMessage == "TRN and Provider trainee ID are not for the same trainee" %}
+    {% set firstName = "—" %}
+    {% set lastName  = "—" %}
+  {% endif %}
+
+  {% if row.errorMessage == "Date standards met: '20/09/2023' - date standards met must be in the past" %}
+    {% set dateStandardsMet = '20/09/2023' %}
   {% endif %}
 
   {% set tableRow = [
     { text: row.rowNumber + 2 },
-    { text: traineeInfoHtml | safe },
-    { text: errorMessage | safe }
+    { text: trn               },
+    { text: providerTraineeId },
+    { text: firstName         },
+    { text: lastName          },
+    { text: dateStandardsMet  },
+    { text: row.errorMessage  }
   ] %}
 
   {% set tableBodyRows = tableBodyRows | push(tableRow) %}
@@ -68,11 +63,28 @@
       classes: "app-table__column-5"
     },
     {
-      text: "Trainee",
-      classes: "app-table__column-25"
+      text: "TRN",
+      classes: "app-table__column-10"
     },
     {
-      text: "Error"
+      text: "Provider trainee ID",
+      classes: "app-table__column-10"
+    },
+    {
+      text: "Last names",
+      classes: "app-table__column-10"
+    },
+    {
+      text: "First names",
+      classes: "app-table__column-10"
+    },
+    {
+      text: "Date standards met",
+      classes: "app-table__column-10"
+    },
+    {
+      text: "Error",
+      classes: "app-table__column-45"
     }
   ]
 %}

--- a/app/views/bulk-update/recommend/fix-errors.html
+++ b/app/views/bulk-update/recommend/fix-errors.html
@@ -26,9 +26,11 @@
   {% set lastName = row.trainee.personalDetails.familyName %}
   {% set dateStandardsMet = row.assessmentDate %}
 
-  {% if row.errorMessage == "Date standards met provided without a TRN or Trainee ID - add a TRN or Trainee ID or remove the date standards met" %}
+  {% if row.errorMessage == "Date standards met provided without a TRN or Provider trainee ID - add a TRN or Provider trainee ID or remove the date standards met" %}
     {% set trn  = "—" %}
     {% set providerTraineeId  = "—" %}
+    {% set firstName = "—" %}
+    {% set lastName  = "—" %}
   {% endif %}
 
   {% if row.errorMessage == "TRN and Provider trainee ID are not for the same trainee" %}

--- a/app/views/bulk-update/recommend/hidden-recommend-trainees.html
+++ b/app/views/bulk-update/recommend/hidden-recommend-trainees.html
@@ -7,8 +7,13 @@
 {% set rows = data.bulkUpload.processedRows %}
 
 {% set trnTextHtml %}
-  Must contain a trainee's TRN. Delete or add trainees as necessary. <br>
-  TRNs must be 7 digits.
+  Must contain a trainee's TRN, or be empty.<br>
+  Delete or add trainees as necessary.
+{% endset %}
+
+{% set traineeIdText %}
+  Must contain your ID for the trainee, or be empty.<br>
+  Delete or add trainees as necessary.
 {% endset %}
 
 {% set dateStandardsMetHtml  %}
@@ -19,6 +24,7 @@
   If the trainee has not met the QTS, leave the cell empty or delete the row.
 {% endset %}
 
+
 {# 
   =================================================
   PREPOPULATED
@@ -28,6 +34,7 @@
 {% set prepopulatedTableBodyRows = [
     [
       { text: trnTextHtml | safe },
+      { text: traineeIdText | safe },
       { text: "For reference only." },
       { text: "For reference only." },
       { text: dateStandardsMetHtml | safe }
@@ -41,6 +48,7 @@
   {% endset %}
   {% set prepopulatedTableRow = [
     { text: row.trainee.trn },
+    { text: row.trainee.reference },
     { text: row.trainee.academicYear },
     { text: routeAndCourse | safe },
     { text: "" }
@@ -52,6 +60,9 @@
   [
     {
       text: "TRN"
+    },
+    {
+      text: "Trainee ID"
     },
     {
       text: "Start academic year"
@@ -74,6 +85,7 @@
 {% set errorTableBodyRows = [
     [
       { text: trnTextHtml | safe },
+      { text: traineeIdText | safe },
       { text: "For reference only." },
       { text: "For reference only." },
       { text: dateStandardsMetHtml | safe },
@@ -103,6 +115,7 @@
 
   {% set errorTableRow = [
     { text: traineeReferenceNumber },
+    { text: row.trainee.reference },
     { text: row.trainee.academicYear },
     { text: routeAndCourse | safe },
     { text: assessmentDate },
@@ -115,6 +128,9 @@
   [
     {
       text: "TRN"
+    },
+    {
+      text: "Trainee ID"
     },
     {
       text: "Start academic year"
@@ -140,6 +156,7 @@
 {% set makeChangesTableBodyRows = [
     [
       { text: trnTextHtml | safe },
+      { text: traineeIdText | safe },
       { text: "For reference only." },
       { text: "For reference only." },
       { text: dateStandardsMetHtml | safe }
@@ -155,6 +172,7 @@
 
   {% set makeChangesTableRow = [
     { text: row.trainee.trn },
+    { text: row.trainee.reference },
     { text: row.trainee.academicYear },
     { text: routeAndCourse | safe },
     { text: assessmentDate }
@@ -166,6 +184,9 @@
   [
     {
       text: "TRN"
+    },
+    {
+      text: "Trainee ID"
     },
     {
       text: "Start academic year"

--- a/app/views/bulk-update/recommend/hidden-recommend-trainees.html
+++ b/app/views/bulk-update/recommend/hidden-recommend-trainees.html
@@ -35,8 +35,9 @@
     [
       { text: trnTextHtml | safe },
       { text: traineeIdText | safe },
-      { text: "For reference only." },
-      { text: "For reference only." },
+      { text: "For reference only" },
+      { text: "For reference only" },
+      { text: "For reference only" },
       { text: dateStandardsMetHtml | safe }
     ]
   ] %}
@@ -49,6 +50,8 @@
   {% set prepopulatedTableRow = [
     { text: row.trainee.trn },
     { text: row.trainee.reference },
+    { text: row.trainee.personalDetails.givenName },
+    { text: row.trainee.personalDetails.familyName },
     { text: row.trainee.academicYear },
     { text: routeAndCourse | safe },
     { text: "" }
@@ -63,6 +66,12 @@
     },
     {
       text: "Trainee ID"
+    },
+    {
+      text: "First names"
+    },
+    {
+      text: "Last names"
     },
     {
       text: "Start academic year"
@@ -86,8 +95,9 @@
     [
       { text: trnTextHtml | safe },
       { text: traineeIdText | safe },
-      { text: "For reference only." },
-      { text: "For reference only." },
+      { text: "For reference only" },
+      { text: "For reference only" },
+      { text: "For reference only" },
       { text: dateStandardsMetHtml | safe },
       { text: "For reference only." }
     ]
@@ -116,6 +126,8 @@
   {% set errorTableRow = [
     { text: traineeReferenceNumber },
     { text: row.trainee.reference },
+    { text: row.trainee.personalDetails.givenName },
+    { text: row.trainee.personalDetails.familyName },
     { text: row.trainee.academicYear },
     { text: routeAndCourse | safe },
     { text: assessmentDate },
@@ -131,6 +143,9 @@
     },
     {
       text: "Trainee ID"
+    },
+    {
+      text: "Trainee name"
     },
     {
       text: "Start academic year"
@@ -157,8 +172,9 @@
     [
       { text: trnTextHtml | safe },
       { text: traineeIdText | safe },
-      { text: "For reference only." },
-      { text: "For reference only." },
+      { text: "For reference only" },
+      { text: "For reference only" },
+      { text: "For reference only" },
       { text: dateStandardsMetHtml | safe }
     ]
   ] %}
@@ -173,6 +189,8 @@
   {% set makeChangesTableRow = [
     { text: row.trainee.trn },
     { text: row.trainee.reference },
+    { text: row.trainee.personalDetails.givenName },
+    { text: row.trainee.personalDetails.familyName },
     { text: row.trainee.academicYear },
     { text: routeAndCourse | safe },
     { text: assessmentDate }
@@ -187,6 +205,9 @@
     },
     {
       text: "Trainee ID"
+    },
+    {
+      text: "Trainee name"
     },
     {
       text: "Start academic year"

--- a/app/views/bulk-update/recommend/hidden-recommend-trainees.html
+++ b/app/views/bulk-update/recommend/hidden-recommend-trainees.html
@@ -50,8 +50,8 @@
   {% set prepopulatedTableRow = [
     { text: row.trainee.trn },
     { text: row.trainee.reference },
-    { text: row.trainee.personalDetails.givenName },
     { text: row.trainee.personalDetails.familyName },
+    { text: row.trainee.personalDetails.givenName },
     { text: row.trainee.academicYear },
     { text: routeAndCourse | safe },
     { text: "" }
@@ -65,13 +65,13 @@
       text: "TRN"
     },
     {
-      text: "Trainee ID"
-    },
-    {
-      text: "First names"
+      text: "Provider trainee ID"
     },
     {
       text: "Last names"
+    },
+    {
+      text: "First names"
     },
     {
       text: "Start academic year"
@@ -126,8 +126,8 @@
   {% set errorTableRow = [
     { text: traineeReferenceNumber },
     { text: row.trainee.reference },
-    { text: row.trainee.personalDetails.givenName },
     { text: row.trainee.personalDetails.familyName },
+    { text: row.trainee.personalDetails.givenName },
     { text: row.trainee.academicYear },
     { text: routeAndCourse | safe },
     { text: assessmentDate },
@@ -142,13 +142,13 @@
       text: "TRN"
     },
     {
-      text: "Trainee ID"
-    },
-    {
-      text: "First names"
+      text: "Provider trainee ID"
     },
     {
       text: "Last names"
+    },
+    {
+      text: "First names"
     },
     {
       text: "Start academic year"
@@ -178,6 +178,7 @@
       { text: "For reference only" },
       { text: "For reference only" },
       { text: "For reference only" },
+      { text: "For reference only" },
       { text: dateStandardsMetHtml | safe }
     ]
   ] %}
@@ -192,8 +193,8 @@
   {% set makeChangesTableRow = [
     { text: row.trainee.trn },
     { text: row.trainee.reference },
-    { text: row.trainee.personalDetails.givenName },
     { text: row.trainee.personalDetails.familyName },
+    { text: row.trainee.personalDetails.givenName },
     { text: row.trainee.academicYear },
     { text: routeAndCourse | safe },
     { text: assessmentDate }
@@ -207,13 +208,13 @@
       text: "TRN"
     },
     {
-      text: "Trainee ID"
-    },
-    {
-      text: "First names"
+      text: "Provider trainee ID"
     },
     {
       text: "Last names"
+    },
+    {
+      text: "First names"
     },
     {
       text: "Start academic year"

--- a/app/views/bulk-update/recommend/hidden-recommend-trainees.html
+++ b/app/views/bulk-update/recommend/hidden-recommend-trainees.html
@@ -145,7 +145,10 @@
       text: "Trainee ID"
     },
     {
-      text: "Trainee name"
+      text: "First names"
+    },
+    {
+      text: "Last names"
     },
     {
       text: "Start academic year"
@@ -207,7 +210,10 @@
       text: "Trainee ID"
     },
     {
-      text: "Trainee name"
+      text: "First names"
+    },
+    {
+      text: "Last names"
     },
     {
       text: "Start academic year"

--- a/app/views/bulk-update/recommend/index.html
+++ b/app/views/bulk-update/recommend/index.html
@@ -86,7 +86,7 @@
           Empty template file
         </h3>
         <p class="govuk-body">
-          This file has the column headings ‘TRN’, <span class="app-nowrap">‘Trainee ID’</span> and <span class="app-nowrap">‘Date standards met’</span>.
+          This file has the column headings ‘TRN’, <span class="app-nowrap">‘Provider trainee ID’</span> and <span class="app-nowrap">‘Date standards met’</span>.
         </p>
         <p>Add the trainees you want to recommend for {{ qualifications }}.</p>
         {{ appDownloadLink({

--- a/app/views/bulk-update/recommend/index.html
+++ b/app/views/bulk-update/recommend/index.html
@@ -71,7 +71,10 @@
           Prepopulated file
         </h3>
         <p>
-          This file containes all {{ traineesThatCanBeRecommended | length }} trainees that can be recommended for {{ qualifications }}. Delete any trainees you do not want to recommened.
+          This file containes all {{ traineesThatCanBeRecommended | length }} trainees that can be recommended for {{ qualifications }}.
+        </p>
+        <p class="govuk-body">
+          Delete any trainees you do not want to recommened.
         </p>
         {{ appDownloadLink({
           linkText: "a prepopulated file to recommend trainees for " + qualifications,
@@ -83,8 +86,9 @@
           Empty template file
         </h3>
         <p class="govuk-body">
-          This file has the column headings ‘TRN’ and ‘Date standards met’. Add the trainees you want to recommend for {{ qualifications }}.
+          This file has the column headings ‘TRN’, <span class="app-nowrap">‘Trainee ID’</span> and <span class="app-nowrap">‘Date standards met’</span>.
         </p>
+        <p>Add the trainees you want to recommend for {{ qualifications }}.</p>
         {{ appDownloadLink({
           linkText: "an empty template file to recommend trainees for " + qualifications,
           fileName: "recommendOnly-template" if bulkRecommendOnly else "recommend-template",


### PR DESCRIPTION
We've seen in the first two rounds of research that users would find it difficult to identify trainees by their TRN alone.

To avoid needing to add names to the spreadsheets, we can give users the trainee ID. This probably isn't sufficient but it would be good to rule it out before reverting to needing to use the trainee names.

## Updated pre-populated file column descriptions

![Screenshot 2022-04-27 at 12 28 15](https://user-images.githubusercontent.com/8417288/165509563-f4415d9a-bcae-4727-93ea-45c229f84fa9.png)

## Updated template column descriptions

![Screenshot 2022-04-27 at 12 32 20](https://user-images.githubusercontent.com/8417288/165509558-c7ff04e9-4797-4faf-89f0-742c8b6d485d.png)

## Update error page

- shows both IDs
- tweaks error message about missing ID
- adds error message about TRN and Trainee ID not matching

![Screenshot 2022-04-27 at 12 25 24](https://user-images.githubusercontent.com/8417288/165510306-3d9c84f5-2ffa-407b-9a99-da62eba22b40.png)


## Updates pending changes

Shows IDs in their own column.

![Screenshot 2022-04-27 at 12 40 59](https://user-images.githubusercontent.com/8417288/165510592-b75d8b04-ea18-44c0-a8e3-9e1f99258e4f.png)
