### PR TITLE
Show actual year to match total trainees tile

### DIFF
--- a/app/views/home.html
+++ b/app/views/home.html
@@ -114,7 +114,7 @@
         {% set traineesAwardedThisYear = traineesAwarded | filterByFunction('isFinishingThisAcademicYear') %}
         <a href="/records?filterTrainingStatus=Awarded&filterEndYears={{ data.years.currentAcademicYear }}" class="status-card status-card--awarded">
           <span class="status-card__count">{{traineesAwardedThisYear | length}}</span>
-          <span class="status-card__status">Awarded this year</span><span class="govuk-visually-hidden"> records. View these records.</span>
+          <span class="status-card__status">Awarded in {{data.years.currentAcademicYear}}</span><span class="govuk-visually-hidden"> records. View these records.</span>
         </a>
 
         {# Currently deferred #}


### PR DESCRIPTION
Our new total trainees tab refers to the actual year - `2022 to 2023` rather than `this year`. It was commented in user research that this now makes the `Awarded this year` potentially ambiguous - why the difference? This updates the awarded tile to use similar language.

<img width="1011" alt="Screenshot 2022-11-30 at 12 01 05" src="https://user-images.githubusercontent.com/2204224/204791016-50cb1d56-b0c3-4dbf-9079-4ccc4927f298.png">
