### PR TITLE
Improve display of missing data on records

### DIFF
--- a/app/assets/sass/components/_invalid-answer.scss
+++ b/app/assets/sass/components/_invalid-answer.scss
@@ -36,9 +36,19 @@ $invalid-colour: $govuk-brand-colour;
   font-weight: 700;
 }
 
-.app-summary-list__value-inset {
-  border-left: 5px solid $invalid-colour;
+.app-summary-list__value--inset {
+  color: $govuk-secondary-text-colour;
+  border-left: 5px solid $govuk-border-colour;
   padding-left: 15px
+}
+
+.app-summary-list__value--invalid {
+  border-left: 5px solid $invalid-colour;
+}
+
+.app-summary-list__message {
+  color: $govuk-secondary-text-colour;
+  // @include govuk-typography-weight-bold;
 }
 
 .app-summary-list__message--invalid {

--- a/app/data/generators/hesa-data.js
+++ b/app/data/generators/hesa-data.js
@@ -1,0 +1,25 @@
+const { faker } = require('@faker-js/faker')
+const moment    = require('moment')
+const weighted   = require('weighted')
+
+let percentageMissing = [0.8,0.2]
+
+module.exports = record => {
+
+  // Some HESA records are missing nationality
+  let nationality = record?.personalDetails?.nationality
+  if (nationality){
+    record.personalDetails.nationality = weighted.select([null, nationality], percentageMissing)
+  }
+
+  let endDate = record?.courseDetails?.endDate
+  if (endDate){
+    record.courseDetails.endDate = weighted.select([null, endDate], percentageMissing)
+  }
+
+  delete record.contactDetails.address
+  delete record.contactDetails.addressType
+
+  return record
+}
+

--- a/app/views/_includes/filter-panel/source.njk
+++ b/app/views/_includes/filter-panel/source.njk
@@ -22,11 +22,11 @@
       text: "Imported from DTTP",
       value: "DTTP",
       checked: checked(query.filterSource, "DTTP")
-    } if data.isAdmin and navActive !== "drafts",
+    } if navActive !== "drafts",
     {
       text: "Imported from HESA",
       value: "HESA",
       checked: checked(query.filterSource, "HESA")
-    } if data.isAdmin and navActive !== "drafts"
+    } if navActive !== "drafts"
   ]
 } | decorateAttributes(data, "data.filterSource"))}}

--- a/app/views/_includes/locked-hesa-record-message.html
+++ b/app/views/_includes/locked-hesa-record-message.html
@@ -6,9 +6,9 @@
     <p class="govuk-body">
       Updates from HESA are imported regularly.
     </p>
