### PR TITLE
Tweaks to guidance before it gets built

### DIFF
--- a/app/views/_includes/forms/schools/lead-school.html
+++ b/app/views/_includes/forms/schools/lead-school.html
@@ -3,7 +3,7 @@
   {{pageHeading}}
 </h1>
 
-<p class="govuk-body">The lead school is the main organisation and point of contact for training providers, placements and partner schools in the school direct partnership.</p>
+<p class="govuk-body">The lead school is the main organisation and point of contact for training providers, placements and partner schools in the School Direct partnership.</p>
 
 <p class="govuk-body">The lead school you select will be able to view the trainee’s record.</p>
 

--- a/app/views/guidance/about-register-trainee-teachers.html
+++ b/app/views/guidance/about-register-trainee-teachers.html
@@ -4,7 +4,7 @@
 
 {% block guidanceContent %}
 
-# About Regsiter trainee teachers
+# About Register trainee teachers
 
 Register trainee teachers (Register) is the service that replaced the Database of Trainee Teachers and Providers (DTTP) in 2022.
 
@@ -28,7 +28,7 @@ If you have trainees eligible for funding, you can view funding information from
 
 ## Access to Register for lead schools
 
-Lead schools that deliver school direct initial teacher training (ITT) courses in partnership with an accredited ITT provider, can access Register to:
+Lead schools that deliver School Direct initial teacher training (ITT) courses in partnership with an accredited ITT provider, can access Register to:
 
 * view trainee records where you’re their lead school
 * view funding from the 2021 to 2022 academic year onwards if you have eligible trainees

--- a/app/views/guidance/manually-registering-trainees.html
+++ b/app/views/guidance/manually-registering-trainees.html
@@ -55,7 +55,7 @@ There are 2 ways to do this in Register and you can choose whichever one suits y
 
 ## Adding specific information to a trainee record
 
-### PE with EBacc
+### PE with EBaccalaureate (PE with EBacc)
 
 Follow these steps to register a trainee on a PE with EBacc course:
 

--- a/app/views/guidance/registering-trainees-through-hesa.html
+++ b/app/views/guidance/registering-trainees-through-hesa.html
@@ -42,7 +42,7 @@ In HESA, withdrawn trainees are recorded by using the [Student.ENDDATE field](ht
 
 HESA has added a new field in their collection for the 2022 to 2023 academic year called ‘expected end date’ ([EXPECTEDENDDATE](https://www.hesa.ac.uk/collection/c22053/e/expectedenddate)). 
 
-This field is optional in HESA but the Register service requires it to issue TRNs and for funding purposes. You must fill out this field in HESA, it will then import into Register as ‘ITT end date’.
+The Register service requires this field to issue TRNs and for funding purposes. You must fill out this field in HESA, it will then import into Register as ‘ITT end date’.
 
 You should keep this field up to date throughout the trainee’s training.
 

--- a/app/views/guidance/registering-trainees-through-hesa.html
+++ b/app/views/guidance/registering-trainees-through-hesa.html
@@ -38,6 +38,16 @@ A ‘withdrawn’ trainee in Register is a trainee that is registered on an ITT 
 
 In HESA, withdrawn trainees are recorded by using the [Student.ENDDATE field](https://www.hesa.ac.uk/collection/c22053/e/enddate) and the [Student.RSNEND field](https://www.hesa.ac.uk/collection/c22053/e/rsnend).
 
+### Expected end date for trainees
+
+HESA has added a new field in their collection for the 2022 to 2023 academic year called ‘expected end date’ ([EXPECTEDENDDATE](https://www.hesa.ac.uk/collection/c22053/e/expectedenddate)). 
+
+This field is optional in HESA but the Register service requires it to issue TRNs and for funding purposes. You must fill out this field in HESA, it will then import into Register as ‘ITT end date’.
+
+You should keep this field up to date throughout the trainee’s training.
+
+
+<!-- commenting out as we deal with this in the HESA mapping, however we could add it back if neeeded
 ### New trainee start dates
 
 If a new trainee starts their course on or before the second Wednesday in October, you must add their trainee start date using the [COMDATE field](https://www.hesa.ac.uk/collection/c22053/e/comdate) in HESA.
@@ -45,6 +55,7 @@ If a new trainee starts their course on or before the second Wednesday in Octobe
 If the trainee starts their training late, you should also fill in the [ITTCOMDATE field](https://www.hesa.ac.uk/collection/c22053/e/ittcomdate) if it’s different from the COMDATE.
 
 If a trainee does not start their training at all, and will never start, you do not need to include them in your HESA submission.
+-->
 
 <!-- commenting out as this is not possible to view in Register yet.
 {% include "_includes/guidance/placements.md" %}


### PR DESCRIPTION
Changes made:
- Removed reference to 'New trainee start date' on guidance page for HEIs/HESA (added in reference to new HESA field called Expected end date)
- Wrote 'School Direct' with capitals in line with BaT style guide
- Wrote EBacc as 'Baccalaureate' when mentioned first time in line with BaT style guide
- Corrected typo in 'Register' spelling on About Register trainee teacher page