### PR TITLE
Add support for historic funding years

### DIFF
--- a/app/filters/app-misc.js
+++ b/app/filters/app-misc.js
@@ -231,10 +231,13 @@ filters.fixNamesFromFunding = (string) => {
   - eg "19/20" ----> "2019 to 20"
   - eg "2019/20" --> "2019 to 20"
 */
-filters.formatYearRange = (string) => {
+filters.formatYearRange = (string, fundingYear = "2021 to 2022") => {
+
+  fundingYearNbsp = fundingYear.replaceAll(' ', '&nbsp;')
+
   return string
     .replace(/(\d{4})\/(\d{2})/, '$1&nbsp;to&nbsp;20$2')
-    .replace(/(\d{2})\/(\d{2})/, '20$1&nbsp;to&nbsp;20$2');
+    .replace(/(\d{2})\/(\d{2})/, fundingYearNbsp)
 }
 
 filters.recordsHaveQualification = (records, qualification) => {

--- a/app/routes.js
+++ b/app/routes.js
@@ -203,5 +203,10 @@ require('./routes/bulk-update-routes')(router)
 // =============================================================================
 require('./routes/organisations-and-users-routes')(router)
 
+// =============================================================================
+// Funding
+// =============================================================================
+require('./routes/funding-routes')(router)
+
 
 module.exports = router

--- a/app/routes/funding-routes.js
+++ b/app/routes/funding-routes.js
@@ -1,0 +1,25 @@
+const _ = require('lodash')
+const filters = require('./../filters.js')()
+const moment = require('moment')
+const path = require('path')
+const seedRandom = require('seedrandom')
+const url = require('url')
+const utils = require('./../lib/utils')
+const weighted = require('weighted')
+const { faker } = require('@faker-js/faker')
+
+module.exports = router => {
+
+  // Render organisation pages, passing along the organisation UUID
+  router.get('/funding/:year/:page*', function (req, res, next) {
+
+    // Use our own render as some templates live at /index.html
+    utils.render(
+      path.join('funding', req.params.page, req.params[0]), res, next, {
+        fundingYearShort: req.params.year,
+        fundingYear: utils.yearToAcademicYearString(req.params.year)
+      }
+    )
+  })
+
+}

--- a/app/views/_includes/funding-header-and-tab-nav.html
+++ b/app/views/_includes/funding-header-and-tab-nav.html
@@ -12,13 +12,13 @@
   label: 'Sub navigation',
   classes: 'govuk-!-margin-bottom-4',
   items: [{
-    text: 'Payment schedule ' + data.years.currentAcademicYear,
-    href: "/funding/payment-schedule",
+    text: 'Payment schedule ' + fundingYear,
+    href: "/funding/" + fundingYearShort + "/payment-schedule",
     active: paymentScheduleTab
   },
   {
-    text: 'Trainee summary ' + data.years.currentAcademicYear,
-    href: '/funding/trainee-summary',
+    text: 'Trainee summary ' + fundingYear,
+    href: "/funding/" + fundingYearShort + "/trainee-summary",
     active: traineeSummaryTab
   }
 ]}) }}

