### PR TITLE
Show subject category as a hint in autocomplete

### DIFF
--- a/app/views/_includes/forms/course-details/index.html
+++ b/app/views/_includes/forms/course-details/index.html
@@ -11,6 +11,19 @@
 
 {% set subjectSpecialisms = data.ittSubjects | removeArrayItems(primarySubjectsToRemove) %}
 
+{# Make autocomplete array so we can have subject category as a hint #}
+{% set subjectsForAutocomplete = [] %}
+
+{% for subject in subjectSpecialisms %}
+  {% set allocationSubject = subject | subjectToAllocationSubject %}
+  {% set subjectsForAutocomplete = subjectsForAutocomplete | push({
+    name: subject,
+    value: subject,
+    hint: allocationSubject if subject != allocationSubject,
+    synonyms: [allocationSubject]
+  }) %}
+{% endfor %}
+
 {# Autocompletes for subjects 2 and 3 #}
 {% set multipleSubjectsHtml %}
   
@@ -44,7 +57,8 @@
       autocompleteOptions: {
         autoselect: true,
         showAllValues: false,
-        allowEmpty: true
+        allowEmpty: true,
+        values: subjectsForAutocomplete
       }
     }
     ) }}
@@ -144,7 +158,8 @@
     value: record.courseDetails.subjects.first,
     autocompleteOptions: {
       autoselect: true,
-      showAllValues: false
+      showAllValues: false,
+      values: subjectsForAutocomplete
     }
   }
   ) }}


### PR DESCRIPTION
Register doesn't currently communicate which specialisms map to which categories - and hence which are eligible for funding or not.

One thing we can do is show the category in the subject autocomplete when users are picking them.

This pr:

* Shows the category as a hint for each specialism
* Except where the specialism name is exactly the same (eg we don't show `Biology` twice)
* Uses the category as a synonym so users can also search for it.

<img width="634" alt="Screenshot 2022-11-14 at 13 23 20" src="https://user-images.githubusercontent.com/2204224/201681825-a649de66-2935-435f-878c-7d1d953e1037.png">
<img width="523" alt="Screenshot 2022-11-14 at 13 23 33" src="https://user-images.githubusercontent.com/2204224/201681849-5de0f65e-decb-4629-91d9-ba36548dfa5a.png">

