### PR TITLE
Add reports section

### DIFF
--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -164,7 +164,12 @@
       text: 'Funding',
       href: '/funding/' + data.years.currentAcademicYearSimple + '/payment-schedule',
       active: true if navActive == 'Funding'
-    } if data.settings.showFundingInPrimaryNav
+    } if data.settings.showFundingInPrimaryNav,
+    {
+      text: 'Reports',
+      href: '/reports',
+      active: true if navActive == 'Reports'
+    }
   ] | removeEmpty %}
 
   {% if not hidePrimaryNav %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -161,15 +161,15 @@
       active: true if navActive == 'courses'
     } if false,
     {
-      text: 'Funding',
-      href: '/funding/' + data.years.currentAcademicYearSimple + '/payment-schedule',
-      active: true if navActive == 'Funding'
-    } if data.settings.showFundingInPrimaryNav,
-    {
       text: 'Reports',
       href: '/reports',
       active: true if navActive == 'Reports'
-    }
+    } if isAuthorised('exportRecords'),
+    {
+      text: 'Funding',
+      href: '/funding/' + data.years.currentAcademicYearSimple + '/payment-schedule',
+      active: true if navActive == 'Funding'
+    } if data.settings.showFundingInPrimaryNav
   ] | removeEmpty %}
 
   {% if not hidePrimaryNav %}

--- a/app/views/reports/census.html
+++ b/app/views/reports/census.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_page.html" %}
 
