### PR TITLE
Added news about domain change now HESA deadline has passed

### DIFF
--- a/app/data/service-updates.yaml
+++ b/app/data/service-updates.yaml
@@ -2,6 +2,16 @@
 
 items:
 
+
+  - date: '2022-05-16'
+    title: Register’s website address (URL) has changed
+    content: >-
+      The website address (URL) for Register has now changed to: <span class="app-nowrap">www&period;register-trainee-teachers.service.gov.uk</span>
+
+
+      You will be automatically redirected to the new URL if you use the old one, so you will not see any disruption to your work or the service.
+
+
   - date: '2022-05-09'
     title: HESA records now visible in Register for the April census update
     content: >-


### PR DESCRIPTION
News and updates section about domain change:

<img width="947" alt="Screenshot 2022-05-16 at 09 56 34" src="https://user-images.githubusercontent.com/68232608/168556426-7a69fe6c-0556-416d-8289-87d18ecfcd16.png">
