### PR TITLE
Tweak withdrawal option text after user research

### DIFF
--- a/app/views/_includes/forms/remove/reason.html
+++ b/app/views/_includes/forms/remove/reason.html
@@ -32,14 +32,11 @@
       text: "Transferring to a different provider"
     },
     {
-      text: "Withdrawing from course",
+      text: "Withdrawing",
       value: "withdraw",
-      _hint: {
-        text: "Not available because the course has not yet started"
-      } if record | ittInTheFuture,
-      _attributes: {
-        disabled: true
-      } if record | ittInTheFuture
+      hint: {
+        text: "Left the course or no longer working towards " + record | getQualificationText
+      }
     } if not record | ittInTheFuture
   ]
 } | decorateAttributes(record, "record.remove.reason")) }}


### PR DESCRIPTION
We had a user in user research who talked about 'transferring' trainees - where the trainee was staying on the course but no longer doing QTS.

Looking at this with @johndoates we felt the existing text didn't fully cover this scenario. 