### PR TITLE
Removed domain notification and added HESA ones

### DIFF
--- a/app/data/service-updates.yaml
+++ b/app/data/service-updates.yaml
@@ -8,7 +8,7 @@ items:
       The import from HESA to Register is working normally. This means if you’re a Higher Education Institute (HEI), you can use Register to see data that you have updated and uploaded to HESA. This will allow you to complete your April census update by 13 May.
 
 
-      If you identify any further issues with your data, contact [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk?subject=HESA%20import%20issues%20in%20Register).
+      If you have updated any data about placements in HESA, you will not be able to see this in Register yet, but this will be available in future. If you identify any further issues with your data, contact [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk?subject=HESA%20import%20issues%20in%20Register).
 
 
   - date: '2022-04-29'

--- a/app/data/service-updates.yaml
+++ b/app/data/service-updates.yaml
@@ -3,7 +3,7 @@
 items:
 
   - date: '2022-05-09'
-    title: HESA records now visible in Register for April census update
+    title: HESA records now visible in Register for the April census update
     content: >-
       The import from HESA to Register is working normally. This means if you’re a Higher Education Institute (HEI), you can use Register to see data that you have updated and uploaded to HESA. This will allow you to complete your April census update by 13 May.
 

--- a/app/data/service-updates.yaml
+++ b/app/data/service-updates.yaml
@@ -3,9 +3,9 @@
 items:
 
   - date: '2022-05-09'
-    title: HESA records now visible in Register for April Census update
+    title: HESA records now visible in Register for April census update
     content: >-
-      The import from HESA to Register is working normally. This means if you’re a Higher Education Institute (HEI), you can use Register to see data that you have updated and uploaded to HESA. This will allow you to complete your April Census update by 13 May.
+      The import from HESA to Register is working normally. This means if you’re a Higher Education Institute (HEI), you can use Register to see data that you have updated and uploaded to HESA. This will allow you to complete your April census update by 13 May.
 
 
       If you identify any further issues with your data, contact [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk?subject=HESA%20import%20issues%20in%20Register).

--- a/app/data/service-updates.yaml
+++ b/app/data/service-updates.yaml
@@ -2,13 +2,22 @@
 
 items:
 
-  - date: '2022-04-27'
-    title: Register’s website address (URL) has changed
+  - date: '2022-05-09'
+    title: HESA records now visible in Register for April Census update
     content: >-
-      The website address (URL) for Register has now changed to: <span class="app-nowrap">www&period;register-trainee-teachers.service.gov.uk</span>
+      The import from HESA to Register is working normally. This means if you’re a Higher Education Institute (HEI), you can use Register to see data that you have updated and uploaded to HESA. This will allow you to complete your April Census update by 13 May.
 
 
-      You will be automatically redirected to the new URL if you use the old one, so you will not see any disruption to your work or the service.
+      If you identify any further issues with your data, contact [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk?subject=HESA%20import%20issues%20in%20Register).
+
+
+  - date: '2022-04-29'
+    title: April HESA census update extended to Friday 13 May 2022
+    content: >-
+      The import from HESA to Register is ongoing. This means if you’re a Higher Education Institute (HEI) of Initial Teacher Training (ITT), you can update and upload data to HESA, but you cannot see this update on Register yet. We’ve extended the deadline for the April census update from 29 April to Friday 13 May.
+
+
+      We will update you when your data is visible to check on Register.
 
 
   - date: '2022-03-16'


### PR DESCRIPTION
- removed domain notification as that is not live on production yet
- added in notification about HESA extension
- added notification about HESA import now working.

This will now match the order on production.

I do not know how to make both the HESA notifications persist like it is on production.