### PR TITLE
Add new degree grade options and grade autocomplete

### DIFF
--- a/app/assets/javascripts/init-autocompletes.js
+++ b/app/assets/javascripts/init-autocompletes.js
@@ -83,7 +83,7 @@ const onConfirm = function(selected) {
     // need to store the current typed text.
     else if (autocompleteInput.value != autocompleteValueInput.getAttribute('data-text') ){
       autocompleteValueInput.value = autocompleteInput.value
-      autocompleteVAlueInput.setAttribute('data-text', autocompleteInput.value)
+      autocompleteValueInput.setAttribute('data-text', autocompleteInput.value)
     }
   }
 

--- a/app/data/degree.js
+++ b/app/data/degree.js
@@ -1645,10 +1645,103 @@ module.exports = () => {
     "Truro College"
   ]
 
+let grades = [
+  { hesa_code: '1',
+    name: 'First-class honours',
+    suggestion_synonyms: ['First class honours with distinction'],
+    match_synonyms: [
+      'First class honours',
+      'First class hons',
+      'First',
+      'First class'
+    ],
+    group: "main_undergrad" },
+  { hesa_code: '2',
+    name: 'Upper second-class honours (2:1)',
+    suggestion_synonyms: [],
+    match_synonyms: ['Upper second class honours', '2:1', '2.1'],
+    group: "main_undergrad" },
+  { hesa_code: '3',
+    name: 'Lower second-class honours (2:2)',
+    suggestion_synonyms: [],
+    match_synonyms: ['Lower second class honours', '2:2', '2.2'],
+    group: "main_undergrad" },
+  { hesa_code: '4',
+    name: 'Undivided second-class honours',
+    suggestion_synonyms: [],
+    match_synonyms: ['Undivided second class honours'],
+    group: "other" },
+  { hesa_code: '5',
+    name: 'Third-class honours',
+    suggestion_synonyms: [],
+    match_synonyms: ['Third class honours', 'Third'],
+    group: "main_undergrad" },
+  { hesa_code: '6',
+    name: 'Fourth-class honours',
+    suggestion_synonyms: [],
+    match_synonyms: ['Fourth class honours'],
+    group: "other" },
+  { hesa_code: '7',
+    name: 'Unclassified',
+    suggestion_synonyms: [],
+    match_synonyms: [],
+    group: "other" },
+  { hesa_code: '8',
+    name: 'Aegrotat',
+    suggestion_synonyms: [],
+    match_synonyms: [],
+    group: "other" },
+  { hesa_code: '10',
+    name: 'Ordinary degree',
+    suggestion_synonyms: [],
+    match_synonyms: ['Ordinary'],
+    group: "other " },
+  { hesa_code: '11',
+    name: 'General degree',
+    suggestion_synonyms: [],
+    match_synonyms: [],
+    group: "other" },
+  { hesa_code: '12',
+    name: 'Distinction',
+    suggestion_synonyms: [],
+    match_synonyms: [],
+    group: "main_postgrad" },
+  { hesa_code: '13',
+    name: 'Merit',
+    suggestion_synonyms: [],
+    match_synonyms: [
+      'Pass with merit'
+    ],
+    group: "main_postgrad" },
+  { hesa_code: '14',
+    name: 'Pass',
+    suggestion_synonyms: [
+      'Awarded'
+    ],
+    match_synonyms: ['Passed'],
+    group: "main_undergrad" },
+  { hesa_code: '98',
+    name: 'Not applicable',
+    suggestion_synonyms: [],
+    match_synonyms: ['NA', 'N/A', 'Not classified'],
+    group: "main_postgrad" },
+  { hesa_code: '99',
+    name: 'Unknown',
+    suggestion_synonyms: [],
+    match_synonyms: [],
+    group: "main_postgrad" }
+]
+
+
   return {
     types: {
       all: types,
       undergraduate: types.filter(type => type.level === 6 || type.level === 7)
+    },
+    grades: {
+      all: grades,
+      undergrad: grades.filter(grade => grade.group == "main_undergrad"),
+      postgrad: grades.filter(grade => grade.group == "main_postgrad")
     },
     invalidInstitutions,
     invalidSubjects,

--- a/app/data/degree.js
+++ b/app/data/degree.js
@@ -415,13 +415,15 @@ module.exports = () => {
       "Level 8 certificate",
       "Level 8 diploma"
     ],
+    level: 7,
     boost: 0.5, // reduced boost so this appears below more specific options
     hint: "Including level 7, level 8, masters, postgraduate certificates and diplomas"
   }, {
     short: 'Degree equivalent',
     text: 'Degree equivalent',
     full: 'Degree equivalent',
-    type: 'other'
+    type: 'other',
+    level: 6
   }]
 
   const subjects = [

--- a/app/data/generators/degree.js
+++ b/app/data/generators/degree.js
@@ -56,17 +56,30 @@ module.exports = (params, application) => {
       }
 
       const level = type.level
-      const grade = faker.helpers.randomize([
-        'First-class honours',
-        'Upper second-class honours (2:1)',
-        'Lower second-class honours (2:2)',
-        'Third-class honours',
-        'Pass',
-        ...(level !== 6) ? ['Merit'] : [],
-        ...(level !== 6) ? ['Distinction'] : [],
-        ...(level !== 6) ? ['Not applicable'] : [],
-        ...(level !== 6) ? ['Unknown'] : []
-      ])
+      let grade
+
+      if (level <= 6){
+        grade = faker.helpers.randomize([
+          'First-class honours',
+          'Upper second-class honours (2:1)',
+          'Lower second-class honours (2:2)',
+          'Third-class honours',
+          'Pass'
+        ])
+      }
+      else {
+        grade = faker.helpers.randomize([
+          'First-class honours',
+          'Upper second-class honours (2:1)',
+          'Lower second-class honours (2:2)',
+          'Pass',
+          'Merit',
+          'Distinction',
+          'Pass',
+          'Merit',
+          'Distinction'
+        ])
+      }
 
       return {
         type,
@@ -83,6 +96,7 @@ module.exports = (params, application) => {
     }
   }
 
+  // Number of qualifications to add
   const count = weighted.select({
     1: 0.9,
     2: 0.1

--- a/app/data/seed-records.js
+++ b/app/data/seed-records.js
@@ -102,10 +102,10 @@ seedRecords.push({
   },
   source: "Apply",
   applyData: {
-    recruitedDate: "2021-05-23T18:24:34.886Z",
-    applicationDate: "2021-04-10T18:17:24.509Z"
+    recruitedDate: "2022-05-23T18:24:34.886Z",
+    applicationDate: "2022-04-10T18:17:24.509Z"
   },
-  "updatedDate": "2021-06-13T19:28:56.667Z",
+  "updatedDate": "2022-08-13T19:28:56.667Z",
   route: 'Provider-led (postgrad)',
   "courseDetails": {
     "ageRange": "11 to 19",
@@ -120,7 +120,7 @@ seedRecords.push({
     ],
     "qualificationsSummary": "PGCE with QTS full time",
     "route": "Provider-led (postgrad)",
-    "startDateVague": "2021-09-01T01:00:00.000Z",
+    "startDateVague": "2022-09-01T01:00:00.000Z",
     "studyMode": "Full time",
     "courseNameLong": "Mathematics (X348)",
     "courseNameShort": "Mathematics",
@@ -224,8 +224,8 @@ seedRecords.push({
   },
   source: "Apply",
   applyData: {
-    recruitedDate: "2021-05-23T18:24:34.886Z",
-    applicationDate: "2021-04-10T18:17:24.509Z",
+    recruitedDate: "2022-05-23T18:24:34.886Z",
+    applicationDate: "2022-04-10T18:17:24.509Z",
     status: "Completed"
   },
   courseDetails: {
@@ -307,7 +307,7 @@ seedRecords.push({
   route: 'Teaching apprenticeship (postgrad)',
   courseDetails: {
     isPublishCourse: true,
-    startDate: "2021-12-18T00:00:00.000Z"
+    startDate: "2022-12-18T00:00:00.000Z"
   },
   trainingDetails: {
     commencementDate: null
@@ -327,7 +327,7 @@ seedRecords.push({
   route: 'Assessment only',
   courseDetails: {
     isPublishCourse: false,
-    startDate: "2021-09-01T00:00:00.000Z"
+    startDate: "2022-09-01T00:00:00.000Z"
   },
   trainingDetails: {
     commencementDate: null
@@ -346,7 +346,7 @@ seedRecords.push({
   "reference": "YW1442",
   trainingDetails: {
     traineeId: "2020/21-074",
-    commencementDate: "2021-09-01T00:00:00.000Z"
+    commencementDate: "2022-09-01T00:00:00.000Z"
   },
   // submittedDate: "2020-06-28T12:37:21.384Z",
   // updatedDate: "2020-07-04T04:26:19.269Z",
@@ -394,7 +394,7 @@ seedRecords.push({
   route: 'Provider-led (postgrad)',
   courseDetails: {
     isPublishCourse: false,
-    startDate: "2021-09-01T00:00:00.000Z"
+    startDate: "2022-09-01T00:00:00.000Z"
   },
   trainingDetails: {
     commencementDate: null
@@ -457,7 +457,7 @@ seedRecords.push({
   route: 'Early years (postgrad)',
   courseDetails: {
     isPublishCourse: false,
-    startDate: "2021-09-01T00:00:00.000Z"
+    startDate: "2022-09-01T00:00:00.000Z"
   },
   trainingDetails: {
     commencementDate: null
@@ -485,7 +485,7 @@ seedRecords.push({
   },
   courseDetails: {
     isPublishCourse: true,
-    startDate: "2021-09-01T00:00:00.000Z"
+    startDate: "2022-09-01T00:00:00.000Z"
   },
   id: "2a4f4dc6-8653-4499-ae5c-22d2cdb5a3de"
 })
@@ -503,7 +503,7 @@ seedRecords.push({
   },
   courseDetails: {
     isPublishCourse: true,
-    startDate: "2021-12-12T00:00:00.000Z"
+    startDate: "2022-09-01T00:00:00.000Z"
   },
   id: "04ad18c1-4cc2-4d3d-a979-0dc1f07fc6b4"
 })
@@ -521,7 +521,7 @@ seedRecords.push({
   },
   courseDetails: {
     isPublishCourse: true,
-    startDate: "2021-12-18T00:00:00.000Z"
+    startDate: "2022-09-01T00:00:00.000Z"
   },
   id: "e8ebf77e-cd81-4b31-8111-5c38b1277184"
 })
@@ -539,7 +539,7 @@ seedRecords.push({
   },
   courseDetails: {
     isPublishCourse: true,
-    startDate: "2021-12-18T00:00:00.000Z"
+    startDate: "2022-09-01T00:00:00.000Z"
   },
   id: "0e74f2b2-a597-46a9-993c-ecbb6d81c4bf"
 })

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -15,6 +15,7 @@ let serviceUpdates          = yaml.load(fs.readFileSync(dataPath + '/service-upd
 // Degree stuff
 let awards                  = require('./awards') // Types of degree
 let degreeData              = require('./degree')()
+let degreeGrades            = degreeData.grades
 let degreeTypes             = degreeData.types.all
 let degreeTypesSimple       = degreeData.types.all.map(type => type.text).sort()
 let subjects                = degreeData.subjects
@@ -263,6 +264,7 @@ module.exports = {
   degreeInstitutions,
   degreeTypes,
   degreeTypesSimple,
+  degreeGrades,
   ethnicities,
   funding,
   ittSubjects,

--- a/app/filters/app-misc.js
+++ b/app/filters/app-misc.js
@@ -157,6 +157,19 @@ filters.getDegreeTypesForAutocomplete = (degreeTypes) => {
   })
 }
 
+// Generate an array of data suitable for autocomplete
+filters.getDegreeGradesForAutocomplete = (degreeGrades) => {
+
+  return degreeGrades.map(grade => {
+
+    return {
+      name: grade.name,
+      value: grade.name,
+      synonyms: grade.suggestion_synonyms.concat(grade.match_synonyms).filter(Boolean),
+    }
+  })
+}
+
 // Return a pretty name for the degree
 filters.getDegreeName = (degree) => {
   if (!degree) return ''

--- a/app/routes/records-list-routes.js
+++ b/app/routes/records-list-routes.js
@@ -524,7 +524,7 @@ module.exports = router => {
     // Truncate records in case there's lots - and as we don't have working pagination
     let filteredRecordsRealCount = registeredRecords.length
     console.log({filteredRecordsRealCount})
-    filteredRecords = registeredRecords.slice(0, 204)
+    filteredRecords = registeredRecords.slice(0, 100)
 
     if (req?.params?.tabName && data.settings.trainingYearsUiStyle != 'Tabs'){
       res.redirect("/records")

--- a/app/views/_includes/filter-panel/years.njk
+++ b/app/views/_includes/filter-panel/years.njk
@@ -205,7 +205,3 @@
 
 {% endif %}
 
-
-{{data.settings | log}}
-
-

--- a/app/views/_includes/forms/degree/details-uk.html
+++ b/app/views/_includes/forms/degree/details-uk.html
@@ -136,13 +136,19 @@
     "Upper second-class honours (2:1)",
     "Lower second-class honours (2:2)",
     "Third-class honours",
-    "Pass"
+    "Pass",
+    "Merit",
+    "Distinction"
   ] %}
     {% set storedGradeOther = true %}
   {% endif %}
 
   {% set degreeGradeOtherHtml %}
-    {{ govukInput({
+
+    {# Degree types #}
+    {% set degreeGradesAutocomplete = data.degreeGrades.all | getDegreeGradesForAutocomplete | sort(attribute='value') %}
+
+{#     {{ govukInput({
       label: {
         text: "Enter the degree grade"
       },
@@ -150,7 +156,28 @@
       classes: "app-!-max-width-one-half",
       name: "degreeTemp[otherGrade]",
       value: degreeTemp.grade if storedGradeOther
-    } | decorateAttributes(degreeTemp, "degreeTemp.grade"))}}
+    } | decorateAttributes(degreeTemp, "degreeTemp.grade"))}} #}
+
+
+    {{ appAutocompleteFromInput({
+      label: {
+        text: "Enter the degree grade",
+        _classes: "govuk-label--s"
+      },
+      _hint: {
+        text: "none"
+      },
+      id: 'degree-grade',
+      name: "degreeTemp[otherGrade]",
+      classes: "govuk-!-width-one-half",
+      value: degreeTemp.grade if storedGradeOther,
+      autocompleteOptions: {
+        minLength: 2,
+        autoselect: false,
+        showSuggestionsBanner: true,
+        values: degreeGradesAutocomplete
+      }
+    })}}
   {% endset %}
 
   {{ govukRadios({
@@ -179,6 +206,15 @@
       },
       {
         text: "Pass"
+      },
+      {
+        text: "Distinction"
+      },
+      {
+        text: "Merit"
+      },
+      {
+        divider: "or"
       },
       {
         text: "Other",


### PR DESCRIPTION
This adds two new default radio options for degree grades: distinction and merit. These are the most common other grades that we don't currently have options for.

<img width="615" alt="Screenshot 2022-10-10 at 17 27 09" src="https://user-images.githubusercontent.com/2204224/194912653-0f10c1c2-0701-440f-a35b-45ee514a0a7c.png">

It also adds a suggestion autocomplete using the dfe reference data:
<img width="712" alt="Screenshot 2022-10-10 at 17 29 46" src="https://user-images.githubusercontent.com/2204224/194913026-052e8820-191e-46ca-b7fc-b4d4929d55d4.png">

