### PR TITLE
Update govuk frontend

### DIFF
--- a/app/data/generators/training-details.js
+++ b/app/data/generators/training-details.js
@@ -42,7 +42,7 @@ module.exports = (params) => {
   else {
     traineeStarted = params?.traineeStarted || weighted.select({
       "true": 0.95, // Most students should have commencement dates
-      "false": 0.5
+      "false": 0.05
     })
   }
 

--- a/app/views/_components/download-link-with-filename/template.njk
+++ b/app/views/_components/download-link-with-filename/template.njk
@@ -1,6 +1,6 @@
 <p class="govuk-body {{params.classes if params.classes}}">
   <span class="app-nowrap"><a class="govuk-link--no-visited-state" href="/public/downloads/{{ params.fileName }}.{{ params.fileType }}" download="{{ params.downloadedFileName | slugify }}.{{ params.fileType }}">{{ params.linkText }}</a></span><br>
   {% if params.showDownloadedFileName %}
-    <span class="govuk-hint">File name: <span class="app-nowrap">{{ params.downloadedFileName }}.{{ params.fileType }}</span></span>
+    <div class="govuk-hint">File name: <span class="app-nowrap">{{ params.downloadedFileName }}.{{ params.fileType }}</span></div>
   {% endif %}
 </p>

--- a/app/views/_includes/forms/bulk/select-trainees.html
+++ b/app/views/_includes/forms/bulk/select-trainees.html
@@ -4,7 +4,7 @@
 {% for trainee in filteredRecords  %}
 
   {% set traineeHintHtml %}
-    <span class="govuk-hint">{{trainee.courseDetails.subjects | prettifySubjects }}, {{trainee.route | lower}}</span>
+    <div class="govuk-hint">{{trainee.courseDetails.subjects | prettifySubjects }}, {{trainee.route | lower}}</div>
     {{govukTag({
       text: trainee.status,
       classes: trainee.status | getStatusClass

--- a/app/views/_includes/summary-cards/bulk-details.html
+++ b/app/views/_includes/summary-cards/bulk-details.html
@@ -6,14 +6,14 @@
 
     {% for trainee in selectedTrainees %}
       {{trainee.personalDetails.fullName}}<br>
-      <span class="govuk-hint">{{trainee.courseDetails.subjects | prettifySubjects }}, {{trainee.route | lower}}</span>
+      <div class="govuk-hint">{{trainee.courseDetails.subjects | prettifySubjects }}, {{trainee.route | lower}}</div>
     {% endfor %}
 
   {% else %}
     <ul class="govuk-list govuk-list--bullet">
       {% for trainee in selectedTrainees %}
         <li>{{trainee.personalDetails.fullName}}<br>
-          <span class="govuk-hint">{{trainee.courseDetails.subjects | prettifySubjects }}, {{trainee.route | lower}}</span>
+          <div class="govuk-hint">{{trainee.courseDetails.subjects | prettifySubjects }}, {{trainee.route | lower}}</div>
         </li>
       {% endfor %}
     </ul>

--- a/app/views/_includes/summary-cards/course-details.html
+++ b/app/views/_includes/summary-cards/course-details.html
@@ -10,13 +10,13 @@
 {% macro courseAndRouteHtml(record, minimalPublishSummary) %}
   {% set isPublishCourse = record.courseDetails.isPublishCourse | falsify %}
   <p class="govuk-body">{{record.route}}</p>
-  <span class="govuk-hint">
+  <div class="govuk-hint">
     {% if isPublishCourse %}
       {{ record.courseDetails.courseNameLong }}
     {% else %}
       {{ record | getAllocationSubject }}
     {% endif %}
-  </span>
+  </div>
 {% endmacro %}
 
 {% macro getCourseMoveLinkPath(defaultPath, nextPath, referrer, showCourseMoveQuestionUpFront) -%}

--- a/app/views/_includes/summary-cards/degree/bursary-details.html
+++ b/app/views/_includes/summary-cards/degree/bursary-details.html
@@ -4,7 +4,7 @@
 {% if bursaryDegree %}
   {% set bursaryHtml %}
     <p class="govuk-body">{{ bursaryDegree | getDegreeName }}</p>
-    <span class="govuk-hint">{{ bursaryDegree | getDegreeHint }}</span>
+    <div class="govuk-hint">{{ bursaryDegree | getDegreeHint }}</div>
   {% endset %}
 {% elseif record.degree.degreeToBeUsedForBursaries %}
   {% set bursaryHtml = "Not provided" %}

--- a/app/views/_includes/summary-cards/funding.html
+++ b/app/views/_includes/summary-cards/funding.html
@@ -109,7 +109,7 @@
   {% if bursaryDegree %}
     {% set bursaryHtml %}
       <p class="govuk-body">{{ bursaryDegree | getDegreeName }}</p>
-      <span class="govuk-hint">{{ bursaryDegree | getDegreeHint }}</span>
+      <div class="govuk-hint">{{ bursaryDegree | getDegreeHint }}</div>
     {% endset %}
   {% elseif record.degree.degreeToBeUsedForBursaries %}
     {% set bursaryHtml = "Not provided" %}

--- a/app/views/_includes/summary-cards/gcse-details-complex.html
+++ b/app/views/_includes/summary-cards/gcse-details-complex.html
@@ -24,7 +24,7 @@
       {% if gcse.country != "United Kingdom" %}
         {% set grade %}
           Grade {{item.grade}}<br>
-          <span class="govuk-hint">{{gcse.type}}, {{gcse.country}}</span>
+          <div class="govuk-hint">{{gcse.type}}, {{gcse.country}}</div>
         {% endset %}
         {# {% set grade = gcse.type + ", " + gcse.country + " (" + item.grade + ")"  %} #}
       {% elseif item.exam %}

--- a/app/views/_includes/summary-cards/placements/placement-overview.html
+++ b/app/views/_includes/summary-cards/placements/placement-overview.html
@@ -10,7 +10,7 @@
       Not applicable
     {% else %}
       <p class="govuk-body">{{placement.school.schoolName}}</p>
-      <span class="govuk-hint">{{placement.school | getSchoolHint}}</span>
+      <div class="govuk-hint">{{placement.school | getSchoolHint}}</div>
     {% endif %}
   {% endset %}
 

--- a/app/views/_includes/summary-cards/placements/single-placement-details.html
+++ b/app/views/_includes/summary-cards/placements/single-placement-details.html
@@ -8,7 +8,7 @@
       Not applicable
     {% else %}
       <p class="govuk-body">{{placement.school.schoolName}}</p>
-      <span class="govuk-hint">{{placement.school | getSchoolHint}}</span>
+      <div class="govuk-hint">{{placement.school | getSchoolHint}}</div>
     {% endif %}
   {% endset %}
 {% endif %}

--- a/app/views/_includes/summary-cards/schools.html
+++ b/app/views/_includes/summary-cards/schools.html
@@ -6,7 +6,7 @@
       Not applicable
     {% else %}
       <p class="govuk-body">{{record.schools.leadSchool.schoolName}}</p>
-      <span class="govuk-hint">{{record.schools.leadSchool | getSchoolHint}}</span>
+      <div class="govuk-hint">{{record.schools.leadSchool | getSchoolHint}}</div>
     {% endif %}
   {% endset %}
 {% endif %}
@@ -35,7 +35,7 @@
       Not applicable
     {% else %}
     <p class="govuk-body">{{record.schools.employingSchool.schoolName}}</p>
-    <span class="govuk-hint">{{record.schools.employingSchool | getSchoolHint}}</span>
+    <div class="govuk-hint">{{record.schools.employingSchool | getSchoolHint}}</div>
     {% endif %}
   {% endset %}
 {% endif %}

--- a/app/views/_includes/summary-cards/trainee-progress.html
+++ b/app/views/_includes/summary-cards/trainee-progress.html
@@ -113,7 +113,7 @@
 
 {% set submittedDateHtml %}
   <p class="govuk-body">{{record.submittedDate | govukDate}}</p>
-  <span class="govuk-hint">{{record.submittedDate | formatDate('relative')}}</span>
+  <div class="govuk-hint">{{record.submittedDate | formatDate('relative')}}</div>
 {% endset %}
 
 {% set pendingTrnRow = {
@@ -245,7 +245,7 @@
 {% set updatedDateHtml %}
   <p class="govuk-body">{{record.updatedDate | govukDate or 'Not provided'}}</p>
   {% if record.updatedDate | isInLast( 7, 'days') %}
-    <span class="govuk-hint">{{ record.updatedDate | formatDate('relative') }}</span>
+    <div class="govuk-hint">{{ record.updatedDate | formatDate('relative') }}</div>
   {% endif %}
 {% endset %}
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^3.14.0",
+    "govuk-frontend": "^4.4.0",
     "govuk-markdown": "^0.3.0",
     "gulp": "^4.0.0",
     "gulp-nodemon": "^2.5.0",


### PR DESCRIPTION
Updates to latest govuk-frontend.

I've run through the [4.0 documented breaking changes](https://github.com/alphagov/govuk-frontend/releases/tag/v4.0.0) and done the requested checks.

The main visual change in the prototype is for the accordions on the funding pages.

| Before | After |
|--------|-------|
| <img width="726" alt="Screenshot 2022-11-22 at 13 36 45" src="https://user-images.githubusercontent.com/2204224/203327726-befb0a49-5f93-4a02-8359-b679df346a14.png">    | <img width="706" alt="Screenshot 2022-11-22 at 13 36 56" src="https://user-images.githubusercontent.com/2204224/203327756-2dc12856-bafc-49de-8dc8-5fc8a713226c.png">   |



