### PR TITLE
Content change to In training tile and filter

### DIFF
--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -1649,7 +1649,7 @@ exports.filterRecords = (records, data, filters = {}) => {
       else if (filters.trainingStatus.includes("Awarded") && record.status && record.status.includes("awarded")){
         return true
       }
-      else if (filters.trainingStatus.includes("In training") && exports.isInTraining(record)){
+      else if (filters.trainingStatus.includes("Actively training") && exports.isInTraining(record)){
         return true
       }
       else return false

--- a/app/routes/records-list-routes.js
+++ b/app/routes/records-list-routes.js
@@ -466,7 +466,7 @@ module.exports = router => {
 
     // by default set search results to show "Current" trainees
     // if (!hasQueryString) filters.cohortFilter = ["Current"]
-    // if (!hasQueryString) filters.trainingStatus = ["In training"]
+    // if (!hasQueryString) filters.trainingStatus = ["Actively training"]
 
     let searchQuery = getSearchQuery(req)
 
@@ -599,7 +599,7 @@ module.exports = router => {
 
     // by default set search results to show "Current" trainees
     // if (!hasQueryString) filters.cohortFilter = ["Current"]
-    if (!hasQueryString) filters.trainingStatus = ["In training"]
+    if (!hasQueryString) filters.trainingStatus = ["Actively training"]
 
     let searchQuery = getSearchQuery(req)
 

--- a/app/views/_includes/filter-panel/support/training-status.njk
+++ b/app/views/_includes/filter-panel/support/training-status.njk
@@ -2,7 +2,7 @@
   {%- if not query -%}
     checked
   {%- else -%}
-    {{- checked(query.filterTrainingStatus, "In training") -}}
+    {{- checked(query.filterTrainingStatus, "Actively training") -}}
   {%- endif -%}
 {%- endset %}
 
@@ -35,7 +35,7 @@
       checked: checked(query.filterTrainingStatus, "Course not started yet")
     } if coursenNotYetStarted | length,
     {
-      text: "In training",
+      text: "Actively training",
       checked: checked(query.filterTrainingStatus, "Draft")
     },
     {

--- a/app/views/_includes/filter-panel/training-status.njk
+++ b/app/views/_includes/filter-panel/training-status.njk
@@ -2,7 +2,7 @@
   {%- if not query -%}
     checked
   {%- else -%}
-    {{- checked(query.filterTrainingStatus, "In training") -}}
+    {{- checked(query.filterTrainingStatus, "Actively training") -}}
   {%- endif -%}
 {%- endset %} #}
 
@@ -30,9 +30,9 @@
       checked: checked(query.filterTrainingStatus, "Course not started yet")
     } if coursenNotYetStarted | length,
     {
-      text: "In training",
+      text: "Actively training",
       _checked: checkedStatus,
-      checked: checked(query.filterTrainingStatus, "In training")
+      checked: checked(query.filterTrainingStatus, "Actively training")
     },
     {
       text: "Deferred",

--- a/app/views/_includes/locked-hesa-record-message.html
+++ b/app/views/_includes/locked-hesa-record-message.html
@@ -16,7 +16,7 @@
       </h3>
       <p class="govuk-body">
         {# Assume sync has happened within in last 2 hours #}
-        HESA records last imported at: {{ moment().subtract(78, 'minutes') | govukDateTime }}
+        Last import for all HESA records at {{ moment().subtract(78, 'minutes') | govukDateTime }}
       </p>
      {#  <p class="govuk-body">
         You will be able to recommend the trainee for QTS at the end of the academic year.

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -102,11 +102,11 @@
           <span class="status-card__status">Course not started yet</span><span class="govuk-visually-hidden"> records. View these records.</span>
         </a>
 
-        {# In training #}
+        {# Actively training #}
         {% set traineesInTraining = registeredTrainees | filterByFunction('isInTraining') %}
-        <a href="/records?&filterTrainingStatus=In training" class="status-card status-card--in-training">
+        <a href="/records?&filterTrainingStatus=Actively training" class="status-card status-card--in-training">
           <span class="status-card__count">{{traineesInTraining | length}}</span>
-          <span class="status-card__status">In training</span><span class="govuk-visually-hidden"> records. View these records.</span>
+          <span class="status-card__status">Actively training</span><span class="govuk-visually-hidden"> records. View these records.</span>
         </a>
 
         {# Awarded this year #}

--- a/app/views/reports/choose-trainee-records/statuses.html
+++ b/app/views/reports/choose-trainee-records/statuses.html
@@ -29,7 +29,7 @@
       text: "Course not started yet"
     },
     {
-      text: "In training"
+      text: "Actively training"
     },
     {
       text: "Deferred"

--- a/app/views/support/index.html
+++ b/app/views/support/index.html
@@ -45,11 +45,11 @@
           <span class="status-card__status">Course not started yet</span><span class="govuk-visually-hidden"> records. View these records.</span>
         </a>
 
-        {# In training #}
+        {# Actively training #}
         {% set traineesInTraining = registeredTrainees | filterByFunction('isInTraining') %}
-        <a href="/records?&filterTrainingStatus=In training" class="status-card status-card--in-training">
+        <a href="/records?&filterTrainingStatus=Actively training" class="status-card status-card--in-training">
           <span class="status-card__count">{{traineesInTraining | length}}</span>
-          <span class="status-card__status">In training</span><span class="govuk-visually-hidden"> records. View these records.</span>
+          <span class="status-card__status">Actively training</span><span class="govuk-visually-hidden"> records. View these records.</span>
         </a>
 
         {# Awarded this year #}
@@ -112,7 +112,7 @@
           <span class="status-card__status">Organisations</span><span class="govuk-visually-hidden">. View these providers.</span>
         </a>
 
-        {# In training #}
+        {# Lead schools #}
         {% set leadSchools = data.providers.leadSchools.all %}
         <a href="support/organisations" class="status-card status-card--in-training">
           <span class="status-card__count">{{leadSchools | length}}</span>


### PR DESCRIPTION
- Changed 'In training' tile to 'Actively training'

<img width="989" alt="Screenshot 2022-10-27 at 13 27 59" src="https://user-images.githubusercontent.com/68232608/198284491-2a9d7be8-0c3e-44d8-9f56-e6d3fc3053e3.png">

- Changed filter on Record list page to 'Actively training'

<img width="333" alt="Screenshot 2022-10-27 at 13 28 11" src="https://user-images.githubusercontent.com/68232608/198284525-fb788a8a-6573-4c88-a87f-e659402d6181.png">

- Updated HESA records message to be clearer its all trainee records

<img width="716" alt="Screenshot 2022-10-27 at 13 29 12" src="https://user-images.githubusercontent.com/68232608/198284561-ebe5cc3c-6d34-415d-a276-c27609954aec.png">
