### PR TITLE
Add users and orgs

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -45,6 +45,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "components/record-header";
 @import "components/record-actions";
 @import "components/records-actions";
+@import "components/user-card";
 @import "components/sub-navigation";
 @import "components/timeline";
 @import "components/status-card";

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -41,6 +41,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "components/cookie-banner";
 @import "components/invalid-answer";
 @import "components/notice-banner";
+@import "components/organisation-switcher";
 @import "components/record-header";
 @import "components/record-actions";
 @import "components/records-actions";

--- a/app/assets/sass/components/_organisation-switcher.scss
+++ b/app/assets/sass/components/_organisation-switcher.scss
@@ -1,0 +1,24 @@
+// Stolen from Publish - https://github.com/DFE-Digital/publish-teacher-training-prototype/blob/1238c02cc0149fc06ab0548dac8c5f7d3d773986/app/views/_components/organisation-switcher/_organisation-switcher.scss
+
+.app-organisation-switcher {
+  @include govuk-clearfix;
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(2);
+  // padding-bottom: govuk-spacing(1);
+  // border-bottom: 1px solid $govuk-border-colour;
+}
+
+.app-organisation-switcher__title {
+  @include govuk-font($size: 19, $weight: "bold");
+  @include govuk-media-query($from: tablet) {
+    float: left;
+    width: 75%;
+  }
+}
+
+.app-organisation-switcher__link {
+  @include govuk-link-common;
+  @include govuk-media-query($from: tablet) {
+    float: right;
+  }
+}

--- a/app/assets/sass/components/_summary-card.scss
+++ b/app/assets/sass/components/_summary-card.scss
@@ -86,7 +86,7 @@
 
   // Summary list component overrides
   .govuk-summary-list {
-    margin: #{govuk-spacing(2) * -1} 0;
+    margin-bottom: govuk-spacing(-2);
   }
 
   @include govuk-media-query($until: desktop) {

--- a/app/assets/sass/components/_user-card.scss
+++ b/app/assets/sass/components/_user-card.scss
@@ -1,0 +1,6 @@
+
+
+.app-user-card--extra {
+  @include govuk-typography-weight-regular;
+
+}

--- a/app/data/accrediting-providers.js
+++ b/app/data/accrediting-providers.js
@@ -1,3 +1,9 @@
+const { faker } = require('@faker-js/faker')
+
+// Seed allows the UUIDs to be consistent each time we run this. The seed should be different than that used by lead-schools.js so we get different UUIDs for each.
+faker.seed(124);
+
+
 const all = [
   "2Schools Consortium",
   "AA Teamworks West Yorkshire SCITT",
@@ -337,7 +343,8 @@ const makeObject = (providers, type) => {
     return {
       name: provider,
       type: "accreditingProvider",
-      accreditingProviderType: type
+      accreditingProviderType: type,
+      id: faker.datatype.uuid()
     }
   } )
 }

