### PR TITLE
Added performance profiles date and tweaked census content

### DIFF
--- a/app/views/guidance/dates-and-deadlines.html
+++ b/app/views/guidance/dates-and-deadlines.html
@@ -22,7 +22,7 @@
   rows: [
     [
       {
-        html: "Wednesday 12 October 2022" | nowrap
+        html: "12 October 2022" | nowrap
       },
       {
         text: "The second Wednesday of October every academic year is called the ‘census date’. If a new trainee starts their course after this date, they will not be included in the ITT census publication. This is why it’s important to add your new trainees as they start their training."
@@ -33,7 +33,15 @@
         html: "1 November 2022" | nowrap
       },
       {
-        text: "A senior person from your organisation must sign off your new trainee data on or before this date (this should be a different person to who submitted the data). "
+        text: "A senior person from your organisation must sign off your new trainee data on or before this date. This should be a different person to the one who submitted the data. This data will be used for the ITT census publication."
+      }
+    ],
+    [
+      {
+        html: "31 January 2023" | nowrap
+      },
+      {
+        text: "A senior person from your organisation must sign off your 2021 to 2022 trainee data on or before this date. This should be a different person to the one who submitted the data. Some of this data will be used for the ITT performance profiles publication."
       }
     ]
   ]


### PR DESCRIPTION
I added the date when performance profile data needs to be signed off. 

I also made minor changes to the existing content about the census data by:

- taking text out of brackets an putting it into its own sentences, to make it more readable
- removing “Wednesday” from the first date, as we explain the pattern in the "what happens" column
- saying that the new trainee data will be used for the census, to match the new line about performance profile data 

