### PR TITLE
Add link to GIAS to help providers find schools

### DIFF
--- a/app/views/_includes/forms/schools/employing-school.html
+++ b/app/views/_includes/forms/schools/employing-school.html
@@ -32,7 +32,11 @@
 {% set detailsHtml %}
 
   <p class="govuk-body">
-    If the employing school is missing from the list, contact <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>
+    If the employing school is missing from the list, try searching for its unique reference number (URN) on <a href="#">Get information about schools (opens in a new tab)</a>.
+  </p>
+
+  <p class="govuk-body">
+    If you still cannot find the school, contact <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>
   </p>
 
   <p class="govuk-body">You do not need to provide an employing school if the trainee is funded or employed privately.</p>

--- a/app/views/_includes/forms/schools/lead-school.html
+++ b/app/views/_includes/forms/schools/lead-school.html
@@ -36,7 +36,11 @@
 {% set detailsHtml %}
 
   <p class="govuk-body">
-    If the lead school is missing from the list, contact <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>
+    If the lead school is missing from the list, try searching for its unique reference number (URN) on <a href="#">Get information about schools (opens in a new tab)</a>.
+  </p>
+
+  <p class="govuk-body">
+    If you still cannot find the school, contact <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>
   </p>
 
   <p class="govuk-body">You do not need to provide a lead school if the trainee is funded or employed privately.</p>


### PR DESCRIPTION
We've had a couple cases of providers not able to locate schools - it would help if they searched first on GIAS before contacting us.

In one example, they were searching using a postcode that was different than the postcode in GIAS

In the other the school name was too common and they had the wrong URN.