### PR TITLE
Move placement details to end of manual data guidance

### DIFF
--- a/app/views/guidance/check-data.html
+++ b/app/views/guidance/check-data.html
@@ -184,18 +184,6 @@
 
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-<h3 class='govuk-heading-m'>Placement details</h3>
-
-<div class="govuk-inset-text">
-
-  <p>You should keep a record of the location of the trainee’s placements.</p>
-
-  <p>You cannot currently provide this data but you’ll be asked to provide it later in the 2022 to 2023 academic year.</p>
-
-</div>
-
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
 <h3 class='govuk-heading-m'>Funding details</h3>
 
 <ul class='govuk-list'>
@@ -215,5 +203,17 @@
     Whether the trainee is applying for a scholarship
   </li>
 </ul>
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+<h3 class='govuk-heading-m'>Placement details</h3>
+
+<div class="govuk-inset-text">
+
+  <p>You should keep a record of the location of the trainee’s placements.</p>
+
+  <p>You cannot currently provide this data but you’ll be asked to provide it later in the 2022 to 2023 academic year.</p>
+
+</div>
 
 {% endblock %}

--- a/app/views/guidance/check-data.html
+++ b/app/views/guidance/check-data.html
@@ -210,9 +210,9 @@
 
 <div class="govuk-inset-text">
 
-  <p>You should keep a record of the location of the trainee’s placements.</p>
+  <p class="govuk-body">You should keep a record of the location of the trainee’s placements.</p>
 
-  <p>You cannot currently provide this data but you’ll be asked to provide it later in the 2022 to 2023 academic year.</p>
+  <p class="govuk-body">You cannot currently provide this data but you’ll be asked to provide it later in the 2022 to 2023 academic year.</p>
 
 </div>
 

--- a/app/views/guidance/check-data.html
+++ b/app/views/guidance/check-data.html
@@ -194,6 +194,8 @@
 
 </div>
 
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
 <h3 class='govuk-heading-m'>Funding details</h3>
 
 <ul class='govuk-list'>


### PR DESCRIPTION
I've moved the placement details to the end of the guidance page about manual data entry. 

The guidance shows the data in the order in which it appears in the task list. Since we don't ask about placement details currently it does not fit into this order, so we should put it at the end of the page.

![CleanShot 2022-11-17 at 16 24 40](https://user-images.githubusercontent.com/29047487/202501407-48686fc0-0abf-460a-9321-6635a472f936.png)