-    <p class="govuk-body">
+   {#  <p class="govuk-body">
       You will be able to recommend the trainee for QTS at the end of the academic year.
-    </p>
+    </p> #}
   {% endset %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/_includes/summary-cards/contact-details.html
+++ b/app/views/_includes/summary-cards/contact-details.html
@@ -14,7 +14,7 @@
 {% endif %}
 {% set address = address or 'Not provided' %}
 
-
+{% set isHesa = record | sourceIsHESA %}
 
 {% set contactDetailsRows = [
   {
@@ -33,7 +33,7 @@
         }
       ]
     } if canAmend
-  },
+  } if not isHesa,
   {
     key: {
       text: "Phone number"

--- a/app/views/_includes/summary-cards/course-details.html
+++ b/app/views/_includes/summary-cards/course-details.html
@@ -185,7 +185,7 @@
     text: "ITT end date"
   },
   value: {
-    text: courseDetails.endDate | govukDate or 'Not provided'
+    text: courseDetails.endDate | govukDate
   },
   actions: {
     items: [
@@ -313,7 +313,10 @@
 
 {% set courseDetailsHtml %}
   {{ govukSummaryList({
-    rows: courseDetailsRows | highlightInvalidRows
+    rows: courseDetailsRows | highlightInvalidRows({
+        treatEmptyAsMissing: true,
+        recordSource: record.source
+      })
   }) }}
 {% endset %}
 

--- a/app/views/_includes/summary-cards/personal-details.html
+++ b/app/views/_includes/summary-cards/personal-details.html
@@ -52,7 +52,7 @@
       text: "Nationality"
     },
     value: {
-      text: record.personalDetails.nationality | uniq | removeArrayItem("Other") | joinify or 'Not entered'
+      text: record.personalDetails.nationality | uniq | removeArrayItem("Other") | joinify
     },
     actions: {
       items: [
@@ -68,7 +68,10 @@
 
 {% set personalDetailsHtml %}
   {{ govukSummaryList({
-    rows: personalDetailsRows | highlightInvalidRows
+    rows: personalDetailsRows | highlightInvalidRows({
+        treatEmptyAsMissing: true,
+        recordSource: record.source
+      })
   }) }}
 {% endset %}
 

--- a/app/views/_includes/summary-cards/placements/no-placement-details.html
+++ b/app/views/_includes/summary-cards/placements/no-placement-details.html
@@ -3,7 +3,7 @@
     text: "Placements"
   },
   value: {
-    text: 'Not provided yet'
+    text: 'Not provided yet' if not record | sourceIsHESA
   },
   actions: {
     items: [
@@ -22,7 +22,10 @@
 
 {% set placementDetailsHtml %}
   {{ govukSummaryList({
-    rows: placementDetailsRows
+    rows: placementDetailsRows | highlightInvalidRows({
+      treatEmptyAsMissing: true,
+      recordSource: record.source
+    })
   }) }}
 {% endset %}
 

--- a/app/views/_includes/summary-cards/placements/placement-overview.html
+++ b/app/views/_includes/summary-cards/placements/placement-overview.html
@@ -32,8 +32,32 @@
     } if canAmend and false
   }) %}
 
-  {% if placements | length == 1 %}
-    {% set placementRows = placementRows | push({
+{% endfor %}
+
+{# Make sure there’s always two rows #}
+{% if placementCount == 0 %}
+  {% set placementRows = placementRows | push({
+    key: {
+      text: "First placement"
+    },
+    value: {
+      text: ''
+    },
+    actions: {
+      items: [
+        {
+          href: recordPath + "/placements/add" | addReferrer(referrer),
+          text: "Add",
+          visuallyHiddenText: " placement"
+        }
+      ]
+    } if canAmend
+  } if not record | isDraft ) %}
+{% endif %}
+
+{# Suppresses the action link if there are no placements so we don't end up with two links to the same place #}
+{% if placementCount < 2 %}
+  {% set placementRows = placementRows | push({
     key: {
       text: "Second placement"
     },
@@ -45,19 +69,20 @@
         {
           href: recordPath + "/placements/add" | addReferrer(referrer),
           text: "Add",
-          visuallyHiddenText: "second placement"
+          visuallyHiddenText: " placement",
+          suppressActionLink: true if placementCount == 0
         }
       ]
     } if canAmend
   } if not record | isDraft ) %}
-    
-  {% endif %}
-  
-{% endfor %}
+{% endif %}
 
 {% set placementDetailsHtml %}
   {{ govukSummaryList({
-      rows: placementRows | highlightInvalidRows({ treatEmptyAsMissing: true})
+    rows: placementRows | highlightInvalidRows({
+      treatEmptyAsMissing: true,
+      recordSource: record.source,
+    })
   }) }}
 {% endset %}
 
@@ -83,17 +108,6 @@
 
   {% include "_includes/incomplete.njk" %}
 
-{% elseif placementCount == 0 %}
-  {% include "_includes/summary-cards/placements/no-placement-details.html" %}
-{# {% elseif placementCount == 0 %}
-  <p class="govuk-body">You have not added any placements yet.</p>
-  <div class="govuk-form-group">
-    {{ govukButton({
-      "text": "Add a placement",
-      href: recordPath + '/placements/add' | addReferrer(referrer),
-      classes: "govuk-button--secondary govuk-!-margin-bottom-0"
-    }) }}
-  </div> #}
 {% else %}
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",

--- a/app/views/_includes/summary-cards/placements/placement-overview.html
+++ b/app/views/_includes/summary-cards/placements/placement-overview.html
@@ -81,7 +81,7 @@
   {{ govukSummaryList({
     rows: placementRows | highlightInvalidRows({
       treatEmptyAsMissing: true,
-      recordSource: record.source,
+      recordSource: record.source
     })
   }) }}
 {% endset %}

--- a/app/views/_includes/summary-cards/trainee-progress.html
+++ b/app/views/_includes/summary-cards/trainee-progress.html
@@ -317,7 +317,8 @@
 {% set traineeProgressHtml %}
   {{ govukSummaryList({
     rows: traineeProgressRows | highlightInvalidRows({
-        treatEmptyAsMissing: true
+        treatEmptyAsMissing: true,
+        recordSource: record.source
       })
   }) }}
 {% endset %}

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -63,7 +63,6 @@
       html: adminOnlyFilters
     }) }}
     {% else %}
-      {% include "_includes/filter-panel/source.njk" %}
 
   {% endif %}
 
@@ -88,6 +87,10 @@
   {% include "_includes/filter-panel/subjects.njk" %}
 
   {% include "_includes/filter-panel/studyMode.njk" %}
+
+  {% if not data.isAdmin %}
+    {% include "_includes/filter-panel/source.njk" %}
+  {% endif %}
 
 {% endset %}
 

--- a/app/views/records.html
+++ b/app/views/records.html
@@ -62,6 +62,8 @@
       classes: "app-status-box--filter-outdent",
       html: adminOnlyFilters
     }) }}
+    {% else %}
+      {% include "_includes/filter-panel/source.njk" %}
 
   {% endif %}
 


### PR DESCRIPTION
HESA records are sometimes missing data that we'd normally require. Since this can't be modified by users, we'll style this differently than our standard blue missing style.

New style:
<img width="1021" alt="Screenshot 2022-04-29 at 16 47 53" src="https://user-images.githubusercontent.com/2204224/165979245-c335e8c9-2f23-4651-91e7-6ce4bdbf85b7.png">

PR updates the seeds so that these items are commonly missing from HESA records:
* Nationality
* ITT End date

I also tweaked the placement summary card so that it will *always* show at least two rows. If you're missing both placements it only shows one call to action link though.

A record missing one placement:
<img width="978" alt="Screenshot 2022-04-29 at 16 52 20" src="https://user-images.githubusercontent.com/2204224/165980056-d04709f6-9e06-42eb-a01e-668978a39dd8.png">

A record missing both placements:
<img width="980" alt="Screenshot 2022-04-29 at 16 52 38" src="https://user-images.githubusercontent.com/2204224/165980074-abc7d429-0c2e-4f7c-b1d6-f8a613280d0f.png">

A HESA record missing one placement:
<img width="980" alt="Screenshot 2022-04-29 at 16 54 13" src="https://user-images.githubusercontent.com/2204224/165980322-1ab58ad1-1d8e-4cb9-906c-ae5e16292a43.png">

A HESA record missing both placements:
<img width="989" alt="Screenshot 2022-04-29 at 16 53 51" src="https://user-images.githubusercontent.com/2204224/165980243-a16caa51-2709-493a-b7bc-bebbce6b9794.png">

