### PR TITLE
Fix invalid answer styling on autocompletes

### DIFF
--- a/app/assets/javascripts/init-autocompletes.js
+++ b/app/assets/javascripts/init-autocompletes.js
@@ -115,7 +115,7 @@ const setupAutocomplete = (component) => {
   // Get config for autocomplete
   const autoselect          = element.getAttribute('data-autoselect') || false
   const classes             = element.getAttribute('data-classes') || false
-  const describedById       = element.getAttribute('aria-describedby') || false
+  const describedByIds      = element.getAttribute('aria-describedby') || false
   const minLength           = element.getAttribute('data-min-length') || 2
   const placeholder         = element.getAttribute('data-placeholder') || false
   const showAllValues       = element.getAttribute('data-show-all-values') || false
@@ -130,10 +130,17 @@ const setupAutocomplete = (component) => {
   // If the enhanced element has aria-describedBy, grab the description to pass
   // to the autocomplete
   let describedBy = null
-  if (describedById){
-    describedBy = document.getElementById(describedById).innerText
-    // Add a full stop if the hint didn't have one.
-    describedBy = (describedBy.endsWith(".")) ? describedBy : `${describedBy}.`
+  if (describedByIds){
+
+    // Can be an array where the field is in error
+    let describedByIdsArray = describedByIds.trim().split(' ')
+    describedBy = describedByIdsArray.map(describedById => {
+      let innerText = document.getElementById(describedById).innerText
+      // Make sure each item ends in a full stop.
+      if (!innerText.endsWith(".")){
+        innerText = `${innerText}.`
+      }
+    }).join(' ')
   }
 
   // If enhancing a select and values not provided, fall back to options from select

--- a/app/assets/sass/components/_invalid-answer.scss
+++ b/app/assets/sass/components/_invalid-answer.scss
@@ -51,6 +51,10 @@ $invalid-colour: $govuk-brand-colour;
   // @include govuk-typography-weight-bold;
 }
 
+.app-summary-list__value--invalid .app-summary-list__user-value {
+  color: $govuk-text-colour;
+}
+
 .app-summary-list__message--invalid {
   color: $invalid-colour;
   @include govuk-typography-weight-bold;
@@ -64,7 +68,15 @@ $invalid-colour: $govuk-brand-colour;
   color: $invalid-colour;
 }
 
+.app-invalid-answer .autocomplete__input {
+  border-color: $invalid-colour;
+}
+
 .app-invalid-answer .govuk-form-group--error {
+  border-color: $invalid-colour;
+}
+
+.app-invalid-answer .govuk-select--error {
   border-color: $invalid-colour;
 }
 

--- a/app/views/_components/autocomplete-new/template.njk
+++ b/app/views/_components/autocomplete-new/template.njk
@@ -25,16 +25,20 @@
 If so, generate an autocomplete specific class that can be applied
 to the parent #}
 {% set widthClass = false %}
+{% set classesExceptWidth = '' %}
 {% if params.classes %}
   {% set classes = params.classes | split(" ") %}
   {% for class in classes %}
     {% if class | includes("govuk-!-width")  %}
       {% set widthClass = class | replace("govuk-!", "app-!-autocomplete--max")  %}
+    {% else %}
+      {% set classesExceptWidth = classesExceptWidth | push(class) %}
     {% endif %}
   {% endfor %}
+  {% set classesExceptWidth = classesExceptWidth | spaceSeparate %}
 {% endif %}
 
-<div data-module="app-autocomplete" class="govuk-form-group {{ 'app-autocomplete--with-suggestions' if showSuggestions}} {{params.autocompleteOptions.classes}} {{widthClass if widthClass}}">
+<div data-module="app-autocomplete" class="govuk-form-group {{ 'app-autocomplete--with-suggestions' if showSuggestions}} {{classesExceptWidth}} {{params.autocompleteOptions.classes}} {{widthClass if widthClass}}">
 
   {% if autocompleteType == "input" %}
 


### PR DESCRIPTION
Fixes broken styling on the autocompletes when there were invalid answers.

A few different issues:
* When an item is in error, an input gets a second id in `aria-describedby` - the autocomplete js code assumed there was only one
* The right colours weren't being set.
* The improved autocomplete component macro wasn't applying classes it was passed.