### PR TITLE
Show count of trainees and conditional text on reports page

### DIFF
--- a/app/views/reports/itt-new-starter-data-sign-off.html
+++ b/app/views/reports/itt-new-starter-data-sign-off.html
@@ -12,6 +12,10 @@
 {% set academicYearShort = data.years.currentAcademicYear | academicYearToYear %}
 
 {% set censusDate = "2022-10-12" %}
+
+{% set traineeCount = 37 %}
+
+{% set hasZeroTraineesToExport = true if traineeCount == 0 %}
   
 {% block content %}
 {{super()}}
@@ -74,8 +78,19 @@
 
       <input name="successFlash" type="hidden" value="Export successfully downloaded">
 
+      {% if hasZeroTraineesToExport %}
+        {{ govukInsetText({
+          text: "You have no trainees available to export. Check you have added new trainees for the " + data.years.currentAcademicYear + " academic year."
+        }) }}
+      {% endif %}
+
+      {% set buttonText -%}
+        Export new trainee data ({{traineeCount}} {{"trainee" | pluralise(traineeCount)}})
+      {%- endset %}
+
       {{ govukButton({
-        "text": "Export new trainee data (CSV)"
+        "text": "Export new trainee data (CSV)",
+        "text": buttonText
       }) }}
 
     </form>


### PR DESCRIPTION
The reports page somewhat assumes providers will have trainees to export - but that may not always be the case.

To help with this, show a count of trainees that will be exported in the export button:

1 trainee:
<img width="420" alt="Screenshot 2022-09-14 at 12 05 54" src="https://user-images.githubusercontent.com/2204224/190138746-1914b122-82a0-42a1-b961-4660fc56e606.png">

Multiple trainees:
<img width="525" alt="Screenshot 2022-09-14 at 12 03 57" src="https://user-images.githubusercontent.com/2204224/190138773-67cb2027-1f90-4f6e-9046-58553b9b0f51.png">

When there are zero trainees, also show a conditional inset text:
<img width="1124" alt="Screenshot 2022-09-14 at 12 06 52" src="https://user-images.githubusercontent.com/2204224/190138834-dd1ef860-3c1a-4b7c-b32e-aabe96ed8e37.png">
