### PR TITLE
Rename initiative to mention it's a bursary

### DIFF
--- a/app/data/training-route-data.js
+++ b/app/data/training-route-data.js
@@ -80,7 +80,8 @@ let defaultRouteData = {
   ],
   initiatives: [
     "Now teach",
-    "Transition to teach"
+    "Transition to teach",
+    "Troops to Teachers bursary"
   ],
   financialSupportAvailable: false
 }
@@ -128,7 +129,8 @@ let baseRouteData = {
     ],
     initiatives: [
       "Now teach",
-      "Transition to teach"
+      "Transition to teach",
+      "Troops to Teachers bursary"
     ],
     financialSupportAvailable: true,
     financialSupport: [


### PR DESCRIPTION
Troops to teach is a bursary, not an initiative. For the moment, a short term fix is to call it a bursary here.

Renames to `Troops to Teachers bursary`