-{% set pageHeading = 'Export Census records' %}
+{% set pageHeading = 'Export census records' %}
 
 {# {% set formAction = "./reinstate/confirm" %} #}
 
@@ -13,96 +13,59 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">{{pageHeading}}</h1>
 
+    <p class="govuk-body">
+      Use this export to see your trainee data for the initial teacher training (ITT) census.
+    </p>
+
+    <p class="govuk-body">
+      The ITT census is put together using the <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology" class="govuk-link">Initial Teacher Training Census methodology</a>.
+    </p>
+
     <h2 class="govuk-heading-m">
-      About the export
+      About this export
     </h2>
 
     <p class="govuk-body">
-      This export approximates the trainees that included in the {{academicYear}} census. The census is compiled using the <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology" class="govuk-link">Initial Teacher Training Census methodology</a>.
+      This export includes trainees that are likely to be included in the {{ academicYear }} ITT census. The ITT census counts trainees registered on a course on the second Wednesday of October, this is sometimes called the ‘census date’.
     </p>
 
-    <p class="govuk-body">This export includes trainees:</p>
+    <p class="govuk-body">The census date for the {{ academicYear }} academic year is Wednesday 12 October {{academicYearShort}}.</p>
+
+    <p class="govuk-body">This export will include trainees:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        that are registered (no drafts)
+        that are registered (so their records are not drafts in Register) 
       </li>
       <li>
-        on their first year
+        on their first year of training 
       </li>
       <li>
-        on ITT courses starting from 1 August {{ academicYearShort }}
+        on ITT courses starting from 1 August {{ academicYearShort }} and the census date
       </li>
       <li>
-        on ITT courses starting no later than the second Wednesday of October {{academicYearShort}}
+        that started their training on or before the census date
       </li>
       <li>
-        on courses leading to QTS
-      </li>
-      <li>
-        not on the Assessment Only route
-      </li>
-      <li>
-        that started training on or before the second Wednesday of October {{academicYearShort}}
-      </li>
-      <li>
-        have not withdrawn, or withdrew after the second Wednesday of October {{academicYearShort}}
+        on courses leading to qualified teacher status (QTS)
       </li>
     </ul>
 
-    {% set insetText %}
-      The export will include trainees where you have not yet given us a trainee start date — as we do not yet know if they started training on or before the second Wednesday of October {{academicYearShort}}
-    {% endset %}
+    <p class="govuk-body">This export will not include trainees on the Assessment only route.</p>
 
-    {{ govukInsetText({
-      text: insetText
-    }) }}
+    <h2 class="govuk-heading-m">How this export will be different from the ITT census</h2>
 
-    <h3 class="govuk-heading-s">How the export will differ from Census</h3>
-
-    <p class="govuk-body">The ITT census also excludes a small number of trainees where you have indicated they are not eligible for UK financial support and do not have a DfE allocated place. This export will not exclude them so may incllude extra trainees. Read the <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology" class="govuk-link">Initial Teacher Training Census methodology</a> for more details.</p>
-
-    {# {{ govukRadios({
-      idPrefix: "hesaExport",
-      name: "",
-      fieldset: {
-        legend: {
-          text: 'Which records would you like to export?',
-          isPageHeading: false,
-          classes: "govuk-fieldset__legend--m"
-        }
-      },
-      hint: {
-        text: ""
-      },
-      items: [
-        {
-          value: "2021 to 2022 cycle",
-          text: "Records updated in the " + data.years.currentAcademicYear + " academic year (500 records)"
-        },
-        {
-          value: "2 months updated",
-          text: "Records updated in last 2 months (46 records)",
-          hint: {
-            text: "Updated records only"
-          } if false
-        },
-        {
-          value: "2 months uploaded",
-          text: "All records uploaded in last 2 months (456 records)",
-          hint: {
-            text: "Includes records that were uploaded but not changed"
-          }
-        } if false,
-        {
-          divider: "or"
-        },
-        {
-          value: "All records",
-          text: "All records from HESA (1562 records)"
-        }
-      ]
-    } | decorateAttributes(data, ""))}} #}
+    <p class="govuk-body">
+      All trainees that should be included in the ITT census will be in this export, but there might be a small number of extra trainees that would not normally be included. This is because Register currently does not have a way to exclude them. Trainees who could be in this export are:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        trainees without a start date because we cannot know if a trainee started their course on or before the census date without a start date
+      </li>
+      <li>
+        trainees that are self funded (not eligible for UK financial support and do not have a DfE allocated place), the ITT census excludes these trainees. 
+      </li>
+    </ul>
 
     {{ govukButton({
       "text": "Export trainee records (CSV)"

--- a/app/views/reports/census.html
+++ b/app/views/reports/census.html
@@ -45,6 +45,9 @@
       <li>
         that started training on or before the second Wednesday of October {{academicYearShort}}
       </li>
+      <li>
+        have not withdrawn, or withdrew after the second Wednesday of October {{academicYearShort}}
+      </li>
     </ul>
 
     {% set insetText %}

--- a/app/views/reports/census.html
+++ b/app/views/reports/census.html
@@ -1,0 +1,111 @@
+{% extends "_templates/_page.html" %}
+
+{% set pageHeading = 'Export Census records' %}
+
+{# {% set formAction = "./reinstate/confirm" %} #}
+
+{% set academicYear = data.years.currentAcademicYear %}
+{% set academicYearShort = data.years.currentAcademicYear | academicYearToYear %}
+  
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">{{pageHeading}}</h1>
+
+    <h2 class="govuk-heading-m">
+      About the export
+    </h2>
+
+    <p class="govuk-body">
+      This export approximates the trainees that included in the {{academicYear}} census. The census is compiled using the <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology" class="govuk-link">Initial Teacher Training Census methodology</a>.
+    </p>
+
+    <p class="govuk-body">This export includes trainees:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        that are registered (no drafts)
+      </li>
+      <li>
+        on their first year
+      </li>
+      <li>
+        on ITT courses starting from 1 August {{ academicYearShort }}
+      </li>
+      <li>
+        on ITT courses starting no later than the second Wednesday of October {{academicYearShort}}
+      </li>
+      <li>
+        on courses leading to QTS
+      </li>
+      <li>
+        not on the Assessment Only route
+      </li>
+      <li>
+        that started training on or before the second Wednesday of October {{academicYearShort}}
+      </li>
+    </ul>
+
+    {% set insetText %}
+      The export will include trainees where you have not yet given us a trainee start date — as we do not yet know if they started training on or before the second Wednesday of October {{academicYearShort}}
+    {% endset %}
+
+    {{ govukInsetText({
+      text: insetText
+    }) }}
+
+    <h3 class="govuk-heading-s">How the export will differ from Census</h3>
+
+    <p class="govuk-body">The ITT census also excludes a small number of trainees where you have indicated they are not eligible for UK financial support and do not have a DfE allocated place. This export will not exclude them so may incllude extra trainees. Read the <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology" class="govuk-link">Initial Teacher Training Census methodology</a> for more details.</p>
+
+    {# {{ govukRadios({
+      idPrefix: "hesaExport",
+      name: "",
+      fieldset: {
+        legend: {
+          text: 'Which records would you like to export?',
+          isPageHeading: false,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      hint: {
+        text: ""
+      },
+      items: [
+        {
+          value: "2021 to 2022 cycle",
+          text: "Records updated in the " + data.years.currentAcademicYear + " academic year (500 records)"
+        },
+        {
+          value: "2 months updated",
+          text: "Records updated in last 2 months (46 records)",
+          hint: {
+            text: "Updated records only"
+          } if false
+        },
+        {
+          value: "2 months uploaded",
+          text: "All records uploaded in last 2 months (456 records)",
+          hint: {
+            text: "Includes records that were uploaded but not changed"
+          }
+        } if false,
+        {
+          divider: "or"
+        },
+        {
+          value: "All records",
+          text: "All records from HESA (1562 records)"
+        }
+      ]
+    } | decorateAttributes(data, ""))}} #}
+
+    {{ govukButton({
+      "text": "Export trainee records (CSV)"
+    }) }}
+    
+  </div>
+</div>
+  
+{% endblock %}

--- a/app/views/reports/census.html
+++ b/app/views/reports/census.html
@@ -26,7 +26,7 @@
     </h2>
 
     <p class="govuk-body">
-      This export includes trainees that are likely to be included in the {{ academicYear }} ITT census. The ITT census counts trainees registered on a course on the second Wednesday of October, this is sometimes called the ‘census date’.
+      This export includes trainees that are likely to be included in the {{ academicYear }} ITT census. The ITT census counts trainees registered on a course on the second Wednesday of October every academic year, this is sometimes called the ‘census date’.
     </p>
 
     <p class="govuk-body">The census date for the {{ academicYear }} academic year is Wednesday 12 October {{academicYearShort}}.</p>
@@ -63,7 +63,7 @@
         trainees without a start date because we cannot know if a trainee started their course on or before the census date without a start date
       </li>
       <li>
-        trainees that are self funded (not eligible for UK financial support and do not have a DfE allocated place), the ITT census excludes these trainees. 
+        trainees that are self funded (not eligible for UK financial support and do not have a DfE allocated place) — the ITT census excludes these trainees. 
       </li>
     </ul>
 

--- a/app/views/reports/hesa.html
+++ b/app/views/reports/hesa.html
@@ -11,11 +11,19 @@
     <h1 class="govuk-heading-l">{{pageHeading}}</h1>
 
     <h2 class="govuk-heading-m">
-      About the export
+      About this export
     </h2>
 
     <p class="govuk-body">
-      Use this export if you’d like to compare data provided to HESA with what Register stores. <a href="#" class="govuk-link">How HESA data maps to a trainee record</a> details the fields we use and how we convert trainee data.
+      Use these exports to compare data provided to HESA and how that data is stored in Register.
+    </p>
+
+    <p class="govuk-body">
+      The export will filter your trainee records with the field ‘hesa_updated_at’, which shows you the last time any trainee record was updated in HESA. The export removes columns where HESA does not provide data, for example home address.
+    </p>
+
+    <p class="govuk-body">
+      <a href="#" class="govuk-link">Our guidance on how HESA data compares to Register data</a> will give you a breakdown of how we convert HESA data into Register.
     </p>
 
     <p class="govuk-body">
@@ -29,7 +37,7 @@
       name: "",
       fieldset: {
         legend: {
-          text: 'Which records would you like to export?',
+          text: 'Which trainee records would you like to export?',
           isPageHeading: false,
           classes: "govuk-fieldset__legend--m"
         }
@@ -40,11 +48,11 @@
       items: [
         {
           value: "2021 to 2022 cycle",
-          text: "Records updated in the 2021 to 2022 academic year (500 records)"
+          text: "Trainee records updated in HESA in the " + academicYear + " academic year (500 records)"
         },
         {
           value: "2 months updated",
-          text: "Records updated in last 2 months (46 records)",
+          text: "Trainee records updated in HESA in the last 2 months (46 records)",
           hint: {
             text: "Updated records only"
           } if false
@@ -61,7 +69,7 @@
         },
         {
           value: "All records",
-          text: "All records from HESA (1562 records)"
+          text: "All trainee records from HESA (1562 records)"
         }
       ]
     } | decorateAttributes(data, ""))}}

--- a/app/views/reports/hesa.html
+++ b/app/views/reports/hesa.html
@@ -3,7 +3,10 @@
 {% set pageHeading = 'Export HESA records' %}
 
 {# {% set formAction = "./reinstate/confirm" %} #}
-  
+
+{% set academicYear = data.years.currentAcademicYear %}
+{% set academicYearShort = data.years.currentAcademicYear | academicYearToYear %}
+
 {% block content %}
 
 <div class="govuk-grid-row">
@@ -24,12 +27,6 @@
 
     <p class="govuk-body">
       <a href="#" class="govuk-link">Our guidance on how HESA data compares to Register data</a> will give you a breakdown of how we import HESA data into Register.
-    </p>
-
-    <p class="govuk-body">
-      This exports your trainee records, filtering trainees using the fields ‘hesa_updated_at’{#  or ‘hesa_last_uploaded_at’ #}.
-
-      It removes columns where hesa does not provide data - such as contact address.
     </p>
 
     {{ govukRadios({

--- a/app/views/reports/hesa.html
+++ b/app/views/reports/hesa.html
@@ -10,20 +10,20 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">{{pageHeading}}</h1>
 
-    <h2 class="govuk-heading-m">
-      About this export
-    </h2>
-
     <p class="govuk-body">
       Use these exports to compare data provided to HESA and how that data is stored in Register.
     </p>
+
+    <h2 class="govuk-heading-m">
+      About this export
+    </h2>
 
     <p class="govuk-body">
       The export will filter your trainee records with the field ‘hesa_updated_at’, which shows you the last time any trainee record was updated in HESA. The export removes columns where HESA does not provide data, for example home address.
     </p>
 
     <p class="govuk-body">
-      <a href="#" class="govuk-link">Our guidance on how HESA data compares to Register data</a> will give you a breakdown of how we convert HESA data into Register.
+      <a href="#" class="govuk-link">Our guidance on how HESA data compares to Register data</a> will give you a breakdown of how we import HESA data into Register.
     </p>
 
     <p class="govuk-body">

--- a/app/views/reports/hesa.html
+++ b/app/views/reports/hesa.html
@@ -1,0 +1,76 @@
+{% extends "_templates/_page.html" %}
+
+{% set pageHeading = 'Export HESA records' %}
+
+{# {% set formAction = "./reinstate/confirm" %} #}
+  
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">{{pageHeading}}</h1>
+
+    <h2 class="govuk-heading-m">
+      About the export
+    </h2>
+
+    <p class="govuk-body">
+      Use this export if you’d like to compare data provided to HESA with what Register stores. <a href="#" class="govuk-link">How HESA data maps to a trainee record</a> details the fields we use and how we convert trainee data.
+    </p>
+
+    <p class="govuk-body">
+      This exports your trainee records, filtering trainees using the fields ‘hesa_updated_at’{#  or ‘hesa_last_uploaded_at’ #}.
+
+      It removes columns where hesa does not provide data - such as contact address.
+    </p>
+
+    {{ govukRadios({
+      idPrefix: "hesaExport",
+      name: "",
+      fieldset: {
+        legend: {
+          text: 'Which records would you like to export?',
+          isPageHeading: false,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      hint: {
+        text: ""
+      },
+      items: [
+        {
+          value: "2021 to 2022 cycle",
+          text: "Records updated in the 2021 to 2022 academic year (500 records)"
+        },
+        {
+          value: "2 months updated",
+          text: "Records updated in last 2 months (46 records)",
+          hint: {
+            text: "Updated records only"
+          } if false
+        },
+        {
+          value: "2 months uploaded",
+          text: "All records uploaded in last 2 months (456 records)",
+          hint: {
+            text: "Includes records that were uploaded but not changed"
+          }
+        } if false,
+        {
+          divider: "or"
+        },
+        {
+          value: "All records",
+          text: "All records from HESA (1562 records)"
+        }
+      ]
+    } | decorateAttributes(data, ""))}}
+
+    {{ govukButton({
+      "text": "Export trainee records (CSV)"
+    }) }}
+    
+  </div>
+</div>
+  
+{% endblock %}

--- a/app/views/reports/index.html
+++ b/app/views/reports/index.html
@@ -2,7 +2,7 @@
 {% extends "_templates/_page.html" %}
 {% set backLink = '/home' %}
 
-{% set pageHeading = 'Export records' %}
+{% set pageHeading = 'Reports' %}
 
 {% block content %}
 
@@ -13,7 +13,7 @@
     <ul class="govuk-list govuk-list--spaced">
       <li>
         <a class="govuk-link" href="/reports/census">
-          Export Census view
+          Export census records for the {{data.years.currentAcademicYear}} academic year
         </a>
       </li>
 
@@ -21,7 +21,7 @@
       {% if activeProvider.accreditingProviderType == "HEI" %}
         <li>
           <a class="govuk-link" href="/reports/hesa">
-            Export HESA records
+            Export HESA (Higher Education Statistics Agency) records
           </a>
         </li>
       {% endif %}

--- a/app/views/reports/index.html
+++ b/app/views/reports/index.html
@@ -1,0 +1,29 @@
+
+{% extends "_templates/_page.html" %}
+{% set backLink = '/home' %}
+
+{% set pageHeading = 'Export records' %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">{{pageHeading}}</h1>
+
+    <ul class="govuk-list govuk-list--spaced">
+      <li>
+        <a class="govuk-link" href="/reports/census">
+          Export Census view
+        </a>
+      </li>
+      <li>
+        <a class="govuk-link" href="/reports/hesa">
+          Export HESA records
+        </a>
+      </li>
+
+    </ul>
+    
+  </div>
+</div>
+{% endblock %}

--- a/app/views/reports/index.html
+++ b/app/views/reports/index.html
@@ -16,12 +16,15 @@
           Export Census view
         </a>
       </li>
-      <li>
-        <a class="govuk-link" href="/reports/hesa">
-          Export HESA records
-        </a>
-      </li>
 
+      {# HESA export only relevant to HEIs #}
+      {% if activeProvider.accreditingProviderType == "HEI" %}
+        <li>
+          <a class="govuk-link" href="/reports/hesa">
+            Export HESA records
+          </a>
+        </li>
+      {% endif %}
     </ul>
     
   </div>


### PR DESCRIPTION
Adds a new section to the service where users can access reports. We can use this if we need to provide any arbitrary data or pages on specific topics.

## Added to the header:
<img width="1111" alt="Screenshot 2022-06-29 at 10 19 04" src="https://user-images.githubusercontent.com/2204224/176400884-93e29aaf-0536-48f3-8162-b05459b10d8a.png">

## Reports index:
<img width="1066" alt="Screenshot 2022-06-29 at 10 19 22" src="https://user-images.githubusercontent.com/2204224/176400954-9ec93b5a-262d-4097-a1fe-aaecfe7edd0a.png">

## Census report:

We've gone through the census methodology to pick out the things we should be filtering. We've got some further analysis to do on what makes a trainee self-funded and whether we can identify those trainees.

<img width="1064" alt="Screenshot 2022-06-29 at 10 19 48" src="https://user-images.githubusercontent.com/2204224/176401065-8b922e2c-f19e-4235-94d4-621636dd3d4d.png">

## HESA report:

Our data from hesa only tells us the last time a record was updated, not when it was created or last submitted. This limits the filters we can do.

To start, I've suggested all updates since the start of the academic year, and 'recent' updates - suggesting 2 months.

We've put in a change request with HESA to request created date and last submitted date. This could allow us to revisit these reports.

<img width="1053" alt="Screenshot 2022-06-29 at 10 20 21" src="https://user-images.githubusercontent.com/2204224/176401276-31552091-31d3-47ee-9570-d59e8fd661a5.png">

