### PR TITLE
Let admins change accrediting provider

### DIFF
--- a/app/views/_includes/forms/support/change-accrediting-provider.html
+++ b/app/views/_includes/forms/support/change-accrediting-provider.html
@@ -1,0 +1,69 @@
+{% set providers = data.signedInProviders %}
+
+{% set providers = data.providers.accreditingProviders.all | sort(attribute = "name") %}
+
+{% set providerItems = [] %}
+
+{% for provider in providers %}
+  {% set providerItems = providerItems | push({
+    text: provider.name + " (" + (provider.providerCode or "C23") + ")",
+    value: provider.name
+  }) %}
+{% endfor %}
+
+{# {% set providerItems = providerItems | push({divider: 'or'}) %}
+ #}
+
+<h1 class="govuk-heading-l">{{pageHeading}}</h1>
+
+{% set adminInsetContentHtml %}
+  <p class="govuk-body">
+    This feature is only available to admins.
+  </p>
+  <p class="govuk-body">
+    The old and new providers will both be sent a notification that the accrediting provider for this trainee has been updated.
+  </p>
+{% endset %}
+
+
+{{ appAdminFeature({
+  html: adminInsetContentHtml
+}) }}
+
+
+{{ appAutocompleteFromSelect({
+  label: {
+    text: "Select new accrediting provider",
+    classes: "govuk-label--s"
+  },
+  hint: {
+    html: degreeHint
+  },
+  id: 'provider',
+  name: "record[provider]",
+  _items: providers | toSelectItems,
+  items: providerItems,
+  classes: "govuk-!-width-two-thirds",
+  value: record.provider,
+  autocompleteOptions: {
+    autoselect: false,
+    showAllValues: true,
+    minLength: 2,
+    showSuggestionsBanner: false
+  }
+}) }}
+
+{# {{ govukRadios({
+  fieldset: {
+    legend: {
+      text: pageHeading,
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--l"
+    }
+  },
+  items: providerItems
+} | decorateAttributes(record, "record.provider")) }} #}
+
+{{ govukButton({
+  text: "Continue"
+}) }}

--- a/app/views/_includes/forms/support/change-accrediting-provider.html
+++ b/app/views/_includes/forms/support/change-accrediting-provider.html
@@ -17,11 +17,13 @@
 <h1 class="govuk-heading-l">{{pageHeading}}</h1>
 
 {% set adminInsetContentHtml %}
+
   <p class="govuk-body">
-    This feature is only available to admins.
+    You should only change the accrediting provider if the current provider <strong>{{record.provider}}</strong> has instructed you to.
   </p>
+
   <p class="govuk-body">
-    The old and new providers will both be sent a notification that the accrediting provider for this trainee has been updated.
+    The old and new providers will be sent a notification confirming the change.
   </p>
 {% endset %}
 
@@ -44,7 +46,7 @@
   _items: providers | toSelectItems,
   items: providerItems,
   classes: "govuk-!-width-two-thirds",
