### PR TITLE
removes line that isn't quite accurate

### DIFF
--- a/app/views/funding/trainee-summary.html
+++ b/app/views/funding/trainee-summary.html
@@ -189,9 +189,6 @@
         </p>
       {% else %}
         <p class="govuk-body">
-          This trainee summary covers {{ fundingTypes | andSeparate }} as recorded in the <span class="app-nowrap">October {{ data.years.defaultCourseYear }} ITT census.</span>
-        </p>
-        <p class="govuk-body">
           Last updated: 1 December {{ data.years.defaultCourseYear }}
         </p>
         {{ appDownloadLink({


### PR DESCRIPTION
The trainee summary contains the line: "This trainee summary covers {{ fundingTypes | andSeparate }} as recorded in the October {{ data.years.defaultCourseYear }} ITT census."

The funding team do not update this count if any trainees defer or withdraw, but they do add new trainees to it. Instead of explaining this complexity, I think we should remove the line.