### PR TITLE
Removed line about HESA.

### DIFF
--- a/app/data/service-updates.yaml
+++ b/app/data/service-updates.yaml
@@ -9,7 +9,7 @@ items:
       SCITTs and HEIs with trainees that do not go through HESA, can now start creating draft trainee records in Register for the 2022 to 2023 academic year. You can either register your trainees immediately or wait, and register them closer to the start of their course.
       
       
-      Applications from Apply for teacher training (Apply) with a ‘recruited’ status will also be imported into Register as draft records. This will only happen for applications that will not go through HESA. Applications will import into Register every day at 4:00am. You should not need to manually duplicate applications from Apply into Register.
+      Applications from Apply for teacher training (Apply) with a ‘recruited’ status will also be imported into Register as draft records. Applications will import into Register every day at 4:00am. You should not need to manually duplicate applications from Apply into Register.
 
  
   - date: '2022-07-11'


### PR DESCRIPTION
Removed line about HESA to make it less confusing for users in that Applications don’t go through HESA anyway. I thought it better to remove than try and explain what we mean and making this even more confusing. We’ve also already sent out comms about the details so this section doesn’t need it.

<img width="601" alt="Screenshot 2022-08-11 at 13 53 34" src="https://user-images.githubusercontent.com/68232608/184137807-febd2982-6282-442c-b592-62f57cd0b5b7.png">

