### PR TITLE
Delete publish course references when the subject specialism changes …

### DIFF
--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -499,6 +499,19 @@ exports.getAllocationSubject = (input) => {
   }
 }
 
+exports.getCourseAllocationSubject = (input) => {
+  // Support passing in a course or a record
+  let courseSubject = input?.publishSubjects?.first || input?.courseDetails?.publishSubjects?.first || false
+  if (!courseSubject){
+    console.log('No course subject available')
+    return false
+  }
+  else {
+    let allocationSubject = exports.subjectToAllocationSubject(courseSubject)
+    return allocationSubject
+  }
+}
+
 
 // Internal helper to look up bursary available
 exports.getFinancialSupportByRouteAndSubject = (route, subject) => {

--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -828,6 +828,19 @@ module.exports = router => {
     // Map back to cardinal object
     courseDetails.subjects = utils.arrayToOrdinalObject(subjectsArray)
 
+    // It’s possible for a user to change the specialism to something completely
+    // different than the selected Publish course. If this happens, delete the 
+    // Publish course references and pretend it’s a manual course.
+    if (courseDetails.isPublishCourse){
+      let allocationSubject = utils.getAllocationSubject(courseDetails)
+      let courseAllocationSubject = utils.getCourseAllocationSubject(courseDetails)
+
+      if (allocationSubject != courseAllocationSubject){
+        console.log(`The allocation subject (${allocationSubject}) of subject 1 (${courseDetails?.subjects?.first}) does not match the Publish course allocatoin subject (${courseAllocationSubject}). Deleting references to old Publish course.`)
+        courseDetails = utils.deletePublishCourseReferences(courseDetails)
+      }
+    }
+
     // Merge autocomplete and radio answers
     if (courseDetails.ageRange == 'Other age range'){
       courseDetails.ageRange = courseDetails.ageRangeOther
@@ -837,6 +850,7 @@ module.exports = router => {
     // Save back to record
     record.courseDetails = courseDetails
 
+    // Todo: unsure why this is only on drafts
     if (utils.isDraft(record)){
       record = utils.setAcademicYear(record)
     }

--- a/app/views/_includes/summary-cards/course-details.html
+++ b/app/views/_includes/summary-cards/course-details.html
@@ -13,7 +13,7 @@
   <span class="govuk-hint">
     {% if isPublishCourse %}
       {{ record.courseDetails.courseNameLong }}
-    {% elseif minimalPublishSummary %}
+    {% else %}
       {{ record.courseDetails.subjects | prettifySubjects }}
     {% endif %}
   </span>


### PR DESCRIPTION
…to a different allocation subject

Previously, if a provider edited the subject specialism whilst a Publish course was linked, you'd end up in a situation where we'd say they're on one course, but the subjects are completely different.

Example:
<img width="993" alt="Screenshot 2022-05-24 at 18 20 24" src="https://user-images.githubusercontent.com/2204224/170094988-d055ac51-129e-4014-9d8c-84a10dac2a54.png">

If they change the subjects such that the trainee ends up with a different allocation subject, we should not consider it still the same "course".

In this pr once we've got manual course details, we compare the allocation subject to what the course would have been. If they don't match, then clear the publish course details.

Example:
<img width="990" alt="Screenshot 2022-05-24 at 18 24 11" src="https://user-images.githubusercontent.com/2204224/170095615-3822f5ba-697e-4827-ae73-037152eb31e5.png">

