### PR TITLE
Show timestamp on HESA records

### DIFF
--- a/app/functions.js
+++ b/app/functions.js
@@ -63,6 +63,9 @@ module.exports = function (env) {
   // Expose all of lodash
   functions.lodash = _
 
+  // Expose all of moment
+  functions.moment = moment
+
   // Expose all of faker
   functions.faker = faker
 

--- a/app/views/_includes/locked-hesa-record-message.html
+++ b/app/views/_includes/locked-hesa-record-message.html
@@ -15,7 +15,8 @@
         This record was imported from HESA and cannot be edited except to {{ deferOrReinstateText }} or withdraw the trainee.
       </h3>
       <p class="govuk-body">
-        Updates from HESA are imported regularly.
+        {# Assume sync has happened within in last 2 hours #}
+        HESA records last imported at: {{ moment().subtract(78, 'minutes') | govukDateTime }}
       </p>
      {#  <p class="govuk-body">
         You will be able to recommend the trainee for QTS at the end of the academic year.


### PR DESCRIPTION
Providers have been unsure how quickly we're syncing with HESA and would like reassurance.

This adds a timestamp to the inset text on HESA records to show the time we last synced.

<img width="1064" alt="Screenshot 2022-09-07 at 17 33 48" src="https://user-images.githubusercontent.com/2204224/188932428-9e79c152-c94b-4695-8f73-6edea8fe2cba.png">
