### PR TITLE
Typo in census methodology link

### DIFF
--- a/app/views/reports/itt-new-starter-data-sign-off.html
+++ b/app/views/reports/itt-new-starter-data-sign-off.html
@@ -42,7 +42,7 @@
 
       <p class="govuk-body">After signing off your new trainee data, it gets analysed and filtered for the ITT census publication. </p>
 
-      <p class="govuk-body">Not all your new trainees in this export will be included in the ITT census publication. To understand what data will be used, read the <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology" class="govuk-link">Intial Teacher Training Census methodology</a>.</p>
+      <p class="govuk-body">Not all your new trainees in this export will be included in the ITT census publication. To understand what data will be used, read the <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology" class="govuk-link">Initial Teacher Training Census methodology</a>.</p>
 
       <h2 class="govuk-heading-m">New trainees without a start date</h2>
 


### PR DESCRIPTION
Corrected spelling of 'Initial' in the census methodology link:
<img width="671" alt="Screenshot 2022-08-05 at 13 44 11" src="https://user-images.githubusercontent.com/68232608/183079890-97a49c13-7d90-4f96-bc2e-15f1f7a5a452.png">

