### PR TITLE
Mention territories in label text

### DIFF
--- a/app/views/_includes/forms/degree/details-international.html
+++ b/app/views/_includes/forms/degree/details-international.html
@@ -31,7 +31,7 @@
 {# Degree country #}
 {{ appAutocompleteFromSelect({
   label: {
-    text: "In which country is the degree institution based?",
+    text: "In which country or territory is the degree institution based?",
     classes: "govuk-label--s"
   },
   id: 'degree-country',


### PR DESCRIPTION
We're adding some territories to our degree country autocomplete. This updates the label text to match.

<img width="689" alt="Screenshot 2022-09-14 at 16 11 52" src="https://user-images.githubusercontent.com/2204224/190193861-34e5a7c0-ee8c-4270-8bfc-15559bf29d40.png">
