### PR TITLE
Add iQTS section and ask about country

### DIFF
--- a/app/data/generators/iqts-data.js
+++ b/app/data/generators/iqts-data.js
@@ -1,0 +1,19 @@
+const { faker } = require('@faker-js/faker')
+const moment    = require('moment')
+const weighted   = require('weighted')
+
+const countries = require('../countries')
+const countriesExcludingUK = countries.filter(country => country != "United Kingdom")
+
+let percentageMissing = [0.8,0.2]
+
+module.exports = params => {
+
+
+
+  let randomCountry = faker.helpers.randomize(countriesExcludingUK)
+
+  return {
+    country: randomCountry
+  }
+}

--- a/app/data/generators/iqts-data.js
+++ b/app/data/generators/iqts-data.js
@@ -1,15 +1,9 @@
 const { faker } = require('@faker-js/faker')
-const moment    = require('moment')
-const weighted   = require('weighted')
 
 const countries = require('../countries')
 const countriesExcludingUK = countries.filter(country => country != "United Kingdom")
 
-let percentageMissing = [0.8,0.2]
-
 module.exports = params => {
-
-
 
   let randomCountry = faker.helpers.randomize(countriesExcludingUK)
 

--- a/app/data/generators/source.js
+++ b/app/data/generators/source.js
@@ -14,7 +14,7 @@ module.exports = application => {
 
     // HEI records are nearly all HESA
     if (application.accreditingProviderType == "HEI") {
-      if (application.route.includes("Opt-in")){
+      if (application.route.includes("Opt-in") || application.route.includes("iQTS")){
         return "Manual"
       }
       else return "HESA"

--- a/app/data/training-route-data.js
+++ b/app/data/training-route-data.js
@@ -572,6 +572,7 @@ let baseRouteData = {
       'contactDetails',
       'diversity',
       'degree',
+      'iQts'
       // 'schools',
       // 'placement'
       // 'funding'

--- a/app/data/training-route-data.js
+++ b/app/data/training-route-data.js
@@ -572,7 +572,7 @@ let baseRouteData = {
       'contactDetails',
       'diversity',
       'degree',
-      'iQts'
+      'iqts'
       // 'schools',
       // 'placement'
       // 'funding'

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -1213,7 +1213,7 @@ exports.calculateCourseEndAcademicYear = record => {
 // End academic year depends on the trainee status and what data
 // we have available
 exports.calculateEndAcademicYear = record => {
-  console.log("Calculating end academic year")
+  // console.log("Calculating end academic year")
   if (exports.isAwarded(record)){
     return exports.dateToAcademicYear(record?.qualificationAwardedDate)
   }

--- a/app/routes/records-list-routes.js
+++ b/app/routes/records-list-routes.js
@@ -573,8 +573,11 @@ module.exports = router => {
     let registeredRecords = objectFilters.removeWhere(filteredRecords, 'status', "Draft")
     let registeredRecordsCount = hasFilters ? registeredRecords.length : null
 
+    let filteredRecordsRealCount = draftRecords.length
+
     res.render('drafts', {
       filteredRecords: draftRecords,
+      filteredRecordsRealCount,
       hasFilters,
       selectedFilters,
       registeredRecordsCount

--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -1446,4 +1446,18 @@ module.exports = router => {
   })
 
 
+  // =============================================================================
+  // iQTS
+  // =============================================================================
+
+
+  // Redirect to first page of iQTS
+  router.get(['/:recordtype/:uuid/iqts','/:recordtype/iqts'], function (req, res) {
+    const data = req.session.data
+    let recordPath = utils.getRecordPath(req)
+    let referrer = utils.getReferrer(req.query.referrer)
+    res.redirect(`${recordPath}/iqts/country${referrer}`)
+  })
+
+
 }

--- a/app/views/_includes/forms/iqts/country.html
+++ b/app/views/_includes/forms/iqts/country.html
@@ -1,0 +1,53 @@
+{% include "_includes/trainee-name-caption.njk" %}
+<h1 class="govuk-heading-l">
+  {{pageHeading}}
+</h1>
+
+{% set label = "Search for a school by its unique reference number (URN), name or postcode" %}
+
+{# Todo - this could probably be the default that the autocomplete progressively enhances #}
+{# <div class="app-no-js-only">
+  {{ govukInput({
+    id: "schoolSearch",
+    name: "_schoolSearch",
+    label: {
+      text: label
+    },
+    value: query._schoolSearch,
+    classes: 'app-!-max-width-two-thirds'
+  }) }}
+</div>
+
+<div class="app-js-only">
+  {{ appSchoolAutocomplete({
+    name: "_autocomplete_result_uuid",
+    value: record.schools.employingSchool.schoolName,
+    uuid: record.schools.employingSchool.uuid,
+    label: {
+      text: label
+    }
+  }) }}
+</div> #}
+
+{# Degree country #}
+{{ appAutocompleteFromSelect({
+  label: {
+    _text: "In which country or territory is the degree institution based?",
+    classes: "govuk-label--s"
+  },
+  id: 'iqts-country',
+  name: "record[iqts][country]",
+  items: data.countries | removeArrayItem("United Kingdom") | toSelectItems,
+  classes: "govuk-!-width-two-thirds",
+  value: record.iqts.country,
+  autocompleteOptions: {
+    minLength: 2,
+    autoselect: true,
+    showAllValues: false
+  }
+} ) }}
+
+
+{{ govukButton({
+  text: "Continue"
+}) }}

--- a/app/views/_includes/forms/select-route.html
+++ b/app/views/_includes/forms/select-route.html
@@ -12,7 +12,7 @@
 
     {% elseif route | includes("iQTS") %}
       {% set hint = {
-        text: "iQTS is amazing"
+        text: "This is a trial programme that specific training providers are offering for the 2022 to 2023 academic year"
       } %}
     {% endif %}
 

--- a/app/views/_includes/forms/select-route.html
+++ b/app/views/_includes/forms/select-route.html
@@ -2,12 +2,23 @@
 {% set enabledTrainingRoutes = [] %}
 {% for route in data.settings.enabledTrainingRoutes %}
   {% if not data.trainingRoutes[route].disableForNewDrafts %}
-    {% set enabledTrainingRoutes = enabledTrainingRoutes | push({
-      text: route,
-      hint: {
+    {% set hint = false %}
+
+    {% if route | includes("Provider-led") %}
+      {% set hint = {
         text: "Training run by higher education institutions (HEIs) or school centred
           initial teacher training (SCITT) providers"
-      } if route | includes("Provider-led")
+      } %}
+
+    {% elseif route | includes("iQTS") %}
+      {% set hint = {
+        text: "iQTS is amazing"
+      } %}
+    {% endif %}
+
+    {% set enabledTrainingRoutes = enabledTrainingRoutes | push({
+      text: route,
+      hint: hint
     }) %}
   {% endif %}
 {% endfor %}

--- a/app/views/_includes/forms/select-route.html
+++ b/app/views/_includes/forms/select-route.html
@@ -12,7 +12,7 @@
 
     {% elseif route | includes("iQTS") %}
       {% set hint = {
-        text: "This is a trial programme that specific training providers are offering for the 2022 to 2023 academic year"
+        text: "This is a trial programme that selected training providers are offering for the 2022 to 2023 academic year"
       } %}
     {% endif %}
 

--- a/app/views/_includes/forms/select-route.html
+++ b/app/views/_includes/forms/select-route.html
@@ -12,7 +12,7 @@
 
     {% elseif route | includes("iQTS") %}
       {% set hint = {
-        text: "This is a trial programme that selected training providers are offering for the 2022 to 2023 academic year"
+        text: "This is a pilot programme that selected training providers are offering for the 2022 to 2023 academic year"
       } %}
     {% endif %}
 

--- a/app/views/_includes/summary-cards/iqts.html
+++ b/app/views/_includes/summary-cards/iqts.html
@@ -27,9 +27,9 @@
   }) }}
 {% endset %}
 
-{% set complete = record.iQts | sectionIsComplete %}
-{% set status  = record.iQts | getStatusText %}
-{% set sectionIsRequired = record | requiresSection("iQts") %}
+{% set complete = record.iqts | sectionIsComplete %}
+{% set status  = record.iqts | getStatusText %}
+{% set sectionIsRequired = record | requiresSection("iqts") %}
 
 {% if not sectionIsRequired %}
   {# Section not required #}

--- a/app/views/_includes/summary-cards/iqts.html
+++ b/app/views/_includes/summary-cards/iqts.html
@@ -1,0 +1,65 @@
+
+{% set iqtsRows = [
+  {
+    key: {
+      text: "Country of study"
+    },
+    value: {
+      html: record.iqts.country or "Not provided"
+    },
+    actions: {
+      items: [
+        {
+          href: recordPath + "/iqts/country" | addReferrer(referrer),
+          text: "Change",
+          visuallyHiddenText: "country"
+        }
+      ]
+    } if canAmend
+  }
+  ] %}
+
+
+
+{% set contactDetailsHtml %}
+  {{ govukSummaryList({
+    rows: iqtsRows | highlightInvalidRows
+  }) }}
+{% endset %}
+
+{% set complete = record.iQts | sectionIsComplete %}
+{% set status  = record.iQts | getStatusText %}
+{% set sectionIsRequired = record | requiresSection("iQts") %}
+
+{% if not sectionIsRequired %}
+  {# Section not required #}
+{% elseif showIncomplete and not complete %}
+
+  {% set incompleteType = "warning" if errorList %}
+  {% set incompleteId = "iqts-details" %}
+  {% if status == "Review" %}
+    {% set incompleteText = "iQTS details not reviewed" %}
+    {% set incompleteLink = recordPath + "/iqts/confirm" %}
+    {% set incompleteLinkText = "Review section" %}
+  {% elseif status == "In progress" %}
+    {% set incompleteText = "iQTS details not marked as complete" %}
+    {% set incompleteLink = recordPath + "/iqts/confirm" %}
+    {% set incompleteLinkText = "Continue section" %}
+  {% else %}
+    {% set incompleteText = "iQTS details not started" %}
+    {% set incompleteLink = recordPath + "/iqts" %}
+    {% set incompleteLinkText = "Start section" %}
+  {% endif %}
+
+  {% include "_includes/incomplete.njk" %}
+
+{% else %}
+
+  {{ appSummaryCard({
+    classes: "govuk-!-margin-bottom-6",
+    titleText: "iQTS details",
+    html: contactDetailsHtml
+  }) }}
+  
+{% endif %}
+

--- a/app/views/_includes/summary-cards/iqts.html
+++ b/app/views/_includes/summary-cards/iqts.html
@@ -2,7 +2,7 @@
 {% set iqtsRows = [
   {
     key: {
-      text: "Country of study"
+      text: "Country or territory of training"
     },
     value: {
       html: record.iqts.country or "Not provided"
@@ -57,7 +57,7 @@
 
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
-    titleText: "iQTS details",
+    titleText: "International training details",
     html: contactDetailsHtml
   }) }}
   

--- a/app/views/new-record/check-record.html
+++ b/app/views/new-record/check-record.html
@@ -87,6 +87,8 @@
 
 {% include "_includes/summary-cards/course-details.html" %}
 
+{% include "_includes/summary-cards/iqts.html" %}
+
 {% include "_includes/summary-cards/training-details/training-details.html" %}
 
 {% include "_includes/summary-cards/schools.html" %}

--- a/app/views/new-record/iqts/confirm.html
+++ b/app/views/new-record/iqts/confirm.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_new-record.html" %}
 
-{% set pageHeading = "Confirm iQTS details" %}
+{% set pageHeading = "Confirm international training details" %}
 {% set backLink = './../overview' %}
 {% set backText = "Back to draft record" %}
 {% set gridColumn = 'govuk-grid-column-full' %}

--- a/app/views/new-record/iqts/confirm.html
+++ b/app/views/new-record/iqts/confirm.html
@@ -24,12 +24,12 @@
   {% if record | sourceIsManual or not data.settings.groupApplySections %}
     {{ govukCheckboxes({
       idPrefix: "contact-details",
-      name: "record[iQts][status]",
+      name: "record[iqts][status]",
       items: [
         {
           value: "Completed",
           text: checkboxText,
-          checked: checked(record.iQts.status, "Completed")
+          checked: checked(record.iqts.status, "Completed")
         }
       ]
       }) }}

--- a/app/views/new-record/iqts/confirm.html
+++ b/app/views/new-record/iqts/confirm.html
@@ -1,0 +1,42 @@
+{% extends "_templates/_new-record.html" %}
+
+{% set pageHeading = "Confirm iQTS details" %}
+{% set backLink = './../overview' %}
+{% set backText = "Back to draft record" %}
+{% set gridColumn = 'govuk-grid-column-full' %}
+{% set formAction = "./../overview" | orReferrer(referrer) %}
+
+{% block formContent %}
+  {% include "_includes/trainee-name-caption.njk" %}
+  <h1 class="govuk-heading-l">
+    {{pageHeading}}
+  </h1>
+  {% include "_includes/summary-cards/iqts.html" %}
+
+  {% set checkboxText %}
+    {% if record | sourceIsManual %}
+      I have completed this section
+    {% else %}
+      I have reviewed this section
+    {% endif %}
+  {% endset %}
+
+  {% if record | sourceIsManual or not data.settings.groupApplySections %}
+    {{ govukCheckboxes({
+      idPrefix: "contact-details",
+      name: "record[iQts][status]",
+      items: [
+        {
+          value: "Completed",
+          text: checkboxText,
+          checked: checked(record.iQts.status, "Completed")
+        }
+      ]
+      }) }}
+  {% endif %}
+
+  {{ govukButton({
+    text: "Continue"
+  }) }}
+
+{% endblock %}

--- a/app/views/new-record/iqts/country.html
+++ b/app/views/new-record/iqts/country.html
@@ -1,7 +1,7 @@
 {% extends "_templates/_new-record.html" %}
 
 
-{% set pageHeading = "Which country or territory?" %}
+{% set pageHeading = "Which country or territory is the trainee studying in?" %}
 
 {% set formAction = "./confirm" | addReferrer(referrer) %}
 

--- a/app/views/new-record/iqts/country.html
+++ b/app/views/new-record/iqts/country.html
@@ -1,0 +1,13 @@
+{% extends "_templates/_new-record.html" %}
+
+
+{% set pageHeading = "Which country or territory?" %}
+
+{% set formAction = "./confirm" | addReferrer(referrer) %}
+
+{% block formContent %}
+
+  {% include "_includes/forms/iqts/country.html" %}
+
+{% endblock %}
+

--- a/app/views/new-record/overview.html
+++ b/app/views/new-record/overview.html
@@ -130,8 +130,8 @@
   } if record | requiresSection("courseDetails"),
   {
     text: "International training details",
-    href: "iqts" | reviewIfInProgress(record.iQts),
-    id: "iQts",
+    href: "iqts" | reviewIfInProgress(record.iqts),
+    id: "iqts",
     tag: {
       classes: record.iqts | getStatusText | getStatusClass,
       text: record.iqts | getStatusText

--- a/app/views/new-record/overview.html
+++ b/app/views/new-record/overview.html
@@ -133,10 +133,10 @@
     href: "iqts" | reviewIfInProgress(record.iQts),
     id: "iQts",
     tag: {
-      classes: record.iQts | getStatusText | getStatusClass,
-      text: record.iQts | getStatusText
+      classes: record.iqts | getStatusText | getStatusClass,
+      text: record.iqts | getStatusText
     }
-  } if record | requiresSection("iQts"),
+  } if record | requiresSection("iqts"),
   {
     text: "Trainee ID",
     href: "training-details" | reviewIfInProgress(record.trainingDetails),

--- a/app/views/new-record/overview.html
+++ b/app/views/new-record/overview.html
@@ -129,6 +129,15 @@
     }
   } if record | requiresSection("courseDetails"),
   {
+    text: "iQTS details",
+    href: "iqts" | reviewIfInProgress(record.iQts),
+    id: "iQts",
+    tag: {
+      classes: record.iQts | getStatusText | getStatusClass,
+      text: record.iQts | getStatusText
+    }
+  } if record | requiresSection("iQts"),
+  {
     text: "Trainee ID",
     href: "training-details" | reviewIfInProgress(record.trainingDetails),
     id: "training-details",

--- a/app/views/new-record/overview.html
+++ b/app/views/new-record/overview.html
@@ -129,7 +129,7 @@
     }
   } if record | requiresSection("courseDetails"),
   {
-    text: "iQTS details",
+    text: "International training details",
     href: "iqts" | reviewIfInProgress(record.iQts),
     id: "iQts",
     tag: {

--- a/app/views/record.html
+++ b/app/views/record.html
@@ -32,7 +32,7 @@
       <p class="govuk-body"><a href="{{recordPath}}/previous-course-details" class="govuk-link">View previous course changes</a></p>
     {% endif %}
 
-    {% if record | requiresSection("iQts") %}
+    {% if record | requiresSection("iqts") %}
       {# <h2 class="govuk-heading-s">iQTS</h2> #}
       {% include "_includes/summary-cards/iqts.html" %}
     {% endif %}

--- a/app/views/record.html
+++ b/app/views/record.html
@@ -32,13 +32,18 @@
       <p class="govuk-body"><a href="{{recordPath}}/previous-course-details" class="govuk-link">View previous course changes</a></p>
     {% endif %}
 
+    {% if record | requiresSection("iQts") %}
+      {# <h2 class="govuk-heading-s">iQTS</h2> #}
+      {% include "_includes/summary-cards/iqts.html" %}
+    {% endif %}
+
     {% if record | requiresSection("schools") %}
-      <h2 class="govuk-heading-s">Schools</h2>
+      {# <h2 class="govuk-heading-s">Schools</h2> #}
       {% include "_includes/summary-cards/schools.html" %}
     {% endif %}
 
     {% if record | requiresSection("placement") %}
-      <h2 class="govuk-heading-s">Placements</h2>
+      {# <h2 class="govuk-heading-s">Placements</h2> #}
       {% include "_includes/summary-cards/placements/placement-overview.html" %}
     {% endif %}
 

--- a/app/views/record/iqts/confirm.html
+++ b/app/views/record/iqts/confirm.html
@@ -31,7 +31,7 @@
         {
           value: "Completed",
           text: checkboxText,
-          checked: checked(record.iQts.status, "Completed")
+          checked: checked(record.iqts.status, "Completed")
         }
       ]
       }) }}

--- a/app/views/record/iqts/confirm.html
+++ b/app/views/record/iqts/confirm.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_record-form.html" %}
 
-{% set pageHeading = "Confirm iQTS details" %}
+{% set pageHeading = "Confirm international training details" %}
 
 {% set backLink = ("/record/" + data.record.id) | orReferrer(referrer) %}
 {% set backText = "Back to record" %}

--- a/app/views/record/iqts/confirm.html
+++ b/app/views/record/iqts/confirm.html
@@ -1,0 +1,44 @@
+{% extends "_templates/_record-form.html" %}
+
+{% set pageHeading = "Confirm iQTS details" %}
+
+{% set backLink = ("/record/" + data.record.id) | orReferrer(referrer) %}
+{% set backText = "Back to record" %}
+
+{% set gridColumn = 'govuk-grid-column-full' %}
+{% set formAction = "./update" | addReferrer(referrer) %}
+
+{% block formContent %}
+  {% include "_includes/trainee-name-caption.njk" %}
+  <h1 class="govuk-heading-l">
+    {{pageHeading}}
+  </h1>
+  {% include "_includes/summary-cards/iqts.html" %}
+
+{#   {% set checkboxText %}
+    {% if record | sourceIsManual %}
+      I have completed this section
+    {% else %}
+      I have reviewed this section
+    {% endif %}
+  {% endset %}
+
+  {% if record | sourceIsManual or not data.settings.groupApplySections %}
+    {{ govukCheckboxes({
+      idPrefix: "contact-details",
+      name: "record[iQts][status]",
+      items: [
+        {
+          value: "Completed",
+          text: checkboxText,
+          checked: checked(record.iQts.status, "Completed")
+        }
+      ]
+      }) }}
+  {% endif %} #}
+
+  {{ govukButton({
+    text: "Update record"
+  }) }}
+
+{% endblock %}

--- a/app/views/record/iqts/country.html
+++ b/app/views/record/iqts/country.html
@@ -1,7 +1,6 @@
 {% extends "_templates/_record-form.html" %}
 
-
-{% set pageHeading = "Which country or territory?" %}
+{% set pageHeading = "Which country or territory is the trainee studying in?" %}
 
 {% set formAction = "./confirm" | addReferrer(referrer) %}
 

--- a/app/views/record/iqts/country.html
+++ b/app/views/record/iqts/country.html
@@ -1,0 +1,13 @@
+{% extends "_templates/_record-form.html" %}
+
+
+{% set pageHeading = "Which country or territory?" %}
+
+{% set formAction = "./confirm" | addReferrer(referrer) %}
+
+{% block formContent %}
+
+  {% include "_includes/forms/iqts/country.html" %}
+
+{% endblock %}
+

--- a/scripts/generate-records.js
+++ b/scripts/generate-records.js
@@ -67,6 +67,7 @@ const generateSource = require('../app/data/generators/source')
 const generateStatus = require('../app/data/generators/status')
 const generateApplyData = require('../app/data/generators/apply-data')
 const generateHesaData = require('../app/data/generators/hesa-data')
+const generateIQtsData = require('../app/data/generators/iqts-data')
 
 // Populate application data object with fake data
 const generateFakeApplication = (params = {}) => {
@@ -161,6 +162,11 @@ const generateFakeApplication = (params = {}) => {
   // Placements
   if (requiredSections.includes('placement')) {
     application.placement        = (params.placement === null) ? undefined : { ...generatePlacement(application), ...params.placement } 
+  }
+
+  // iQTS
+  if (requiredSections.includes('iqts')) {
+    application.iqts        = (params.iqts === null) ? undefined : { ...generateIQtsData(application), ...params.iqts }
   }
 
   // Make sure statuses match qualifications
@@ -312,6 +318,7 @@ const generateFakeApplicationsForProvider = (provider, year, count) => {
       status: 'Completed'
     },
     degree: null,
+    iqts: null,
     updatedDate: faker.date.between(
       moment(),
       moment().subtract(16, 'days'))


### PR DESCRIPTION
Adds a new section 'iQTS' where we can ask about fields specific to international qualified teacher status. For the moment there will be one question, asking about the country of study.

I've not added any hooks to Apply drafts as these trainees will only be registered manually.

## Route selection page
<img width="1015" alt="Screenshot 2022-10-07 at 10 41 11" src="https://user-images.githubusercontent.com/2204224/194524419-f267824a-59fd-44d3-a1d5-64d5a4f297b7.png">


## New section in task list
<img width="1036" alt="Screenshot 2022-10-07 at 10 36 48" src="https://user-images.githubusercontent.com/2204224/194523470-dee94ac0-b320-4e59-a57d-ef09beac8ad3.png">

## Asking about country or territory
<img width="1032" alt="Screenshot 2022-10-07 at 10 37 10" src="https://user-images.githubusercontent.com/2204224/194523545-a9241c86-6a1c-40da-b049-037cc1d24d51.png">

## Confirmation page
<img width="1042" alt="Screenshot 2022-10-07 at 10 37 25" src="https://user-images.githubusercontent.com/2204224/194523612-24809640-529c-4a34-81e2-732e7da0e53c.png">

## Check record page
<img width="1034" alt="Screenshot 2022-10-07 at 10 41 57" src="https://user-images.githubusercontent.com/2204224/194524548-d3be4387-f609-4da8-bf82-91da54f74863.png">

## Registered trainee
<img width="1042" alt="Screenshot 2022-10-07 at 10 42 25" src="https://user-images.githubusercontent.com/2204224/194524672-f668cc7a-f636-4f6f-b857-11eaf4636f7a.png">