-  value: record.provider,
+  value: null,
   autocompleteOptions: {
     autoselect: false,
     showAllValues: true,

--- a/app/views/_includes/summary-cards/accrediting-provider.html
+++ b/app/views/_includes/summary-cards/accrediting-provider.html
@@ -1,3 +1,13 @@
+{% set provider = record.provider | getProviderData %}
+
+{% set providerText %}
+  {% if record.provider %}
+    {{record.provider | safe}} ({{provider.providerCode or "C23"}})
+  {% else %}
+    Not provided
+  {% endif %}
+{% endset %}
+
 
 {% set recordBaseRows = [
   {
@@ -5,7 +15,7 @@
       text: "Accrediting provider"
     },
     value: {
-      text: record.provider or "Not provided"
+      text: providerText or "Not provided"
     },
     actions: {
       items: [

--- a/app/views/_includes/summary-cards/accrediting-provider.html
+++ b/app/views/_includes/summary-cards/accrediting-provider.html
@@ -1,0 +1,37 @@
+
+{% set recordBaseRows = [
+  {
+    key: {
+      text: "Accrediting provider"
+    },
+    value: {
+      text: record.provider or "Not provided"
+    },
+    actions: {
+      items: [
+        {
+          href: recordPath + "/accrediting-provider/change" | addReferrer(referrer),
+          text: "Change",
+          visuallyHiddenText: "accrediting provider"
+        }
+      ]
+    } if canAmend
+  }
+  ] %}
+
+
+{% set recordBaseHtml %}
+  {{ govukSummaryList({
+    rows: recordBaseRows
+  }) }}
+{% endset %}
+
+
+
+
+{{ appSummaryCard({
+  classes: "govuk-!-margin-bottom-6",
+  titleText: "Accrediting provider",
+  html: recordBaseHtml
+}) }}
+

--- a/app/views/_includes/summary-cards/trainee-progress.html
+++ b/app/views/_includes/summary-cards/trainee-progress.html
@@ -1,6 +1,8 @@
+{% set provider = record.provider | getProviderData %}
+
 {% set providerText %}
   {% if record.provider %}
-    {{record.provider | safe}} (C85)
+    {{record.provider | safe}} ({{provider.providerCode or "C23"}})
   {% else %}
     Not provided
   {% endif %}
@@ -17,12 +19,12 @@
   actions: {
     items: [
       {
-        href: recordPath + "/pick-provider" | addReferrer(referrer),
+        href: recordPath + "/accrediting-provider/change" | addReferrer(referrer),
         text: "Change",
-        visuallyHiddenText: "provider"
+        visuallyHiddenText: "accrediting provider"
       }
     ]
-  } if canAmend and false
+  } if canAmend and data.isAdmin
 } %}
 
 {% set sourceText %}

--- a/app/views/record/accrediting-provider/change.html
+++ b/app/views/record/accrediting-provider/change.html
@@ -1,0 +1,15 @@
+{% extends "_templates/_record-form.html" %}
+
+{% set pageHeading %}
+  Change accrediting provider
+{% endset %}
+
+
+
+{% set formAction = "./confirm" | addReferrer(referrer) %}
+
+{% block formContent %}
+
+  {% include "_includes/forms/support/change-accrediting-provider.html" %}
+
+{% endblock %}

--- a/app/views/record/accrediting-provider/confirm.html
+++ b/app/views/record/accrediting-provider/confirm.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_record-form.html" %}
 
-{% set pageHeading = "Confirm accrediting provider" %}
+{% set pageHeading = "Confirm new accrediting provider" %}
 
 {% set backLink = ("/record/" + data.record.id) | orReferrer(referrer) %}
 {% set backText = "Back to record" %}
@@ -13,9 +13,17 @@
   <h1 class="govuk-heading-l">
     {{pageHeading}}
   </h1>
+
   {% include "_includes/summary-cards/accrediting-provider.html" %}
 
-
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      {{ govukWarningText({
+        text: "The provider you have selected will be given ownership of this record. Selecting the wrong provider could lead to a data breach.",
+        iconFallbackText: "Warning"
+      }) }}
+    </div>
+  </div>
 
   {{ govukButton({
     text: "Update record"

--- a/app/views/record/accrediting-provider/confirm.html
+++ b/app/views/record/accrediting-provider/confirm.html
@@ -1,0 +1,25 @@
+{% extends "_templates/_record-form.html" %}
+
+{% set pageHeading = "Confirm accrediting provider" %}
+
+{% set backLink = ("/record/" + data.record.id) | orReferrer(referrer) %}
+{% set backText = "Back to record" %}
+
+{% set gridColumn = 'govuk-grid-column-full' %}
+{% set formAction = "./update" | addReferrer(referrer) %}
+
+{% block formContent %}
+  {% include "_includes/trainee-name-caption.njk" %}
+  <h1 class="govuk-heading-l">
+    {{pageHeading}}
+  </h1>
+  {% include "_includes/summary-cards/accrediting-provider.html" %}
+
+
+
+  {{ govukButton({
+    text: "Update record"
+  }) }}
+
+{% endblock %}
+


### PR DESCRIPTION
Adds the ability for admins to change the accrediting provider of a trainee.

When signed in as an admin, users get a 'change' link on the accrediting provider row, leading them to a new flow.

Trainee summary card:
<img width="1001" alt="Screenshot 2022-07-20 at 15 05 56" src="https://user-images.githubusercontent.com/2204224/180002765-a2c7bcd8-ff48-4a4c-b8bd-7f4dcc0eaee4.png">

Edit page:
<img width="1047" alt="Screenshot 2022-07-20 at 17 40 26" src="https://user-images.githubusercontent.com/2204224/180037157-dcf645f4-436d-4d8d-8c14-ce7f1f2f5ea7.png">

Confirm page:
<img width="1045" alt="Screenshot 2022-07-20 at 17 40 34" src="https://user-images.githubusercontent.com/2204224/180037172-de3b0429-07cb-476f-8f27-9723051d0e33.png">

Success banner:
<img width="1019" alt="Screenshot 2022-07-20 at 15 06 36" src="https://user-images.githubusercontent.com/2204224/180002837-bd7d76db-9dfa-43df-953c-1daf259c1e3b.png">

To test:

Go to prototype settings and turn on admin mode. From there, navigate to a trainee and change their provider.