### PR TITLE
Bugfixes

### DIFF
--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -1136,10 +1136,19 @@ exports.isCurrentYear = record => {
     endAcademicYear = exports.dateToAcademicYear(record?.courseDetails?.endDate)
   }
   else {
-    if (record?.courseDetails?.duration > 1){
-      endAcademicYear = record?.academicYear + 1
+    if (exports.isUndergraduate(record)){
+      endAcademicYear = record?.academicYear + 2
     }
-    else endAcademicYear = record?.academicYear
+    else if (exports.isPartTime(record)){
+      endAcademicYear = record?.academicYear + 1
+    } 
+    else if (exports.isFullTime(record)){
+      endAcademicYear = record?.academicYear
+    }
+    else {
+      console.log("No course ITT end date. Assuming it finishes in same year.")
+      endAcademicYear = record?.academicYear
+    }
   }
 
   let isFinishingThisYearOrGreater = (endAcademicYear == years.currentAcademicYear) || (endAcademicYear == years.nextAcademicYear)

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -153,7 +153,7 @@ exports.academicYearStringToYear = string => {
 exports.dateToAcademicYear = date => {
   let theDate = moment(date)
   if (!theDate.isValid()){
-    console.log("Error in dateToAcademicYear: provided date is invalid")
+    console.log(`Error in dateToAcademicYear: provided date (${theDate, date}) is invalid`)
     return false
   }
   let theYear = theDate.year()
@@ -1067,7 +1067,7 @@ exports.isApprenticeship = record => {
 // Active, Future, Historic
 
 exports.isActive = record => {
-  return exports.isCurrentYear(record) || (exports.isPreviousYears(record) && exports.isActiveStatus(record))
+  return exports.isActiveStatus(record) || exports.isCurrentYear(record)
 }
 
 exports.isPreviousYears = record => {
@@ -1129,9 +1129,21 @@ exports.isHesaAndLocked = record => {
 // - are on a course that finishes this year, or in the future
 exports.isCurrentYear = record => {
   let isStartingThisYear = record?.academicYear == years.currentAcademicYear
-  let endAcademicYear = exports.dateToAcademicYear(record?.courseDetails?.endDate)
+
+  // HESA records are sometimes missing course end dates. If 
+  let endAcademicYear
+  if (record?.courseDetails?.endDate){
+    endAcademicYear = exports.dateToAcademicYear(record?.courseDetails?.endDate)
+  }
+  else {
+    if (record?.courseDetails?.duration > 1){
+      endAcademicYear = record?.academicYear + 1
+    }
+    else endAcademicYear = record?.academicYear
+  }
+
   let isFinishingThisYearOrGreater = (endAcademicYear == years.currentAcademicYear) || (endAcademicYear == years.nextAcademicYear)
-  return isStartingThisYear || (isFinishingThisYearOrGreater && !exports.isFutureYear) || !record?.academicYear
+  return isStartingThisYear || (isFinishingThisYearOrGreater && !exports.isFutureYear(record)) || !record?.academicYear
 }
 
 exports.isFutureYear = record => {
@@ -1655,6 +1667,7 @@ exports.filterByYear = (records, array) => {
 // Filter records by status
 exports.filterByActive = (records) => {
   return records.filter(record => exports.isActive(record) )
+  // return records.filter(record => true )
 }
 
 exports.filterByFuture = (records) => {

--- a/app/routes/existing-record-routes.js
+++ b/app/routes/existing-record-routes.js
@@ -568,7 +568,7 @@ module.exports = router => {
       // Implicitly not a course change, so we can delete any temp data
       delete record?.temp?.courseMoveTemp
       // 307 Redirect to POST route
-      res.redirect(307, `${recordPath}/course-details/update${referrer}`);
+      res.redirect(307, `${recordPath}/course-details/update${referrer}`)
     }
   })
   router.post('/:recordtype/:uuid/course-details/course-change-date-question-answer', function (req, res) {

--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -340,7 +340,7 @@ module.exports = router => {
         record.courseDetails = utils.deletePublishCourseReferences(record.courseDetails)
       }
 
-      // Todo: shoudl this be a function? probably we should check the record stored in data not
+      // Todo: should this be a function? probably we should check the record stored in data not
       // the route on the course
       let routeHasChanged = (record.route != record?.courseDetails?.route)
 


### PR DESCRIPTION
Our cohorts filters were breaking as some HESA records are missing ITT end dates. This updates the logic so that where the end date is missing, we guess at it based on it being undergrad or else full time or part time.