--- a/app/data/lead-schools.js
+++ b/app/data/lead-schools.js
@@ -1,3 +1,8 @@
+const { faker } = require('@faker-js/faker')
+
+// Seed allows the UUIDs to be consistent each time we run this. The seed should be different than that used by lead-schools.js so we get different UUIDs for each.
+faker.seed(123);
+
 let selectedLeadSchools = [
   {
     name: "Whitmore High School",
@@ -91,7 +96,8 @@ module.exports = {
   selected: selectedLeadSchools.map(school => {
     return {
       type: "leadSchool",
-      ...school
+      ...school,
+      id: faker.datatype.uuid()
     }
   })
 }

--- a/app/data/permissions.js
+++ b/app/data/permissions.js
@@ -1,0 +1,25 @@
+let allUserPermissions = {
+  "accreditingProvider":[
+    "view trainees",
+    "add trainees",
+    "edit trainees",
+    "export trainees",
+    "view funding"
+  ],
+  "leadSchool": [
+    "view trainees",
+    "view funding",
+    // "export trainees"
+  ]
+}
+
+let allAdminPermissions = allUserPermissions
+// Push in `manage team members`
+Object.keys(allAdminPermissions).forEach(type => {
+  allAdminPermissions[type].unshift('manage team members')
+})
+
+module.exports = {
+  allUserPermissions,
+  allAdminPermissions
+}

--- a/app/data/permissions.js
+++ b/app/data/permissions.js
@@ -1,8 +1,8 @@
 let allUserPermissions = {
   "accreditingProvider":[
     "view trainees",
-    "add trainees",
-    "edit trainees",
+    // "add trainees",
+    "add and edit trainees",
     "export trainees",
     "view funding"
   ],

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,12 +1,14 @@
 const yaml                  = require('js-yaml')
 const fs                    = require('fs')
 const path                  = require('path')
+const utils                 = require('../lib/utils.js')
 
 let countries               = require('./countries')
 let ethnicities             = require('./ethnicities')
 let nationalities           = require('./nationalities')
 let statuses                = require('./status')
 let strings                 = require('./strings')
+let permissions             = require('./permissions')
 const dataPath              = path.resolve(__dirname);
 let serviceUpdates          = yaml.load(fs.readFileSync(dataPath + '/service-updates.yaml'))
 
@@ -17,6 +19,8 @@ let degreeTypes             = degreeData.types.all
 let degreeTypesSimple       = degreeData.types.all.map(type => type.text).sort()
 let subjects                = degreeData.subjects
 let ukComparableDegrees     = degreeData.ukComparableDegrees
+let allUsers                = require('./users.json')
+const userFilters           = require('../filters/users.js').filters
 
 // Sort two things alphabetically, not case-sensitive
 const sortAlphabetical = (x, y) => {
@@ -76,7 +80,8 @@ providers.all = providers.accreditingProviders.all.concat(providers.leadSchools.
 
 providers.selected = providers.accreditingProviders.selected.concat(providers.leadSchools.selected)
 
-// console.log(providers.all)
+
+
 
 
 let years                   = require('./years')
@@ -105,6 +110,9 @@ settings.userProviders = [
   "Beam Primary School",
   "Hope Academy"
 ]
+
+
+
 
 let isAdmin = false
 settings.defaultAdminName = "System admin"
@@ -139,6 +147,72 @@ settings.courseLimit = 12
 // the minimum number of placements before EYTS/QTS can be awarded
 settings.minPlacementsRequired = 2
 
+
+// Users
+let defaultUser = {
+  fullName: 'Jane Burns',
+  id: '43e32448-30ba-4ce1-94ea-00da84b45f08'
+}
+
+
+// This will generate a default user that belongs to each enabled organisation
+// Done as a (complex) function so that if we change the enabled orgs through
+// the ui this function can be called to recalculate the defaults
+const calculateUsers = (firstProvider, userProviders) => {
+
+  const lookUpProvider = provider => {
+    let item
+    if (providers?.all){
+      item = providers.all.find(item => item.name == provider) || false
+    }
+    if (!item) console.log(`Error with getProvider data: ${provider} not found.`)
+    return item
+  }
+
+  const getProviderData = providers => {
+    if (Array.isArray(providers)){
+      return providers.map(provider => lookUpProvider(provider) ).filter(Boolean)
+    }
+    else return lookUpProvider(providers)
+  }
+
+  let users = {} // reset users
+  users.all = allUsers
+
+  defaultUser.email = userFilters.getUserEmail({
+    user: defaultUser,
+    provider: firstProvider
+  })
+  defaultUser.providers = getProviderData(userProviders)
+
+  defaultUser.providers.map(provider => {
+
+    provider.access = {
+      role: "team admin",
+      permissions: permissions.allAdminPermissions[provider.type]
+    }
+
+    return provider
+  })
+
+  users.all.push(defaultUser)
+
+  users.byProvider = {}
+
+  allUsers.forEach(user => {
+    user.providers.forEach(provider => {
+      if (!users.byProvider[provider.name]) users.byProvider[provider.name] = []
+      users.byProvider[provider.name].push(user)
+    })
+  })
+
+  return users
+
+}
+
+let users = calculateUsers(defaultProvider, settings.userProviders)
+
+
 // Supliment records with getter for name
 let records = require('./records.json')
 records = records.map(record => {
@@ -172,8 +246,10 @@ module.exports = {
   allTrainingRoutes,
   assessmentOnlyAgeRanges,
   awards,
+  calculateUsers,
   countries,
   courses,
+  defaultUser,
   degreeInstitutions,
   degreeTypes,
   degreeTypesSimple,
@@ -183,6 +259,7 @@ module.exports = {
   allSubjects,
   nationalities,
   notPassedReasons,
+  permissions,
   providers,
   records,
   // schools,
@@ -199,6 +276,7 @@ module.exports = {
   serviceUpdates,
   withdrawalReasons,
   ugEntryQualifications,
+  users,
   years,
   primarySubjectOptions: ittSubjectData.primarySubjectOptions
 }

--- a/app/data/users.json
+++ b/app/data/users.json
@@ -1,0 +1,716 @@
+[
+  {
+    "id": "13a7e8b6-7270-4c99-81e9-9d752e0c295c",
+    "fullName": "Ignatius Block",
+    "email": "ignatius.block@lincoln-school.ac.uk",
+    "providers": [
+      {
+        "name": "University of Lincoln",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "HEI",
+        "id": "1bbf9978-6442-4af6-a41c-d981d69f4712",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees",
+            "export trainees",
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "9ee21172-b616-4d86-9737-c57ecd0a87e9",
+    "fullName": "Kristina Jones",
+    "email": "kristina.jones@lincoln-school.ac.uk",
+    "providers": [
+      {
+        "name": "University of Lincoln",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "HEI",
+        "id": "1bbf9978-6442-4af6-a41c-d981d69f4712",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees",
+            "export trainees",
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "6bad09a7-0ab6-47b1-b811-0a9fcc89e14b",
+    "fullName": "Jeramy Olson",
+    "email": "jeramy.olson@lincoln-school.ac.uk",
+    "providers": [
+      {
+        "name": "University of Lincoln",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "HEI",
+        "id": "1bbf9978-6442-4af6-a41c-d981d69f4712",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees",
+            "export trainees",
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "38465ca6-07c2-495a-9b28-61f732eae81a",
+    "fullName": "Jalyn Haley",
+    "email": "jalyn.haley@lincoln-school.ac.uk",
+    "providers": [
+      {
+        "name": "University of Lincoln",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "HEI",
+        "id": "1bbf9978-6442-4af6-a41c-d981d69f4712",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees",
+            "export trainees",
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "02311730-c4e6-4054-9fd8-8a8017cf6611",
+    "fullName": "Cheyenne Koelpin",
+    "email": "cheyenne.koelpin@kings-oak.ac.uk",
+    "providers": [
+      {
+        "name": "King’s Oak University",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "HEI",
+        "id": "d02b49ce-f934-4c84-a92d-9383f6f5f13b",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "edit trainees",
+            "export trainees"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "5c1c9337-9b46-4e39-bbaa-df0e408619f2",
+    "fullName": "Dashawn Marvin",
+    "email": "dashawn.marvin@kings-oak.ac.uk",
+    "providers": [
+      {
+        "name": "King’s Oak University",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "HEI",
+        "id": "d02b49ce-f934-4c84-a92d-9383f6f5f13b",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "edit trainees",
+            "export trainees"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "193a46ab-465c-40f5-a872-89644a60dea0",
+    "fullName": "Velma Champlin",
+    "email": "velma.champlin@webury-hill.ac.uk",
+    "providers": [
+      {
+        "name": "Webury Hill SCITT",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "SCITT",
+        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees",
+            "add trainees",
+            "edit trainees",
+            "export trainees"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "cb4fcddb-5ff6-4adb-97e1-2ffad1d21d94",
+    "fullName": "Agnes Lind",
+    "email": "agnes.lind@webury-hill.ac.uk",
+    "providers": [
+      {
+        "name": "Webury Hill SCITT",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "SCITT",
+        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees",
+            "add trainees",
+            "edit trainees",
+            "export trainees"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "1535ea55-8b9a-43f9-8a34-16e70e790fe8",
+    "fullName": "Euna Kutch",
+    "email": "euna.kutch@webury-hill.ac.uk",
+    "providers": [
+      {
+        "name": "Webury Hill SCITT",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "SCITT",
+        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees",
+            "add trainees",
+            "edit trainees",
+            "export trainees"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "eeb310b6-e58d-4f07-a0a8-e899cd555e66",
+    "fullName": "Nico Howell",
+    "email": "nico.howell@webury-hill.ac.uk",
+    "providers": [
+      {
+        "name": "Webury Hill SCITT",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "SCITT",
+        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees",
+            "add trainees",
+            "edit trainees",
+            "export trainees"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "f7ea54ae-4734-4565-aecd-bb7f86d3b184",
+    "fullName": "Natasha Considine",
+    "email": "natasha.considine@webury-hill.ac.uk",
+    "providers": [
+      {
+        "name": "Webury Hill SCITT",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "SCITT",
+        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees",
+            "add trainees",
+            "edit trainees",
+            "export trainees"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "9519a3ba-8384-41b9-8a59-8bb1ef9131b8",
+    "fullName": "Orion Kihn",
+    "email": "orion.kihn@john-taylor.ac.uk",
+    "providers": [
+      {
+        "name": "The John Taylor SCITT",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "SCITT",
+        "id": "9a0bea62-dd77-4da9-aa64-cbbc1cc574c8",
+        "access": {
+          "role": "team admin",
+          "permissions": [
+            "manage team members",
+            "view trainees",
+            "add trainees",
+            "edit trainees",
+            "export trainees",
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "7dcc3252-f8a8-4c6b-9387-6c0a0011a56f",
+    "fullName": "Braxton Kuhn",
+    "email": "braxton.kuhn@john-taylor.ac.uk",
+    "providers": [
+      {
+        "name": "The John Taylor SCITT",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "SCITT",
+        "id": "9a0bea62-dd77-4da9-aa64-cbbc1cc574c8",
+        "access": {
+          "role": "team admin",
+          "permissions": [
+            "manage team members",
+            "view trainees",
+            "add trainees",
+            "edit trainees",
+            "export trainees",
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "b316b35d-f724-43e7-97e1-08bd76790c06",
+    "fullName": "Estefania Kohler",
+    "email": "estefania.kohler@john-taylor.ac.uk",
+    "providers": [
+      {
+        "name": "The John Taylor SCITT",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "SCITT",
+        "id": "9a0bea62-dd77-4da9-aa64-cbbc1cc574c8",
+        "access": {
+          "role": "team admin",
+          "permissions": [
+            "manage team members",
+            "view trainees",
+            "add trainees",
+            "edit trainees",
+            "export trainees",
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "529c372e-55d4-4874-af2d-a5cfdf16aa96",
+    "fullName": "Macie Gaylord",
+    "email": "macie.gaylord@whitmore-high.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Whitmore High School",
+        "postcode": "HA2 0AD",
+        "urn": "102239",
+        "id": "bb463b8b-b76c-4f6a-9726-65ab5730b69b",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "164b4269-20f0-417a-97e6-45fd94101e9d",
+    "fullName": "Nikita Gorczany",
+    "email": "nikita.gorczany@whitmore-high.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Whitmore High School",
+        "postcode": "HA2 0AD",
+        "urn": "102239",
+        "id": "bb463b8b-b76c-4f6a-9726-65ab5730b69b",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "851f1ed5-67a9-4f03-90a0-2bee677698dd",
+    "fullName": "Jayde O'Hara",
+    "email": "jayde.o'hara@crispin-school.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Crispin School Academy",
+        "postcode": "BA16 0AD",
+        "urn": "136913",
+        "id": "a27218b8-6a4d-47bb-95b6-5a55334fac1c",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "36c32c21-9f34-4b65-a49f-e0fa805c9351",
+    "fullName": "Barney O'Connell",
+    "email": "barney.o'connell@crispin-school.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Crispin School Academy",
+        "postcode": "BA16 0AD",
+        "urn": "136913",
+        "id": "a27218b8-6a4d-47bb-95b6-5a55334fac1c",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "bea80349-7f43-4c92-890f-8e0320cf5e4e",
+    "fullName": "Gilda Jerde",
+    "email": "gilda.jerde@watford-school.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Watford Grammar School for Girls",
+        "postcode": "WD18 0AE",
+        "urn": "136289",
+        "id": "60627261-4e6c-4ebf-8879-914576ade417",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "b93261db-2ced-47f6-84ce-e8dc6d4ef4d5",
+    "fullName": "Orval Mertz",
+    "email": "orval.mertz@watford-school.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Watford Grammar School for Girls",
+        "postcode": "WD18 0AE",
+        "urn": "136289",
+        "id": "60627261-4e6c-4ebf-8879-914576ade417",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "7ce46b72-9863-4fc1-9315-a274ecc850ef",
+    "fullName": "Samantha Morar",
+    "email": "samantha.morar@joseph-whitaker.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "The Joseph Whitaker School",
+        "postcode": "NG21 0AG",
+        "urn": "137628",
+        "id": "7f3869c1-7dc9-4486-9045-6bade487a49d",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "0ea6642b-90b0-4a03-98b8-ebf5fc7ae038",
+    "fullName": "Martin Stoltenberg",
+    "email": "martin.stoltenberg@joseph-whitaker.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "The Joseph Whitaker School",
+        "postcode": "NG21 0AG",
+        "urn": "137628",
+        "id": "7f3869c1-7dc9-4486-9045-6bade487a49d",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "99248dc6-14de-4258-96c3-3ae0ec585e28",
+    "fullName": "Rhett Barton",
+    "email": "rhett.barton@heckmondwike-school.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Heckmondwike Grammar School",
+        "postcode": "WF16 0AH",
+        "urn": "136283",
+        "id": "94a8d215-ce32-4379-b18e-2aebf0794882",
+        "access": {
+          "role": "team admin",
+          "permissions": [
+            "manage team members",
+            "view trainees",
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "2cc4787d-5d4e-4f56-9e9a-cd5d2fab3ccb",
+    "fullName": "Jacinto Mitchell",
+    "email": "jacinto.mitchell@heckmondwike-school.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Heckmondwike Grammar School",
+        "postcode": "WF16 0AH",
+        "urn": "136283",
+        "id": "94a8d215-ce32-4379-b18e-2aebf0794882",
+        "access": {
+          "role": "team admin",
+          "permissions": [
+            "manage team members",
+            "view trainees",
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "b0b0008b-cb3a-47e6-96b1-98a7baa87070",
+    "fullName": "Orlo Prohaska",
+    "email": "orlo.prohaska@emmanuel-school.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Emmanuel College",
+        "postcode": "NE11 0AN",
+        "urn": "108420",
+        "id": "42cb158b-e836-45ed-9b56-034668b8f05a",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees",
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "b1f8e772-af7c-4356-81aa-83972fd0e224",
+    "fullName": "Nickolas Weissnat",
+    "email": "nickolas.weissnat@emmanuel-school.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Emmanuel College",
+        "postcode": "NE11 0AN",
+        "urn": "108420",
+        "id": "42cb158b-e836-45ed-9b56-034668b8f05a",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees",
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "ef2cf6c1-83e1-4ee6-8a8a-6502a724858f",
+    "fullName": "Maryjane Koelpin",
+    "email": "maryjane.koelpin@moorside-high.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Moorside High School",
+        "postcode": "M27 0AP",
+        "urn": "144199",
+        "id": "c090be24-6c35-45d8-8a81-32e57a3d48dd",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees",
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "a658f5a5-3213-4f5f-99e0-73cc7e3765e4",
+    "fullName": "Zoila Carroll",
+    "email": "zoila.carroll@moorside-high.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Moorside High School",
+        "postcode": "M27 0AP",
+        "urn": "144199",
+        "id": "c090be24-6c35-45d8-8a81-32e57a3d48dd",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees",
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "1afdce26-34ab-4cac-b2df-e3b9499f7af9",
+    "fullName": "Misty Larson",
+    "email": "misty.larson@hope-school.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Hope Academy",
+        "postcode": "WA12 0AQ",
+        "urn": "136421",
+        "id": "86a5c5d2-6d05-4788-9984-0efae5384784",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "c71103fc-7c59-455c-862c-b73d41570764",
+    "fullName": "Richmond Welch",
+    "email": "richmond.welch@hope-school.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Hope Academy",
+        "postcode": "WA12 0AQ",
+        "urn": "136421",
+        "id": "86a5c5d2-6d05-4788-9984-0efae5384784",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view trainees"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "e67c1836-477d-451c-b7bd-9f13b98d9f94",
+    "fullName": "Skyla Reinger",
+    "email": "skyla.reinger@west-park-primary.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "West Park Primary School",
+        "postcode": "TS26 0BU",
+        "urn": "141717",
+        "id": "e4f94b98-c56a-4bd2-a9fd-5fd11603e7e8",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "05ea1cb2-f58a-43a9-a93a-f2deb9708a93",
+    "fullName": "Darryl Balistreri",
+    "email": "darryl.balistreri@west-park-primary.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "West Park Primary School",
+        "postcode": "TS26 0BU",
+        "urn": "141717",
+        "id": "e4f94b98-c56a-4bd2-a9fd-5fd11603e7e8",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "8ddbd215-a4b5-44cf-b401-784b83c5e95e",
+    "fullName": "Shane Rogahn",
+    "email": "shane.rogahn@beam-primary.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Beam Primary School",
+        "postcode": "RM10 9ED",
+        "urn": "101202",
+        "id": "3104de39-071c-47b8-86b4-d62ccc4a4fa6",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "38468dcf-9080-497c-98ae-afde3c538624",
+    "fullName": "Donnie O'Kon",
+    "email": "donnie.o'kon@beam-primary.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Beam Primary School",
+        "postcode": "RM10 9ED",
+        "urn": "101202",
+        "id": "3104de39-071c-47b8-86b4-d62ccc4a4fa6",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "view funding"
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/app/data/users.json
+++ b/app/data/users.json
@@ -12,9 +12,8 @@
         "access": {
           "role": "team member",
           "permissions": [
-            "view trainees",
-            "export trainees",
-            "view funding"
+            "view funding",
+            "export trainees"
           ]
         }
       }
@@ -33,9 +32,8 @@
         "access": {
           "role": "team member",
           "permissions": [
-            "view trainees",
-            "export trainees",
-            "view funding"
+            "view funding",
+            "export trainees"
           ]
         }
       }
@@ -54,9 +52,8 @@
         "access": {
           "role": "team member",
           "permissions": [
-            "view trainees",
-            "export trainees",
-            "view funding"
+            "view funding",
+            "export trainees"
           ]
         }
       }
@@ -75,9 +72,8 @@
         "access": {
           "role": "team member",
           "permissions": [
-            "view trainees",
-            "export trainees",
-            "view funding"
+            "view funding",
+            "export trainees"
           ]
         }
       }
@@ -86,17 +82,17 @@
   {
     "id": "02311730-c4e6-4054-9fd8-8a8017cf6611",
     "fullName": "Cheyenne Koelpin",
-    "email": "cheyenne.koelpin@kings-oak.ac.uk",
+    "email": "cheyenne.koelpin@lincoln-school.ac.uk",
     "providers": [
       {
-        "name": "King’s Oak University",
+        "name": "University of Lincoln",
         "type": "accreditingProvider",
         "accreditingProviderType": "HEI",
-        "id": "d02b49ce-f934-4c84-a92d-9383f6f5f13b",
+        "id": "1bbf9978-6442-4af6-a41c-d981d69f4712",
         "access": {
           "role": "team member",
           "permissions": [
-            "edit trainees",
+            "view funding",
             "export trainees"
           ]
         }
@@ -106,17 +102,17 @@
   {
     "id": "5c1c9337-9b46-4e39-bbaa-df0e408619f2",
     "fullName": "Dashawn Marvin",
-    "email": "dashawn.marvin@kings-oak.ac.uk",
+    "email": "dashawn.marvin@lincoln-school.ac.uk",
     "providers": [
       {
-        "name": "King’s Oak University",
+        "name": "University of Lincoln",
         "type": "accreditingProvider",
         "accreditingProviderType": "HEI",
-        "id": "d02b49ce-f934-4c84-a92d-9383f6f5f13b",
+        "id": "1bbf9978-6442-4af6-a41c-d981d69f4712",
         "access": {
           "role": "team member",
           "permissions": [
-            "edit trainees",
+            "view funding",
             "export trainees"
           ]
         }
@@ -126,19 +122,17 @@
   {
     "id": "193a46ab-465c-40f5-a872-89644a60dea0",
     "fullName": "Velma Champlin",
-    "email": "velma.champlin@webury-hill.ac.uk",
+    "email": "velma.champlin@lincoln-school.ac.uk",
     "providers": [
       {
-        "name": "Webury Hill SCITT",
+        "name": "University of Lincoln",
         "type": "accreditingProvider",
-        "accreditingProviderType": "SCITT",
-        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "accreditingProviderType": "HEI",
+        "id": "1bbf9978-6442-4af6-a41c-d981d69f4712",
         "access": {
           "role": "team member",
           "permissions": [
-            "view trainees",
-            "add trainees",
-            "edit trainees",
+            "view funding",
             "export trainees"
           ]
         }
@@ -148,19 +142,17 @@
   {
     "id": "cb4fcddb-5ff6-4adb-97e1-2ffad1d21d94",
     "fullName": "Agnes Lind",
-    "email": "agnes.lind@webury-hill.ac.uk",
+    "email": "agnes.lind@lincoln-school.ac.uk",
     "providers": [
       {
-        "name": "Webury Hill SCITT",
+        "name": "University of Lincoln",
         "type": "accreditingProvider",
-        "accreditingProviderType": "SCITT",
-        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "accreditingProviderType": "HEI",
+        "id": "1bbf9978-6442-4af6-a41c-d981d69f4712",
         "access": {
           "role": "team member",
           "permissions": [
-            "view trainees",
-            "add trainees",
-            "edit trainees",
+            "view funding",
             "export trainees"
           ]
         }
@@ -170,19 +162,17 @@
   {
     "id": "1535ea55-8b9a-43f9-8a34-16e70e790fe8",
     "fullName": "Euna Kutch",
-    "email": "euna.kutch@webury-hill.ac.uk",
+    "email": "euna.kutch@lincoln-school.ac.uk",
     "providers": [
       {
-        "name": "Webury Hill SCITT",
+        "name": "University of Lincoln",
         "type": "accreditingProvider",
-        "accreditingProviderType": "SCITT",
-        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "accreditingProviderType": "HEI",
+        "id": "1bbf9978-6442-4af6-a41c-d981d69f4712",
         "access": {
           "role": "team member",
           "permissions": [
-            "view trainees",
-            "add trainees",
-            "edit trainees",
+            "view funding",
             "export trainees"
           ]
         }
@@ -192,20 +182,21 @@
   {
     "id": "eeb310b6-e58d-4f07-a0a8-e899cd555e66",
     "fullName": "Nico Howell",
-    "email": "nico.howell@webury-hill.ac.uk",
+    "email": "nico.howell@kings-oak.ac.uk",
     "providers": [
       {
-        "name": "Webury Hill SCITT",
+        "name": "King’s Oak University",
         "type": "accreditingProvider",
-        "accreditingProviderType": "SCITT",
-        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "accreditingProviderType": "HEI",
+        "id": "d02b49ce-f934-4c84-a92d-9383f6f5f13b",
         "access": {
           "role": "team member",
           "permissions": [
+            "export trainees",
+            "view funding",
+            "add and edit trainees",
             "view trainees",
-            "add trainees",
-            "edit trainees",
-            "export trainees"
+            "manage team members"
           ]
         }
       }
@@ -214,7 +205,145 @@
   {
     "id": "f7ea54ae-4734-4565-aecd-bb7f86d3b184",
     "fullName": "Natasha Considine",
-    "email": "natasha.considine@webury-hill.ac.uk",
+    "email": "natasha.considine@kings-oak.ac.uk",
+    "providers": [
+      {
+        "name": "King’s Oak University",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "HEI",
+        "id": "d02b49ce-f934-4c84-a92d-9383f6f5f13b",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "export trainees",
+            "view funding",
+            "add and edit trainees",
+            "view trainees",
+            "manage team members"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "9519a3ba-8384-41b9-8a59-8bb1ef9131b8",
+    "fullName": "Orion Kihn",
+    "email": "orion.kihn@kings-oak.ac.uk",
+    "providers": [
+      {
+        "name": "King’s Oak University",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "HEI",
+        "id": "d02b49ce-f934-4c84-a92d-9383f6f5f13b",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "export trainees",
+            "view funding",
+            "add and edit trainees",
+            "view trainees",
+            "manage team members"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "7dcc3252-f8a8-4c6b-9387-6c0a0011a56f",
+    "fullName": "Braxton Kuhn",
+    "email": "braxton.kuhn@kings-oak.ac.uk",
+    "providers": [
+      {
+        "name": "King’s Oak University",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "HEI",
+        "id": "d02b49ce-f934-4c84-a92d-9383f6f5f13b",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "export trainees",
+            "view funding",
+            "add and edit trainees",
+            "view trainees",
+            "manage team members"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "b316b35d-f724-43e7-97e1-08bd76790c06",
+    "fullName": "Estefania Kohler",
+    "email": "estefania.kohler@kings-oak.ac.uk",
+    "providers": [
+      {
+        "name": "King’s Oak University",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "HEI",
+        "id": "d02b49ce-f934-4c84-a92d-9383f6f5f13b",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "export trainees",
+            "view funding",
+            "add and edit trainees",
+            "view trainees",
+            "manage team members"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "529c372e-55d4-4874-af2d-a5cfdf16aa96",
+    "fullName": "Macie Gaylord",
+    "email": "macie.gaylord@kings-oak.ac.uk",
+    "providers": [
+      {
+        "name": "King’s Oak University",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "HEI",
+        "id": "d02b49ce-f934-4c84-a92d-9383f6f5f13b",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "export trainees",
+            "view funding",
+            "add and edit trainees",
+            "view trainees",
+            "manage team members"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "b426920f-017a-4d7e-a45f-d94101e9dc42",
+    "fullName": "Judah Hilpert",
+    "email": "judah.hilpert@kings-oak.ac.uk",
+    "providers": [
+      {
+        "name": "King’s Oak University",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "HEI",
+        "id": "d02b49ce-f934-4c84-a92d-9383f6f5f13b",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "export trainees",
+            "view funding",
+            "add and edit trainees",
+            "view trainees",
+            "manage team members"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "d567a9f0-310a-402b-ae67-7698dd7a336c",
+    "fullName": "Conor Collier",
+    "email": "conor.collier@webury-hill.ac.uk",
     "providers": [
       {
         "name": "Webury Hill SCITT",
@@ -224,19 +353,186 @@
         "access": {
           "role": "team member",
           "permissions": [
-            "view trainees",
-            "add trainees",
-            "edit trainees",
-            "export trainees"
+            "add and edit trainees",
+            "view funding",
+            "manage team members"
           ]
         }
       }
     ]
   },
   {
-    "id": "9519a3ba-8384-41b9-8a59-8bb1ef9131b8",
-    "fullName": "Orion Kihn",
-    "email": "orion.kihn@john-taylor.ac.uk",
+    "id": "f34b65a4-9fe0-4fa8-85c9-3511a0bea803",
+    "fullName": "Eldridge Mann",
+    "email": "eldridge.mann@webury-hill.ac.uk",
+    "providers": [
+      {
+        "name": "Webury Hill SCITT",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "SCITT",
+        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "add and edit trainees",
+            "view funding",
+            "manage team members"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "c92890f8-e032-40cf-9e4e-669b93261db2",
+    "fullName": "Piper Trantow",
+    "email": "piper.trantow@webury-hill.ac.uk",
+    "providers": [
+      {
+        "name": "Webury Hill SCITT",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "SCITT",
+        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "add and edit trainees",
+            "view funding",
+            "manage team members"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "c4cee8dc-6d4e-4f4d-9c9a-7ce46b729863",
+    "fullName": "Zachery Rosenbaum",
+    "email": "zachery.rosenbaum@webury-hill.ac.uk",
+    "providers": [
+      {
+        "name": "Webury Hill SCITT",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "SCITT",
+        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "add and edit trainees",
+            "view funding",
+            "manage team members"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "5a274ecc-850e-4fd9-90ea-6642b90b0a03",
+    "fullName": "Bertrand Ledner",
+    "email": "bertrand.ledner@webury-hill.ac.uk",
+    "providers": [
+      {
+        "name": "Webury Hill SCITT",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "SCITT",
+        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "add and edit trainees",
+            "view funding",
+            "manage team members"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "f5fc7ae0-38bd-4299-a48d-c614de25856c",
+    "fullName": "Delores Douglas",
+    "email": "delores.douglas@webury-hill.ac.uk",
+    "providers": [
+      {
+        "name": "Webury Hill SCITT",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "SCITT",
+        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "add and edit trainees",
+            "view funding",
+            "manage team members"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "c585e28d-042c-4c47-87d5-d4ef56de9acd",
+    "fullName": "Etha Stehr",
+    "email": "etha.stehr@webury-hill.ac.uk",
+    "providers": [
+      {
+        "name": "Webury Hill SCITT",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "SCITT",
+        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "add and edit trainees",
+            "view funding",
+            "manage team members"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "3ccb79db-0b00-408b-8b3a-7e6d6b198a7b",
+    "fullName": "Makenzie O'Hara",
+    "email": "makenzie.o'hara@webury-hill.ac.uk",
+    "providers": [
+      {
+        "name": "Webury Hill SCITT",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "SCITT",
+        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "add and edit trainees",
+            "view funding",
+            "manage team members"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "0cb0b1f8-e772-4af7-8356-c1aa83972fd0",
+    "fullName": "Tevin Corwin",
+    "email": "tevin.corwin@webury-hill.ac.uk",
+    "providers": [
+      {
+        "name": "Webury Hill SCITT",
+        "type": "accreditingProvider",
+        "accreditingProviderType": "SCITT",
+        "id": "123ab332-dc58-48ca-bef1-ebd638e03e4c",
+        "access": {
+          "role": "team member",
+          "permissions": [
+            "add and edit trainees",
+            "view funding",
+            "manage team members"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "fef2cf6c-183e-41ee-a8a8-a6502a724858",
+    "fullName": "Velva Pollich",
+    "email": "velva.pollich@john-taylor.ac.uk",
     "providers": [
       {
         "name": "The John Taylor SCITT",
@@ -244,23 +540,19 @@
         "accreditingProviderType": "SCITT",
         "id": "9a0bea62-dd77-4da9-aa64-cbbc1cc574c8",
         "access": {
-          "role": "team admin",
+          "role": "team member",
           "permissions": [
-            "manage team members",
-            "view trainees",
-            "add trainees",
-            "edit trainees",
             "export trainees",
-            "view funding"
+            "add and edit trainees"
           ]
         }
       }
     ]
   },
   {
-    "id": "7dcc3252-f8a8-4c6b-9387-6c0a0011a56f",
-    "fullName": "Braxton Kuhn",
-    "email": "braxton.kuhn@john-taylor.ac.uk",
+    "id": "58f5a532-13f5-4f19-a073-cc7e3765e4f1",
+    "fullName": "Layne Buckridge",
+    "email": "layne.buckridge@john-taylor.ac.uk",
     "providers": [
       {
         "name": "The John Taylor SCITT",
@@ -268,47 +560,19 @@
         "accreditingProviderType": "SCITT",
         "id": "9a0bea62-dd77-4da9-aa64-cbbc1cc574c8",
         "access": {
-          "role": "team admin",
+          "role": "team member",
           "permissions": [
-            "manage team members",
-            "view trainees",
-            "add trainees",
-            "edit trainees",
             "export trainees",
-            "view funding"
+            "add and edit trainees"
           ]
         }
       }
     ]
   },
   {
-    "id": "b316b35d-f724-43e7-97e1-08bd76790c06",
-    "fullName": "Estefania Kohler",
-    "email": "estefania.kohler@john-taylor.ac.uk",
-    "providers": [
-      {
-        "name": "The John Taylor SCITT",
-        "type": "accreditingProvider",
-        "accreditingProviderType": "SCITT",
-        "id": "9a0bea62-dd77-4da9-aa64-cbbc1cc574c8",
-        "access": {
-          "role": "team admin",
-          "permissions": [
-            "manage team members",
-            "view trainees",
-            "add trainees",
-            "edit trainees",
-            "export trainees",
-            "view funding"
-          ]
-        }
-      }
-    ]
-  },
-  {
-    "id": "529c372e-55d4-4874-af2d-a5cfdf16aa96",
-    "fullName": "Macie Gaylord",
-    "email": "macie.gaylord@whitmore-high.ac.uk",
+    "id": "e2634abc-ac72-4dfe-bb94-99f7af9b8dc7",
+    "fullName": "Benjamin Carter",
+    "email": "benjamin.carter@whitmore-high.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -319,6 +583,8 @@
         "access": {
           "role": "team member",
           "permissions": [
+            "view trainees",
+            "manage team members",
             "view funding"
           ]
         }
@@ -326,9 +592,9 @@
     ]
   },
   {
-    "id": "164b4269-20f0-417a-97e6-45fd94101e9d",
-    "fullName": "Nikita Gorczany",
-    "email": "nikita.gorczany@whitmore-high.ac.uk",
+    "id": "fc7c5955-c862-4cb7-bd41-570764df2e67",
+    "fullName": "Petra Boyle",
+    "email": "petra.boyle@whitmore-high.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -339,6 +605,8 @@
         "access": {
           "role": "team member",
           "permissions": [
+            "view trainees",
+            "manage team members",
             "view funding"
           ]
         }
@@ -346,9 +614,9 @@
     ]
   },
   {
-    "id": "851f1ed5-67a9-4f03-90a0-2bee677698dd",
-    "fullName": "Jayde O'Hara",
-    "email": "jayde.o'hara@crispin-school.ac.uk",
+    "id": "6477d51c-77bd-49f1-bb98-d9f94eb405ea",
+    "fullName": "Anissa Schimmel",
+    "email": "anissa.schimmel@crispin-school.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -357,8 +625,11 @@
         "urn": "136913",
         "id": "a27218b8-6a4d-47bb-95b6-5a55334fac1c",
         "access": {
-          "role": "team member",
+          "role": "team admin",
           "permissions": [
+            "view trainees",
+            "manage team members",
+            "manage team members",
             "view funding"
           ]
         }
@@ -366,9 +637,9 @@
     ]
   },
   {
-    "id": "36c32c21-9f34-4b65-a49f-e0fa805c9351",
-    "fullName": "Barney O'Connell",
-    "email": "barney.o'connell@crispin-school.ac.uk",
+    "id": "f58a3a9a-93af-42de-b970-8a933088ddbd",
+    "fullName": "Bridgette Braun",
+    "email": "bridgette.braun@crispin-school.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -377,8 +648,11 @@
         "urn": "136913",
         "id": "a27218b8-6a4d-47bb-95b6-5a55334fac1c",
         "access": {
-          "role": "team member",
+          "role": "team admin",
           "permissions": [
+            "view trainees",
+            "manage team members",
+            "manage team members",
             "view funding"
           ]
         }
@@ -386,9 +660,9 @@
     ]
   },
   {
-    "id": "bea80349-7f43-4c92-890f-8e0320cf5e4e",
-    "fullName": "Gilda Jerde",
-    "email": "gilda.jerde@watford-school.ac.uk",
+    "id": "4b54cff4-0178-44b8-bc5e-95eeb238468d",
+    "fullName": "Odessa Windler",
+    "email": "odessa.windler@watford-school.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -397,8 +671,11 @@
         "urn": "136289",
         "id": "60627261-4e6c-4ebf-8879-914576ade417",
         "access": {
-          "role": "team member",
+          "role": "team admin",
           "permissions": [
+            "view trainees",
+            "manage team members",
+            "manage team members",
             "view funding"
           ]
         }
@@ -406,9 +683,9 @@
     ]
   },
   {
-    "id": "b93261db-2ced-47f6-84ce-e8dc6d4ef4d5",
-    "fullName": "Orval Mertz",
-    "email": "orval.mertz@watford-school.ac.uk",
+    "id": "8097c58a-eafd-4e3c-9386-244a55cc319c",
+    "fullName": "Rolando McDermott",
+    "email": "rolando.mcdermott@watford-school.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -417,8 +694,11 @@
         "urn": "136289",
         "id": "60627261-4e6c-4ebf-8879-914576ade417",
         "access": {
-          "role": "team member",
+          "role": "team admin",
           "permissions": [
+            "view trainees",
+            "manage team members",
+            "manage team members",
             "view funding"
           ]
         }
@@ -426,9 +706,9 @@
     ]
   },
   {
-    "id": "7ce46b72-9863-4fc1-9315-a274ecc850ef",
-    "fullName": "Samantha Morar",
-    "email": "samantha.morar@joseph-whitaker.ac.uk",
+    "id": "9619f8af-ac68-482c-a038-a0e73f35ddd2",
+    "fullName": "Felipe Wisoky",
+    "email": "felipe.wisoky@joseph-whitaker.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -437,18 +717,21 @@
         "urn": "137628",
         "id": "7f3869c1-7dc9-4486-9045-6bade487a49d",
         "access": {
-          "role": "team member",
+          "role": "team admin",
           "permissions": [
-            "view trainees"
+            "view trainees",
+            "manage team members",
+            "manage team members",
+            "view funding"
           ]
         }
       }
     ]
   },
   {
-    "id": "0ea6642b-90b0-4a03-98b8-ebf5fc7ae038",
-    "fullName": "Martin Stoltenberg",
-    "email": "martin.stoltenberg@joseph-whitaker.ac.uk",
+    "id": "25f2d1ec-8014-4095-8ebf-0df216f3133a",
+    "fullName": "Marianne Kuhic",
+    "email": "marianne.kuhic@joseph-whitaker.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -457,18 +740,43 @@
         "urn": "137628",
         "id": "7f3869c1-7dc9-4486-9045-6bade487a49d",
         "access": {
+          "role": "team admin",
+          "permissions": [
+            "view trainees",
+            "manage team members",
+            "manage team members",
+            "view funding"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "5178f596-84d6-4b88-87dd-e38345fc61b0",
+    "fullName": "Mary Hamill",
+    "email": "mary.hamill@heckmondwike-school.ac.uk",
+    "providers": [
+      {
+        "type": "leadSchool",
+        "name": "Heckmondwike Grammar School",
+        "postcode": "WF16 0AH",
+        "urn": "136283",
+        "id": "94a8d215-ce32-4379-b18e-2aebf0794882",
+        "access": {
           "role": "team member",
           "permissions": [
-            "view trainees"
+            "view trainees",
+            "manage team members",
+            "view funding"
           ]
         }
       }
     ]
   },
   {
-    "id": "99248dc6-14de-4258-96c3-3ae0ec585e28",
-    "fullName": "Rhett Barton",
-    "email": "rhett.barton@heckmondwike-school.ac.uk",
+    "id": "36fc1679-3541-4dc5-a163-ad5f74bac1fb",
+    "fullName": "Alana Johns",
+    "email": "alana.johns@heckmondwike-school.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -477,10 +785,10 @@
         "urn": "136283",
         "id": "94a8d215-ce32-4379-b18e-2aebf0794882",
         "access": {
-          "role": "team admin",
+          "role": "team member",
           "permissions": [
-            "manage team members",
             "view trainees",
+            "manage team members",
             "view funding"
           ]
         }
@@ -488,31 +796,9 @@
     ]
   },
   {
-    "id": "2cc4787d-5d4e-4f56-9e9a-cd5d2fab3ccb",
-    "fullName": "Jacinto Mitchell",
-    "email": "jacinto.mitchell@heckmondwike-school.ac.uk",
-    "providers": [
-      {
-        "type": "leadSchool",
-        "name": "Heckmondwike Grammar School",
-        "postcode": "WF16 0AH",
-        "urn": "136283",
-        "id": "94a8d215-ce32-4379-b18e-2aebf0794882",
-        "access": {
-          "role": "team admin",
-          "permissions": [
-            "manage team members",
-            "view trainees",
-            "view funding"
-          ]
-        }
-      }
-    ]
-  },
-  {
-    "id": "b0b0008b-cb3a-47e6-96b1-98a7baa87070",
-    "fullName": "Orlo Prohaska",
-    "email": "orlo.prohaska@emmanuel-school.ac.uk",
+    "id": "24ef6845-9a03-4f30-bbf9-79ca76969eff",
+    "fullName": "Marcelina Franey",
+    "email": "marcelina.franey@emmanuel-school.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -524,6 +810,7 @@
           "role": "team member",
           "permissions": [
             "view trainees",
+            "manage team members",
             "view funding"
           ]
         }
@@ -531,9 +818,9 @@
     ]
   },
   {
-    "id": "b1f8e772-af7c-4356-81aa-83972fd0e224",
-    "fullName": "Nickolas Weissnat",
-    "email": "nickolas.weissnat@emmanuel-school.ac.uk",
+    "id": "043f776b-c3cd-416f-88d9-d68a9dca4f7b",
+    "fullName": "Greg Schuster",
+    "email": "greg.schuster@emmanuel-school.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -545,6 +832,7 @@
           "role": "team member",
           "permissions": [
             "view trainees",
+            "manage team members",
             "view funding"
           ]
         }
@@ -552,9 +840,9 @@
     ]
   },
   {
-    "id": "ef2cf6c1-83e1-4ee6-8a8a-6502a724858f",
-    "fullName": "Maryjane Koelpin",
-    "email": "maryjane.koelpin@moorside-high.ac.uk",
+    "id": "9a2a51cd-d9a1-4e90-b33e-095e955246c9",
+    "fullName": "Nina Miller",
+    "email": "nina.miller@moorside-high.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -566,6 +854,7 @@
           "role": "team member",
           "permissions": [
             "view trainees",
+            "manage team members",
             "view funding"
           ]
         }
@@ -573,9 +862,9 @@
     ]
   },
   {
-    "id": "a658f5a5-3213-4f5f-99e0-73cc7e3765e4",
-    "fullName": "Zoila Carroll",
-    "email": "zoila.carroll@moorside-high.ac.uk",
+    "id": "1f808eb6-ed52-465b-ba98-95e312d1e19d",
+    "fullName": "Theresa Homenick",
+    "email": "theresa.homenick@moorside-high.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -587,6 +876,7 @@
           "role": "team member",
           "permissions": [
             "view trainees",
+            "manage team members",
             "view funding"
           ]
         }
@@ -594,9 +884,9 @@
     ]
   },
   {
-    "id": "1afdce26-34ab-4cac-b2df-e3b9499f7af9",
-    "fullName": "Misty Larson",
-    "email": "misty.larson@hope-school.ac.uk",
+    "id": "3ef3c4d3-1f11-4ab9-a6a2-d732a1bd78d5",
+    "fullName": "Maud Raynor",
+    "email": "maud.raynor@hope-school.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -607,16 +897,18 @@
         "access": {
           "role": "team member",
           "permissions": [
-            "view trainees"
+            "view trainees",
+            "manage team members",
+            "view funding"
           ]
         }
       }
     ]
   },
   {
-    "id": "c71103fc-7c59-455c-862c-b73d41570764",
-    "fullName": "Richmond Welch",
-    "email": "richmond.welch@hope-school.ac.uk",
+    "id": "c0837572-0c8d-4662-9167-205f3646b0e6",
+    "fullName": "Diana Armstrong",
+    "email": "diana.armstrong@hope-school.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -627,16 +919,18 @@
         "access": {
           "role": "team member",
           "permissions": [
-            "view trainees"
+            "view trainees",
+            "manage team members",
+            "view funding"
           ]
         }
       }
     ]
   },
   {
-    "id": "e67c1836-477d-451c-b7bd-9f13b98d9f94",
-    "fullName": "Skyla Reinger",
-    "email": "skyla.reinger@west-park-primary.ac.uk",
+    "id": "15ade7e0-d2db-4abf-835a-57cb66b89f57",
+    "fullName": "Arlie Hayes",
+    "email": "arlie.hayes@west-park-primary.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -647,6 +941,8 @@
         "access": {
           "role": "team member",
           "permissions": [
+            "view trainees",
+            "manage team members",
             "view funding"
           ]
         }
@@ -654,9 +950,9 @@
     ]
   },
   {
-    "id": "05ea1cb2-f58a-43a9-a93a-f2deb9708a93",
-    "fullName": "Darryl Balistreri",
-    "email": "darryl.balistreri@west-park-primary.ac.uk",
+    "id": "ec78fd5a-3e51-457a-b0dc-56e6873747d5",
+    "fullName": "Lucious Klein",
+    "email": "lucious.klein@west-park-primary.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -667,6 +963,8 @@
         "access": {
           "role": "team member",
           "permissions": [
+            "view trainees",
+            "manage team members",
             "view funding"
           ]
         }
@@ -674,9 +972,9 @@
     ]
   },
   {
-    "id": "8ddbd215-a4b5-44cf-b401-784b83c5e95e",
-    "fullName": "Shane Rogahn",
-    "email": "shane.rogahn@beam-primary.ac.uk",
+    "id": "e82983a8-f900-4480-bc6c-d8597a0646aa",
+    "fullName": "Emerald Hartmann",
+    "email": "emerald.hartmann@beam-primary.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -685,8 +983,11 @@
         "urn": "101202",
         "id": "3104de39-071c-47b8-86b4-d62ccc4a4fa6",
         "access": {
-          "role": "team member",
+          "role": "team admin",
           "permissions": [
+            "view trainees",
+            "manage team members",
+            "manage team members",
             "view funding"
           ]
         }
@@ -694,9 +995,9 @@
     ]
   },
   {
-    "id": "38468dcf-9080-497c-98ae-afde3c538624",
-    "fullName": "Donnie O'Kon",
-    "email": "donnie.o'kon@beam-primary.ac.uk",
+    "id": "4fff1574-0885-42da-a4bb-b56014d18794",
+    "fullName": "Madison Nikolaus",
+    "email": "madison.nikolaus@beam-primary.ac.uk",
     "providers": [
       {
         "type": "leadSchool",
@@ -705,8 +1006,11 @@
         "urn": "101202",
         "id": "3104de39-071c-47b8-86b4-d62ccc4a4fa6",
         "access": {
-          "role": "team member",
+          "role": "team admin",
           "permissions": [
+            "view trainees",
+            "manage team members",
+            "manage team members",
             "view funding"
           ]
         }

--- a/app/filters/permissions.js
+++ b/app/filters/permissions.js
@@ -29,7 +29,7 @@ filters.getAccessLevels = function(providers, data){
 
   // Loop through each signed-in provider and get their type
   let accessLevels = providers.map(provider => utils.getProviderType.apply(this, [provider, data]))
-  if (data?.isAdmin) accessLevels.push("admin")
+  // if (data?.isAdmin) accessLevels.push("admin")
   return accessLevels
 }
 
@@ -96,7 +96,7 @@ filters.providerIsAuthorised = function(providers, action){
   }
 
   else {
-    console.log(`Error: provider type ${providerType} not recognised.`)
+    console.log(`Error: provider type ${providerType}, access level ${accessLevel} not recognised.`)
   }
 
 }

--- a/app/filters/users.js
+++ b/app/filters/users.js
@@ -1,0 +1,70 @@
+
+const moment = require("moment")
+const _ = require('lodash')
+const utils = require('../lib/utils.js')
+const permissions = require('../data/permissions.js')
+
+// Leave this filters line
+var filters = {}
+
+// Return an array of users that belong to the current signed in provider
+filters.getProviderUsers = function(data){
+  data = data || this?.ctx?.data || false
+
+  let currentProvider = data.settings.userActiveProvider
+
+  let providerUsers = data.users.byProvider?.[currentProvider]
+
+  return providerUsers
+}
+
+// Generate a user’s email address
+// Input: { data, user: {fullName}, provider}
+filters.getUserEmail = function(params){
+
+  data = params.data || this?.ctx?.data || false
+  user = params.user || data.settings.defaultUser
+  activeProvider = params.provider || data?.settings?.userActiveProvider
+  return `${user.fullName.split(" ").join(".")}@${filters.makeFakeSchoolDomain(activeProvider)}`.toLowerCase()
+}
+
+// User a provider’s name to generate a somewhat realistic domain name
+filters.makeFakeSchoolDomain = (input, array=[], tld="ac.uk") => {
+  let output = input.toLowerCase()
+
+  // Strip out a bunch of common words and phrases
+  array = array.concat([
+    "academy",
+    "college",
+    "for boys",
+    "for girls",
+    "grammar",
+    "hei",
+    "scitt", // should come before itt
+    "itt",
+    "of ",
+    "school",
+    "the ",
+    "university"
+    ])
+  array.forEach(item => output = output.replace(item, ""))
+  // Remove punctuation
+  output = output.replace(/[.,'’\/#!$%\^&\*;:{}=\-_`~()]/g,"").trim()
+  // Split and remove falsy
+  .split(" ").filter(Boolean)
+  // If it’s got a single part name, add 'school'
+  if (output.length == 1) output.push("school") 
+  let joined = output.join('-')
+  return `${joined}.${tld}`
+}
+
+// Accrediting provider admins have the most permissions
+let allPossiblePermissions = permissions.allAdminPermissions.accreditingProvider
+
+// Take a user’s urrent permissions and sort them by a predefined order
+filters.sortPermissions = array => array.sort((a, b) => allPossiblePermissions.indexOf(a) - allPossiblePermissions.indexOf(b));
+
+// -------------------------------------------------------------------
+// keep the following line to return your filters to the app
+// -------------------------------------------------------------------
+exports.filters = filters

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -1870,6 +1870,13 @@ exports.getProviderData = function(input, data=false){
 
   const lookUpProvider = provider => {
     let item
+    if (provider == "System admin"){
+      return {
+        name: 'System admin',
+        type: 'admin'
+      }
+    }
+
     if (data?.providers?.all){
       item = data.providers.all.find(item => item.name == provider) || false
     }
@@ -1889,6 +1896,9 @@ exports.getProviderType = function(provider, data=false){
 
   let allProviders = data?.providers?.all
 
+  // Handle the admin provider
+  if (provider == "System admin" || provider.type == "System admin") return 'admin'
+
   let output = false
 
   if (!allProviders) {
@@ -1896,13 +1906,16 @@ exports.getProviderType = function(provider, data=false){
     return false
   }
 
+  // Provider object
   if (_.isObject(provider)){
     output = allProviders.find(item => provider.id == item.id)
   }
-  // string
-  else output = allProviders.find(item => provider == item.name)
+  // String name of provider
+  else {
+    output = allProviders.find(item => provider == item.name)
+  }
 
-  return output.type
+  return output?.type
 
 }
 
@@ -1927,7 +1940,7 @@ exports.getProviderTypeString = (input) => {
       return 'lead school'
       break;
     default:
-      return ""
+      return type
   }
 
 }

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -49,6 +49,11 @@ exports.pickRandom = (array, randomFunction = Math.random) => {
   return array[Math.floor(randomFunction() * array.length)]
 }
 
+// Random number between x and y
+exports.getRandomArbitrary = (min, max) => {
+  return Math.floor(Math.random() * (max - min) + min)
+}
+
 // Sort two things alphabetically, not case-sensitive
 exports.sortAlphabetical = (x, y) => {
   if(x.toLowerCase() !== y.toLowerCase()) {
@@ -1882,8 +1887,49 @@ exports.getProviderData = function(input, data=false){
 exports.getProviderType = function(provider, data=false){
   data = data || this?.ctx?.data || false
 
-  let found = data?.providers?.all && data.providers.all.find(item => item.name == provider)
-  return found?.type || false
+  let allProviders = data?.providers?.all
+
+  let output = false
+
+  if (!allProviders) {
+    console.log("Error with getProviderType: data not provided")
+    return false
+  }
+
+  if (_.isObject(provider)){
+    output = allProviders.find(item => provider.id == item.id)
+  }
+  // string
+  else output = allProviders.find(item => provider == item.name)
+
+  return output.type
+
+}
+
+// Get a human readable provider type eg `lead school`,
+exports.getProviderTypeString = (input) => {
+
+  let type
+  if (_.isObject(input)){
+    type = input.type
+  }
+  else type = input
+
+  switch (type) {
+    case 'accreditingProvider':
+      // if (input.accreditingProviderType){
+      //   return input.accreditingProviderType
+      // }
+      // else
+        return 'accrediting provider'
+      break;
+    case 'leadSchool':
+      return 'lead school'
+      break;
+    default:
+      return ""
+  }
+
 }
 
 exports.providerIsAccrediting = function(provider, data=false){

--- a/app/routes.js
+++ b/app/routes.js
@@ -28,8 +28,8 @@ router.all('*', function(req, res, next){
   if (hasQuery) {
     res.locals.query = req.query
     res.locals.queryString = url.format({
-              query: req.query,
-            })
+      query: req.query,
+    })
   }
   res.locals.flash = req.flash('success') // pass through 'success' messages only
   res.locals.currentPageUrl = url.parse(req.url).pathname
@@ -62,11 +62,15 @@ router.all('*', function(req, res, next){
   if (data?.settings?.userActiveProvider == data.settings.defaultAdminName){
     data.isAdmin = true
     res.locals.data.isAdmin = true
-
   }
   else {
     data.isAdmin = false
     res.locals.data.isAdmin = false
+  }
+
+  if (data?.settings?.userActiveProvider){
+    let provider = utils.getProviderData(data.settings.userActiveProvider, data)
+    res.locals.activeProvider = provider
   }
 
   // data.isAdmin = (data.settings.viewAsAdmin == "true") ? true : false
@@ -193,6 +197,11 @@ require('./routes/bulk-action-routes')(router)
 // Bulk uploads
 // =============================================================================
 require('./routes/bulk-update-routes')(router)
+
+// =============================================================================
+// Organisations and users
+// =============================================================================
+require('./routes/organisations-and-users-routes')(router)
 
 
 module.exports = router

--- a/app/routes/bulk-update-routes.js
+++ b/app/routes/bulk-update-routes.js
@@ -8,10 +8,6 @@ const utils = require('./../lib/utils')
 const weighted = require('weighted')
 const { faker } = require('@faker-js/faker')
 
-const getRandomArbitrary = (min, max) => {
-  return Math.floor(Math.random() * (max - min) + min)
-}
-
 const rowsHaveErrors = rows => {
   if (Array.isArray(rows)) {
     return rows.some(row => row.uploadStatus == "error")
@@ -96,7 +92,7 @@ module.exports = router => {
       }
 
       if (!row.trainee.trainingDetails.commencementDate) {
-        row.trainee.trainingDetails.commencementDate = getRandomArbitrary(6, 8) + "/" + getRandomArbitrary(1, 28) + "/" + data.years.defaultCourseYear
+        row.trainee.trainingDetails.commencementDate = utils.getRandomArbitrary(6, 8) + "/" + utils.getRandomArbitrary(1, 28) + "/" + data.years.defaultCourseYear
       }
 
       if (row.errorMessage == "URN not recognised" || row.errorMessage == "school is closed") {
@@ -194,7 +190,7 @@ module.exports = router => {
     /* For each record, randomly pick whether it's ok, in error, or unchanged. If in error, pick a random error */
     let processedRows = uploadedTrainees.map((trainee, index) => {
 
-      let wildCardDate = getRandomArbitrary(1, 6) + "/" + getRandomArbitrary(1, 28) + "/" + data.years.endOfCurrentCycle
+      let wildCardDate = utils.getRandomArbitrary(1, 6) + "/" + utils.getRandomArbitrary(1, 28) + "/" + data.years.endOfCurrentCycle
 
       let row = {
         trainee,

--- a/app/routes/organisations-and-users-routes.js
+++ b/app/routes/organisations-and-users-routes.js
@@ -1,0 +1,35 @@
+const _ = require('lodash')
+const filters = require('./../filters.js')()
+const moment = require('moment')
+const path = require('path')
+const seedRandom = require('seedrandom')
+const url = require('url')
+const utils = require('./../lib/utils')
+const weighted = require('weighted')
+const { faker } = require('@faker-js/faker')
+
+module.exports = router => {
+
+  // Render a page for each organisation UUID
+  router.get('/organisations/:uuid', function(req, res, next) {
+    const data = req.session.data
+    let uuid = req.params.uuid
+    let provider = data.providers.all.find(provider => provider.id == uuid)
+
+    res.render('organisations/organisation', {
+      provider: provider
+    })
+  })
+
+  // Render organisation pages, passing along the organisation UUID
+  router.get('/organisations/:uuid/:page*', function (req, res, next) {
+    console.log('looking for org')
+    // Use our own render as some templates live at /index.html
+    utils.render(
+      path.join('organisations', req.params.page, req.params[0]), res, next, {
+        uuid: req.params.uuid
+      }
+    )
+  })
+
+}

--- a/app/routes/records-list-routes.js
+++ b/app/routes/records-list-routes.js
@@ -385,13 +385,11 @@ module.exports = router => {
     let registeredRecords = objectFilters.removeWhere(filteredRecords, 'status', "Draft")
     let draftRecordsCount = hasFilters ? draftRecords.length : null
 
-
-
     // Truncate records in case there's lots - and as we don't have working pagination
-    filteredRecords = filteredRecords.slice(0, 204)
+    filteredRecords = registeredRecords.slice(0, 204)
 
     res.render('records', {
-      filteredRecords: registeredRecords,
+      filteredRecords,
       hasFilters,
       selectedFilters,
       draftRecordsCount

--- a/app/views/_includes/organisation-switcher.html
+++ b/app/views/_includes/organisation-switcher.html
@@ -1,7 +1,7 @@
 <div class="app-organisation-switcher govuk-width-container" aria-label="Organisation switcher">
   <div class="app-organisation-switcher__title">{{data.settings.userActiveProvider}}</div>
 
-  <a href="/select-organisation" class="app-organisation-switcher__link">Change organisation</a>
+  <a href="/select-organisation" class="govuk-link--no-visited-state app-organisation-switcher__link">Change organisation</a>
   
 </div>
 

--- a/app/views/_includes/organisation-switcher.html
+++ b/app/views/_includes/organisation-switcher.html
@@ -1,0 +1,8 @@
+<div class="app-organisation-switcher govuk-width-container" aria-label="Organisation switcher">
+  <div class="app-organisation-switcher__title">{{data.settings.userActiveProvider}}</div>
+
+  <a href="/select-organisation" class="app-organisation-switcher__link">Change organisation</a>
+  
+</div>
+
+{{data | log}}

--- a/app/views/_includes/user-card.njk
+++ b/app/views/_includes/user-card.njk
@@ -1,0 +1,42 @@
+{% set showPermissions = false %}
+
+{% set isCurrentUser = user.fullName == data.defaultUser.fullName %}
+
+<div class="app-user-card govuk-!-margin-bottom-6">
+
+  <h3 class="govuk-heading-s">
+    <span class="app-user-card--name">
+      {{user.fullName}}{% if isCurrentUser %} (you){% endif %}
+    </span>
+    <span class="app-user-card--extra">
+       – {{user.email}}
+    </span>
+  </h3>
+
+  {# Permissions #}
+  {% if showPermissions %}
+
+    {% set userPermissions = (user.providers | getRecordById(provider.id)).access %}
+
+    <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-0 govuk-!-font-size-16 govuk-hint">
+      Role: {{userPermissions.role}}
+    </p>
+
+    <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-0 govuk-!-font-size-16 govuk-hint">
+      {{ "You have" if isCurrentUser else "This user has" }} permission to:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1 govuk-!-margin-bottom-0 govuk-!-font-size-16 govuk-hint">
+
+      {% set permissions = userPermissions.permissions | sortPermissions %}
+      
+      {% for permission in permissions %}
+        <li>{{permission}}</li>
+      {% endfor %}
+
+    </ul>
+
+  {% endif %}
+
+
+</div>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -72,6 +72,9 @@
     {% endif %}
 
   {% include "_includes/cookie-banner.html" %}
+
+  {% set shouldShowOrganisationSwitchLink = (data.settings.userProviders | length > 1) and not data.isAdmin and not data.isImpersonating | falsify and not hidePrimaryNav  %}
+
   {# Set serviceName in config.js. #}
   {% set headerClass = 'app-light-header' %}
   {{ govukHeader({
@@ -86,39 +89,50 @@
         text: "Your account"
       } if false,
       {
+        href: "/select-organisation",
+        text: "Change organisation"
+      } if shouldShowOrganisationSwitchLink and false,
+      {
         href: "/start-page",
         text: "Sign out"
       }
     ] if not hideNav
   }) }}
 
+  {% if shouldShowOrganisationSwitchLink %}
+    {% include "_includes/organisation-switcher.html" %}
+  {% endif %}
+
   {% set rightHandSideNavHtml %}
 
-  {% if not data.isAdmin and not data.isImpersonating | falsify %}
-    {% set providerName = data.settings.userActiveProvider %}
-    {% if providerName | providerIsLeadSchool %}
-      {% set providerName -%}
-        {{providerName}}{#  (view only) #}
-      {%- endset %}
-    {% endif %}
+    {% if not data.isAdmin and not data.isImpersonating | falsify %}
+      {% set providerName = data.settings.userActiveProvider %}
 
-    <nav class="moj-primary-navigation">
-      <ul class="moj-primary-navigation__list">
-
+      <nav class="moj-primary-navigation">
+        <ul class="moj-primary-navigation__list">
+          {% set ariaCurrent = "aria-current=page" if navActive == "provider" %}
           <li class="moj-primary-navigation__item">
-            <a class="moj-primary-navigation__link {{ 'aria-current="page"' | safe if navActive == 'provider' }}" href="/select-organisation">
-              {{ providerName }}
+            <a class="moj-primary-navigation__link" {{ ariaCurrent }} href="/organisations/{{activeProvider.id}}">
+              {{provider | log('providerisms')}}
+              {# Most users can only view a single organisation - so the section is specific to them #}
+              {% if not data.isAdmin %}
+                Your organisation
+              {# Admins can view all organsations, so use a more generic section name #}
+              {% else %}
+                Organisations
+              {% endif %}
             </a>
           </li>
 
-      </ul>
+        </ul>
 
-    </nav>
-  {% endif %}
+      </nav>
+    {% endif %}
 
   {% endset %}
 
-  {% set navItems = [{
+  {% set navItems = [
+    {
       text: 'Home',
       href: '/home',
       active: true if navActive == 'home'
@@ -158,10 +172,7 @@
       href: '/funding/payment-schedule',
       active: true if navActive == 'Funding'
     } if data.settings.showFundingInPrimaryNav
-  ] %}
-
-    {# MOJ primary nav does’t handle empty items well, so remove them here #}
-    {% set navItems = navItems | removeEmpty %}
+  ] | removeEmpty %}
 
   {% if not hidePrimaryNav %}
 

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -113,14 +113,7 @@
           {% set ariaCurrent = "aria-current=page" if navActive == "provider" %}
           <li class="moj-primary-navigation__item">
             <a class="moj-primary-navigation__link" {{ ariaCurrent }} href="/organisations/{{activeProvider.id}}">
-              {{provider | log('providerisms')}}
-              {# Most users can only view a single organisation - so the section is specific to them #}
-              {% if not data.isAdmin %}
-                Your organisation
-              {# Admins can view all organsations, so use a more generic section name #}
-              {% else %}
-                Organisations
-              {% endif %}
+              Organisation details
             </a>
           </li>
 

--- a/app/views/organisations/index.html
+++ b/app/views/organisations/index.html
@@ -1,0 +1,50 @@
+{% extends "_templates/_page.html" %}
+
+{% set pageHeading %}
+  Organisations
+{% endset %}
+
+{% set navActive = "home" %}
+
+{% set backText = "Home" %}
+{% set backLink = '/home' %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-l">Organisations</h1>
+
+        <form action="" method="post">
+
+          {# {{ data.users.byProvider[data.settings.userActiveProvider] | log}} #}
+
+          <h2 class="govuk-heading-m">
+            Accrediting providers
+          </h2> 
+          <ol class="govuk-list">
+            {% for organisation in data.providers.accreditingProviders.selected %}
+            <li>
+              <a href="/organisations/{{organisation.id}}" class="govuk-link">{{organisation.name}}</a>
+            </li>
+          {% endfor %}
+          </ol>
+
+          <h2 class="govuk-heading-m">
+            Lead schools
+          </h2> 
+          <ol class="govuk-list">
+            {% for organisation in data.providers.leadSchools.selected %}
+            <li>
+              <a href="/organisations/{{organisation.id}}" class="govuk-link">{{organisation.name}}</a>
+            </li>
+          {% endfor %}
+          </ol>
+
+
+        </form>
+
+      </div>
+    </div>
+
+{% endblock %}

--- a/app/views/organisations/organisation.html
+++ b/app/views/organisations/organisation.html
@@ -1,0 +1,118 @@
+{% extends "_templates/_page.html" %}
+
+{% set pageHeading %}
+  Organisation – {{ provider.name }}
+{% endset %}
+
+{% set navActive = "provider" %}
+
+{% set backText = "Home" %}
+{% set backLink = '/home' %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-l">{{provider.name}}</h1>
+
+        {% set shouldShowOrganisationSwitchLink = (data.settings.userProviders | length > 1) and not data.isAdmin and not data.isImpersonating | falsify  %}
+
+        {# {% if shouldShowOrganisationSwitchLink %}
+          <p class="govuk-body"><a href="/select-organisation" class="govuk-link">Change organisation</a></p>
+        {% endif %} #}
+
+        <h2 class="govuk-heading-m">About your organisation</h2>
+
+        {{ govukSummaryList({
+          rows: [
+            {
+              key: {
+                text: "Organisation type"
+              },
+              value: {
+                text: activeProvider | getProviderTypeString | sentenceCase
+              },
+              actions: {
+                items: [
+                  {
+                    href: "#",
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                  }
+                ]
+              } if false
+            },
+            {
+              key: {
+                text: "Team inbox"
+              },
+              value: {
+                text: "teacher-training@" + provider.name | makeFakeSchoolDomain
+              },
+              actions: {
+                items: [
+                  {
+                    href: "#",
+                    text: "Change",
+                    visuallyHiddenText: "team inbox"
+                  }
+                ]
+              }
+            }
+          ]
+        }) }}
+
+ 
+        <h2 class="govuk-heading-m">Team members</h2>
+
+        {{ govukButton({
+          "text": "Add a team member"
+        }) }}
+
+        {% set providerUsers = data.users.byProvider[provider.name] | sort(attribute = "fullName") %}
+
+        {% if providerUsers | length  > 1 %}
+          <ol class="govuk-list">
+        {% endif %}
+
+          {% for user in providerUsers %}
+            {% if providerUsers | length  > 1 %}
+              <li class="govuk-!-margin-bottom-6">
+            {% endif %}
+            {% set isCurrentUser = user.fullName == data.defaultUser.fullName %}
+            <div class="app-user-card">
+              <h3 class="govuk-heading-s">
+                {{user.fullName}}{% if isCurrentUser %} (you){% endif %}
+              </h3>
+              <p class="govuk-body govuk-hint">{{user.email}}</p>
+
+              {# Permissions #}
+              {# {% set userPermissions = (user.providers | getRecordById(provider.id)).access %}
+              {{userPermissions | log}}
+              <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-0 govuk-!-font-size-16 govuk-hint">Role: {{userPermissions.role}}</p>
+              <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-0 govuk-!-font-size-16 govuk-hint">{{ "You have" if isCurrentUser else "This user has" }} permission to:</p>
+              <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1 govuk-!-margin-bottom-0 govuk-!-font-size-16 govuk-hint">
+
+                {% set permissions = userPermissions.permissions | sortPermissions %}
+                
+                {% for permission in permissions %}
+                  <li>{{permission}}</li>
+                {% endfor %}
+              </ul> #}
+
+            </div>
+            {% if providerUsers | length  > 1 %}
+              </li>
+            {% endif %}
+            
+          {% endfor %}
+
+        {% if providerUsers | length  > 1 %}
+          </ol>
+        {% endif %}
+
+
+      </div>
+    </div>
+
+{% endblock %}

--- a/app/views/organisations/organisation.html
+++ b/app/views/organisations/organisation.html
@@ -82,7 +82,6 @@
             {% set isCurrentUser = user.fullName == data.defaultUser.fullName %}
             <div class="app-user-card">
 
-
               <h3 class="govuk-heading-s">
                 {{user.fullName}}{% if isCurrentUser %} (you){% endif %}
                 <span class="govuk-!-font-weight-regular">
@@ -115,6 +114,9 @@
           </ol>
         {% endif %}
 
+        <p class="govuk-body">
+          If you need to add or remove team members, contact us at <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Add or remove team members from Register trainee teachers" class="govuk-link">becomingateacher@digital.education.gov.uk</a>.
+        </p>
 
       </div>
     </div>

--- a/app/views/organisations/organisation.html
+++ b/app/views/organisations/organisation.html
@@ -81,10 +81,14 @@
             {% endif %}
             {% set isCurrentUser = user.fullName == data.defaultUser.fullName %}
             <div class="app-user-card">
+
+
               <h3 class="govuk-heading-s">
                 {{user.fullName}}{% if isCurrentUser %} (you){% endif %}
+                <span class="govuk-!-font-weight-regular">
+                   – {{user.email}}
+                </span>
               </h3>
-              <p class="govuk-body govuk-hint">{{user.email}}</p>
 
               {# Permissions #}
               {# {% set userPermissions = (user.providers | getRecordById(provider.id)).access %}

--- a/app/views/organisations/organisation.html
+++ b/app/views/organisations/organisation.html
@@ -17,10 +17,6 @@
 
         {% set shouldShowOrganisationSwitchLink = (data.settings.userProviders | length > 1) and not data.isAdmin and not data.isImpersonating | falsify  %}
 
-        {# {% if shouldShowOrganisationSwitchLink %}
-          <p class="govuk-body"><a href="/select-organisation" class="govuk-link">Change organisation</a></p>
-        {% endif %} #}
-
         <h2 class="govuk-heading-m">About your organisation</h2>
 
         {{ govukSummaryList({
@@ -62,7 +58,7 @@
           ]
         }) }}
 
- 
+
         <h2 class="govuk-heading-m">Team members</h2>
 
         {{ govukButton({
@@ -70,47 +66,26 @@
         }) }}
 
         {% set providerUsers = data.users.byProvider[provider.name] | sort(attribute = "fullName") %}
+        {% set hasMultipleUsers = providerUsers | length > 1 %}
 
-        {% if providerUsers | length  > 1 %}
+        {% if hasMultipleUsers %}
           <ol class="govuk-list">
         {% endif %}
 
           {% for user in providerUsers %}
-            {% if providerUsers | length  > 1 %}
-              <li class="govuk-!-margin-bottom-6">
+            {% if hasMultipleUsers %}
+              <li class="">
             {% endif %}
-            {% set isCurrentUser = user.fullName == data.defaultUser.fullName %}
-            <div class="app-user-card">
 
-              <h3 class="govuk-heading-s">
-                {{user.fullName}}{% if isCurrentUser %} (you){% endif %}
-                <span class="govuk-!-font-weight-regular">
-                   – {{user.email}}
-                </span>
-              </h3>
+            {% include "_includes/user-card.njk" %}
 
-              {# Permissions #}
-              {# {% set userPermissions = (user.providers | getRecordById(provider.id)).access %}
-              {{userPermissions | log}}
-              <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-0 govuk-!-font-size-16 govuk-hint">Role: {{userPermissions.role}}</p>
-              <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-0 govuk-!-font-size-16 govuk-hint">{{ "You have" if isCurrentUser else "This user has" }} permission to:</p>
-              <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1 govuk-!-margin-bottom-0 govuk-!-font-size-16 govuk-hint">
-
-                {% set permissions = userPermissions.permissions | sortPermissions %}
-                
-                {% for permission in permissions %}
-                  <li>{{permission}}</li>
-                {% endfor %}
-              </ul> #}
-
-            </div>
-            {% if providerUsers | length  > 1 %}
+            {% if hasMultipleUsers %}
               </li>
             {% endif %}
-            
+
           {% endfor %}
 
-        {% if providerUsers | length  > 1 %}
+        {% if hasMultipleUsers %}
           </ol>
         {% endif %}
 

--- a/app/views/select-organisation.html
+++ b/app/views/select-organisation.html
@@ -62,7 +62,7 @@
         {% endif %}
 
         <p class="govuk-body">
-          If you need to access a different organisation’s records, contact us at <a href="" class="govuk-link">becomingateacher@digital.education.gov.uk</a>.
+          If you need to access a different organisation’s records, contact us at <a href="mailto:becomingateacher@digital.education.gov.uk" class="govuk-link">becomingateacher@digital.education.gov.uk</a>.
         </p>
 
       </div>

--- a/scripts/generate-records.js
+++ b/scripts/generate-records.js
@@ -18,7 +18,8 @@ const statuses          = require('../app/data/status')
 const courses           = require('../app/data/courses.json')
 const accreditingProviderData      = require('../app/data/accrediting-providers.js')
 const providers         = accreditingProviderData.selected
-const statusFilters          = require('./../app/filters/statuses.js').filters
+const statusFilters     = require('./../app/filters/statuses.js').filters
+const utils             = require('./../app/lib/utils.js')
 
 // Settings
 let simpleGcseGrades    = true //output pass/fail rather than full detail
@@ -36,10 +37,6 @@ const sortBySubmittedDate = (x, y) => {
 // Random whole number
 const getRandomInt = (max) => {
   return Math.floor(Math.random() * Math.floor(max))
-}
-// Random number between x and y
-const getRandomArbitrary = (min, max) => {
-  return Math.floor(Math.random() * (max - min) + min)
 }
 
 // Training routes
@@ -198,7 +195,7 @@ const generateFakeApplications = () => {
     // Approximate size of provider
     // TODO: store provider size somewhere so it can be used here and
     // by the course generator
-    let providerSize = getRandomArbitrary(50, 100)
+    let providerSize = utils.getRandomArbitrary(50, 100)
     let yearsToGenerate = defaultYearsToGenerate
     if (provider?.name == "Webury Hill SCITT") providerSize = 130
     if (provider?.name == "King’s Oak University") {
@@ -208,7 +205,7 @@ const generateFakeApplications = () => {
 
     yearsToGenerate.forEach((year) => {
       // Years can be ±10% in size
-      let traineeCount = getRandomArbitrary((providerSize * 0.9), (providerSize * 1.1))
+      let traineeCount = utils.getRandomArbitrary((providerSize * 0.9), (providerSize * 1.1))
       if (year > currentYear){
         traineeCount = traineeCount * 0.3 // generate fewer future trainees
       }

--- a/scripts/generate-users.js
+++ b/scripts/generate-users.js
@@ -1,0 +1,122 @@
+// To generate new users:
+// $ node scripts/generate-users.js
+
+
+const fs            = require('fs')
+const path          = require('path')
+const { faker }     = require('@faker-js/faker')
+faker.locale        = 'en_GB'
+const weighted      = require('weighted')
+const moment        = require('moment')
+const _             = require('lodash')
+const utils         = require('../app/lib/utils.js')
+const userFilters   = require('../app/filters/users.js').filters
+const permissions   = require('../app/data/permissions.js')
+
+let providers = {}
+
+// Combine the two provider files together
+// todo: should a single file provide these? the same code exists in session data defaults
+providers.accreditingProviders    = require('../app/data/accrediting-providers')
+providers.leadSchools = require('../app/data/lead-schools')
+providers.all = providers.accreditingProviders.all.concat(providers.leadSchools.selected)
+providers.selected = providers.accreditingProviders.selected.concat(providers.leadSchools.selected)
+
+
+// Create a single user
+const generateUser = (provider, role='team member') => {
+
+  if (!provider) console.log("Error in generateUser: provider missing")
+
+  let user = {}
+
+  user.id = faker.datatype.uuid()
+  let firstName = faker.name.firstName()
+  let familyName = faker.name.lastName()
+  user.fullName = `${firstName} ${familyName}`
+
+  let emailDomain = userFilters.makeFakeSchoolDomain(provider.name)
+  user.email = `${firstName}.${familyName}@${emailDomain}`.toLowerCase()
+
+  // Shuffle the possible permissions - used so that we can pick the first n and to get some selected randomly
+  let shuffledPermissions = faker.helpers.shuffle(permissions.allUserPermissions[provider.type])
+  
+  let userPermissions = []
+
+  // Team members have a varied number of permissions
+  if (role == 'team member'){
+    // How many permissions should we have
+    let targetCountOfPermissions = utils.getRandomArbitrary(1, shuffledPermissions.length + 1)
+    // Assign those permissions
+    userPermissions = shuffledPermissions.slice(0, Math.min(shuffledPermissions.length, targetCountOfPermissions))
+  }
+  // Admins have all permissions
+  else if (role == 'team admin'){
+    // Team admins have all permissions plus the ability to manage team members
+    userPermissions = ['manage team members', ...shuffledPermissions]
+  }
+
+  // Sort the permissions logically
+  userPermissions = userFilters.sortPermissions(userPermissions)
+
+  provider.access = {
+    role,
+    permissions: userPermissions
+  }
+
+  user.providers = [provider]
+
+  return user
+}
+
+const generateFakeUsers = () => {
+  let users = []
+
+  providers.selected.forEach(provider => {
+
+    let isAccrediting = provider.type == "accreditingProvider"
+    // Create between 2 and 10 users per provider
+    let numberOfUsersToCreate = utils.getRandomArbitrary(2, (isAccrediting)? 10 : 3)
+
+    Array(numberOfUsersToCreate).fill().map((item, index) => {
+      // First user always a team admin. After that, 20% chance.
+      let role = "team admin"
+      if (index != 0) {
+        role = weighted.select(['team admin', 'team member'], [0.2,0.8])
+      }
+      let user = generateUser(provider, role)
+
+      users.push(user)
+    })
+
+  })
+
+  return users
+}
+
+/**
+ * Generate JSON file
+ *
+ * @param {String} filePath Location of generated file
+ * @param {String} count Number of courses to generate
+ *
+ */
+const generateUsersFile = (filePath) => {
+  const users = generateFakeUsers()
+
+  console.log(`Generated ${users.length} fake users`)
+
+  const filedata = JSON.stringify(users, null, 2)
+  fs.writeFile(
+    filePath,
+    filedata,
+    (error) => {
+      if (error) {
+        console.error(error)
+      }
+      // console.log(`Course data generated: ${filePath}`)
+    }
+  )
+}
+
+generateUsersFile(path.join(__dirname, '../app/data/users.json'))

--- a/server.js
+++ b/server.js
@@ -235,8 +235,9 @@ if (useAutoStoreData === 'true') {
 
 // Clear all data in session if you open /prototype-admin/clear-data
 app.post('/admin/clear-data', function (req, res) {
+  console.log("Clearing session data")
   req.session.data = {}
-  res.redirect('/start-page')
+  res.redirect('/')
 })
 
 // Redirect root to /docs when in promo mode.


### PR DESCRIPTION
This is a first step towards adding organisation pages with details about who is in each organisation.

The PR adds a `users.json` file and a page per organisation. To support linking to the organisation page, I've rebuilt the top nav - following the pattern set by Publish.

## Revised top nav:

Now includes a row (organisation switcher) that shows only if the user belongs to more than one organisation. Otherwise it is not there.

This also stops using the provider's name as a link on the right - whilst this *just* works for our accrediting provider's names, some lead schools have longer names and this would force our nav to split across two lines, looking broken.
<img width="1071" alt="Screenshot 2022-06-06 at 11 50 52" src="https://user-images.githubusercontent.com/2204224/172147238-e8365242-0840-4772-91b0-fe7cbc232e80.png">

## Organisation page:

![2022 06 06_11_52_51_Organisation – Webury Hill SCITT - Register trainee teachers - GOV UK](https://user-images.githubusercontent.com/2204224/172147566-d53ab5f8-d3ea-4468-a963-6ffb85c96128.png)

## Other PR details

As part of this I've made a `generate-users` to generate a bunch of users that can belong to each organisation, each with some details and random permissions. At the moment each user only belongs to one org, but in the future it could be extended so the same 'user' exists across multiple.

To handle that the signed in user belongs to several, I hacked in a single `defaultUser` that gets pushed to providers in `userProviders` - so we can track the same user belonging to multiple. This is a bit hacky but ¯\_(ツ)_/¯ 
