### PR TITLE
Refer to expected end dates

### DIFF
--- a/app/views/_includes/forms/course-details/course-dates.html
+++ b/app/views/_includes/forms/course-details/course-dates.html
@@ -71,7 +71,7 @@
   namePrefix: "record[courseDetails][endDate" + studyModeConcatinated + "]",
   fieldset: {
     legend: {
-      text: "ITT end date for all " + (studyMode | lower) + " trainees",
+      text: "Expected end date for all " + (studyMode | lower) + " trainees",
       isPageHeading: false,
       classes: "govuk-fieldset__legend--m"
     }

--- a/app/views/_includes/forms/course-details/early-years.html
+++ b/app/views/_includes/forms/course-details/early-years.html
@@ -72,7 +72,7 @@
 
 {% set endDateHint = "For example, " + "" | today | moment('add', 1, 'years') | toDateArray | spaceSeparate %}
 
-{% set endDateLabel = "ITT end date" %}
+{% set endDateLabel = "Expected end date" %}
 
 {% set programmeEndDateArray = record.courseDetails.endDate | toDateArray %}
 {{ govukDateInput({

--- a/app/views/_includes/forms/course-details/index.html
+++ b/app/views/_includes/forms/course-details/index.html
@@ -329,7 +329,7 @@
   namePrefix: "record[courseDetails][endDate]",
   fieldset: {
     legend: {
-      text: "ITT end date",
+      text: "Expected end date",
       classes: "govuk-fieldset__legend--s"
     }
   },

--- a/app/views/_includes/forms/course-details/trainee-course-dates.html
+++ b/app/views/_includes/forms/course-details/trainee-course-dates.html
@@ -70,7 +70,7 @@
   namePrefix: "record[courseDetails][endDate]",
   fieldset: {
     legend: {
-      text: "ITT end date",
+      text: "Expected end date",
       isPageHeading: false,
       classes: "govuk-fieldset__legend--s"
     }

--- a/app/views/_includes/summary-cards/course-details.html
+++ b/app/views/_includes/summary-cards/course-details.html
@@ -183,7 +183,7 @@
 
 {% set endDateRow = {
   key: {
-    text: "ITT end date"
+    text: "Expected end date"
   },
   value: {
     text: courseDetails.endDate | govukDate,
@@ -194,7 +194,7 @@
       {
         href: recordPath + "/course-details/details" | addReferrer(referrer),
         text: "Change",
-        visuallyHiddenText: "ITT end date"
+        visuallyHiddenText: "expected end date"
       }
     ]
   } if canAmend

--- a/app/views/guidance/check-data.html
+++ b/app/views/guidance/check-data.html
@@ -125,7 +125,7 @@
     ITT start date
   </li>
   <li>
-    ITT end date
+    Expected end date
   </li>
 </ul>
 
@@ -148,7 +148,7 @@
     ITT start date
   </li>
   <li>
-    ITT end date
+    Expected end date
   </li>
 </ul>
 
@@ -162,7 +162,7 @@
     ITT start date
   </li>
   <li>
-    ITT end date
+    Expected end date
   </li>
 </ul>
 


### PR DESCRIPTION
Change this field to refer to `Expected end date` rather than `ITT end date`.

This is because we want users to update this if they know the trainee is likely to finish late, and to match the data we'll now be getting from HESA this academic year.