--- a/app/views/funding/index.html
+++ b/app/views/funding/index.html
@@ -1,0 +1,24 @@
+{% extends "_templates/_page.html" %}
+{% set navActive = "Funding" %}
+{% set pageHeading = "Select a funding year" %}
+
+{% set backLink = "/" %}
+{% set backText = "Home" %}
+
+{% set yearsToShow = [
+  "2021 to 2022",
+  "2020 to 2021"
+  ] %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">{{pageHeading}}</h1>
+
+  <ul class="govuk-list">
+    {% for year in yearsToShow %}
+      <li class="govuk-!-margin-bottom-2">
+        {# TODO: make real styles for this element #}
+        <a href="/funding/{{year | academicYearToYear}}/payment-schedule" class="govuk-!-font-size-24 govuk-!-font-weight-bold govuk-link govuk-link--no-visited-state">{{year}}</a>
+      </li>
+    {% endfor %}
+  </ul>
+{% endblock %}

--- a/app/views/funding/index.html
+++ b/app/views/funding/index.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_page.html" %}
 {% set navActive = "Funding" %}
-{% set pageHeading = "Select a funding year" %}
+{% set pageHeading = "Select an academic year to view its funding" %}
 
 {% set backLink = "/" %}
 {% set backText = "Home" %}

--- a/app/views/funding/payment-schedule.html
+++ b/app/views/funding/payment-schedule.html
@@ -1,7 +1,10 @@
 {% extends "_templates/_page.html" %}
 {% set navActive = "Funding" %}
 {% set pageHeading = navActive %}
-{% set tabName = "Payment schedule " + data.years.currentAcademicYear %}
+{% set tabName = "Payment schedule " + fundingYear %}
+
+{% set backLink = "/funding" %}
+{% set backText = "All funding years" %}
 
 {# Pick data based on user’s organisation #}
 {% if accessLevel == 'accreditingProvider' %}
@@ -16,12 +19,28 @@
   {% set paymentScheduleTab = true %}
   {% include "_includes/funding-header-and-tab-nav.html" %}
 
-  {% if currentMonth() >= 6 %}
-    {% set thisMonth = -1 + currentMonth() - 6 %}
+
+  {#  Offset months as August is the first month, September the second #}
+  {% set monthOffsets = {
+    "January": 6,
+    "February" : 7,
+    "March" : 8,
+    "April" : 9,
+    "May" : 10,
+    "June" : 11,
+    "July" : 12,
+    "August" : 1,
+    "September" : 2,
+    "October" : 3,
+    "November" : 4,
+    "December" : 5
+  } %} 
+
+  {% if fundingYear == data.years.currentAcademicYear %}
+    {% set thisMonth = monthOffsets[currentMonth('nameOfMonth')] %}
   {% else %}
-    {% set thisMonth = -1 + currentMonth() + 6 %}
+    {% set thisMonth = 12 %}
   {% endif %}
-  {# {% set thisMonth = 12 %} #}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
@@ -46,19 +65,21 @@
   {% set rowHeadingCellClasses = "app-table__column-50" %}
   {% set dataCellClasses = "app-table__column-25" %}
 
+  {% set fundingEndYear = fundingYearShort | int + 1 %}
+
   {% set months  = [
-    "August " + data.years.defaultCourseYear,
-    "September " + data.years.defaultCourseYear,
-    "October " + data.years.defaultCourseYear,
-    "November " + data.years.defaultCourseYear,
-    "December " + data.years.defaultCourseYear,
-    "January " + data.years.endOfCurrentCycle,
-    "February " + data.years.endOfCurrentCycle,
-    "March " + data.years.endOfCurrentCycle,
-    "April " + data.years.endOfCurrentCycle,
-    "May " + data.years.endOfCurrentCycle,
-    "June " + data.years.endOfCurrentCycle,
-    "July " + data.years.endOfCurrentCycle
+    "August " + fundingYearShort,
+    "September " + fundingYearShort,
+    "October " + fundingYearShort,
+    "November " + fundingYearShort,
+    "December " + fundingYearShort,
+    "January " + fundingEndYear,
+    "February " + fundingEndYear,
+    "March " + fundingEndYear,
+    "April " + fundingEndYear,
+    "May " + fundingEndYear,
+    "June " + fundingEndYear,
+    "July " + fundingEndYear
   ]%}
 
   {% set pastTotal     = 0 %}
@@ -136,11 +157,11 @@
         {% for item in dataSource %}
           {% set row = [] %}
           {% if item.cumulativeMonthlyPayments[monthIndex] > 0 %}
-            {% set row = row | push({ text: item.descriptions | fixNamesFromFunding | sentenceCase | formatYearRange | safe }) %}
+            {% set row = row | push({ text: item.descriptions | fixNamesFromFunding | sentenceCase | formatYearRange(fundingYear) | safe }) %}
             {% set row = row | push({ text: item.monthlyPayments[monthIndex] | currency, format: "numeric" }) %}
             {% set row = row | push({ text: item.cumulativeMonthlyPayments[monthIndex] | currency, format: "numeric" }) %}
           {% elseif item.cumulativeMonthlyPayments[monthIndex] > item.cumulativeMonthlyPayments[monthIndex - 1] %}
-            {% set row = row | push({ text: item.descriptions | fixNamesFromFunding | sentenceCase | formatYearRange | safe }) %}
+            {% set row = row | push({ text: item.descriptions | fixNamesFromFunding | sentenceCase | formatYearRange | replace("2020 to 2021", fundingYear) | safe }) %}
             {% set row = row | push({ text: "–", format: "numeric" }) %}
             {% set row = row | push({ text: item.cumulativeMonthlyPayments[monthIndex] | currency, format: "numeric" }) %}
           {% endif %}

--- a/app/views/funding/trainee-summary.html
+++ b/app/views/funding/trainee-summary.html
@@ -1,7 +1,10 @@
 {% extends "_templates/_page.html" %}
 {% set navActive = "Funding" %}
 {% set pageHeading = navActive %}
-{% set tabName = "Trainee summary " + data.years.currentAcademicYear %}
+{% set tabName = "Trainee summary " + fundingYear %}
+
+{% set backLink = "/funding" %}
+{% set backText = "All funding years" %}
 
 {% set totalForAllTrainees = 1 %}
 

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -162,7 +162,7 @@
     } if false,
     {
       text: 'Funding',
-      href: '/funding/payment-schedule',
+      href: '/funding/' + data.years.currentAcademicYearSimple + '/payment-schedule',
       active: true if navActive == 'Funding'
     } if data.settings.showFundingInPrimaryNav
   ] | removeEmpty %}


### PR DESCRIPTION
We're about to start a new academic year - this means the current funding page will roll over to 2022 to 2023 and the data for 2021 to 2022 won't be visible any more.

This adds ui to the funding section to let users explicitly pick a year's funding to look at. When navigating to the funding section we'll default to the current academic year.

Adds a breadcrumb to view different funding years:
<img width="1129" alt="Screenshot 2022-06-17 at 14 35 40" src="https://user-images.githubusercontent.com/2204224/174309188-0e782e89-f6c4-4a83-807a-2c1eaa5b290c.png">

Adds a funding index page that lists available years:
<img width="1082" alt="Screenshot 2022-06-17 at 14 35 53" src="https://user-images.githubusercontent.com/2204224/174309213-bf13d1ad-6087-4eaa-8cbb-9be4ed9e8cc2.png">

When on a prior year, implicitly there should be no predicted payments:
<img width="1095" alt="Screenshot 2022-06-17 at 14 36 06" src="https://user-images.githubusercontent.com/2204224/174309248-5059449b-30dd-406b-8758-35bbc27e5b11.png">

