### PR TITLE
Hide org page features for simpler first release

### DIFF
--- a/app/views/organisations/organisation.html
+++ b/app/views/organisations/organisation.html
@@ -54,16 +54,17 @@
                   }
                 ]
               }
-            }
-          ]
+            } if false
+          ],
+        classes: "govuk-!-margin-bottom-9"
         }) }}
 
 
         <h2 class="govuk-heading-m">Team members</h2>
 
-        {{ govukButton({
+        {# {{ govukButton({
           "text": "Add a team member"
-        }) }}
+        }) }} #}
 
         {% set providerUsers = data.users.byProvider[provider.name] | sort(attribute = "fullName") %}
         {% set hasMultipleUsers = providerUsers | length > 1 %}


### PR DESCRIPTION
Hides the ui for adding a trainee and team inbox - so that we can get to a static page that can be built sooner.