### PR TITLE
Cleanup and updates to support ui

### DIFF
--- a/app/routes/support-routes.js
+++ b/app/routes/support-routes.js
@@ -107,8 +107,8 @@ module.exports = router => {
     if (access == "Remove"){
       targetUrl = `${targetUrl}/confirm-remove`
     }
-    else if (access == "Archive"){
-      targetUrl = `${targetUrl}/confirm-archive`
+    else if (access == "Delete"){
+      targetUrl = `${targetUrl}/confirm-delete`
     }
     else {
       targetUrl = `${targetUrl}/confirm`

--- a/app/views/_includes/forms/support/users/organisations/edit.html
+++ b/app/views/_includes/forms/support/users/organisations/edit.html
@@ -32,8 +32,8 @@
       }
     },
     {
-      text: "Archive this user account",
-      value: "Archive"
+      text: "Delete this user account",
+      value: "Delete"
     }
   ]
 }| decorateAttributes(userOrganisationTemp, "userOrganisationTemp.access"))}}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -79,7 +79,7 @@
   {% set headerClass = 'app-light-header' %}
   {{ govukHeader({
     homepageUrl: "/start-page",
-    productName: serviceName,
+    productName: serviceName if not isSupportUi else "Support for Register",
     serviceUrl: "/records",
     classes: headerClass,
     containerClasses: "govuk-width-container",
@@ -179,10 +179,15 @@
       active: true if navActive == 'home'
     },
     {
-      text: 'Trainees',
+      text: 'Draft trainees',
+      href: '/support/trainees',
+      active: true if navActive == 'drafts'
+    },
+    {
+      text: 'Registered trainees',
       href: '/support/trainees',
       active: true if navActive == 'trainees'
-    } if isAuthorised('viewDrafts'),
+    },
     {
       text: 'Users',
       href: '/support/users',

--- a/app/views/support/organisations/users/confirm-archive.html
+++ b/app/views/support/organisations/users/confirm-archive.html
@@ -1,4 +1,0 @@
-
-{% set formAction = providerUrl %}
-
-{% include "support/shared/confirm-archive-user-org.html" %}

--- a/app/views/support/organisations/users/confirm-delete.html
+++ b/app/views/support/organisations/users/confirm-delete.html
@@ -1,0 +1,4 @@
+
+{% set formAction = providerUrl %}
+
+{% include "support/shared/confirm-delete-user-org.html" %}

--- a/app/views/support/shared/confirm-delete-user-org.html
+++ b/app/views/support/shared/confirm-delete-user-org.html
@@ -1,7 +1,7 @@
 {% extends "_templates/_form.html" %}
 
 {% set pageHeading %}
-  Archive {{user.fullName}}’s account?
+  Delete {{user.fullName}}’s account?
 {% endset %}
 
 {# {% set formAction = "./archive" %} #}
@@ -19,10 +19,10 @@
 {# {% include "_includes/forms/support/users/organisations/remove.html" %} #}
 
 {% set buttonText %}
-  Yes I’m sure – remove {{ user.fullName }}’s account
+  Yes I’m sure – delete {{ user.fullName }}’s account
 {% endset %}
 
-<input name="successFlash" type="hidden" value="User archived">
+<input name="successFlash" type="hidden" value="User deleted">
 
 {{ govukButton({
   text: buttonText,

--- a/app/views/support/users/confirm-delete.html
+++ b/app/views/support/users/confirm-delete.html
@@ -1,0 +1,3 @@
+{% set formAction = '/support/users' %}
+
+{% include "support/shared/confirm-delete-user-org.html" %}

--- a/app/views/support/users/organisations/confirm-archive.html
+++ b/app/views/support/users/organisations/confirm-archive.html
@@ -1,3 +1,0 @@
-{% set formAction = userUrl %}
-
-{% include "support/shared/confirm-archive-user-org.html" %}

--- a/app/views/support/users/organisations/confirm-delete.html
+++ b/app/views/support/users/organisations/confirm-delete.html
@@ -1,0 +1,3 @@
+{% set formAction = '/support/users' %}
+
+{% include "support/shared/confirm-delete-user-org.html" %}

--- a/app/views/support/users/view.html
+++ b/app/views/support/users/view.html
@@ -20,9 +20,9 @@
     } if params.organisations[0].type == "accreditingProvider",
     {
       text: "Access"
-    },
+    }if false,
     {
-      text: "Change"
+      text: "Remove access"
     }
   ] %}
 
@@ -38,9 +38,9 @@
     {% endset %}
     {% set changeLinkHtml %}
       {% if organisation.type == 'accreditingProvider' %}
-        <a href="{{userUrl}}/organisations/{{organisation.id}}/edit" class="govuk-link">Change<span class="govuk-visually-hidden"> access to {{organisation.name}}</span></a>
+        <a href="{{userUrl}}/organisations/{{organisation.id}}/edit" class="govuk-link">Remove<span class="govuk-visually-hidden"> access to {{organisation.name}}</span></a>
       {% else %}
-        <a href="{{userUrl}}/schools/{{organisation.id}}/edit" class="govuk-link">Change<span class="govuk-visually-hidden"> access to {{organisation.name}}</span></a>
+        <a href="{{userUrl}}/schools/{{organisation.id}}/edit" class="govuk-link">Remove<span class="govuk-visually-hidden"> access to {{organisation.name}}</span></a>
       {% endif %}
       
     {% endset %}
@@ -51,9 +51,10 @@
       },
       {
         text: organisation | getProviderTypeString(true)
-      } if params.organisations[0].type == "accreditingProvider", {
+      } if params.organisations[0].type == "accreditingProvider",
+      {
         text: "Standard"
-      },
+      } if false,
       {
         html: changeLinkHtml
       }
@@ -136,7 +137,7 @@
 
       
 
-      <p class="govuk-body govuk-!-margin-top-8"><a href="./archive-user/confirm" class="govuk-link app-destructive-link">Archive user</a></p>
+      <p class="govuk-body govuk-!-margin-top-8"><a href="{{currentPageUrl}}/confirm-delete" class="govuk-link app-destructive-link">Delete this user</a></p>
 
     </div>
   </div>


### PR DESCRIPTION
Renames `archive` to `delete`

Renames the ui to `Support for Register` - this matches Apply's support site.

