### PR TITLE
Tweak skip language

### DIFF
--- a/app/views/bulk-update/recommend/fix-errors.html
+++ b/app/views/bulk-update/recommend/fix-errors.html
@@ -80,7 +80,7 @@
         {% if hasErrors and hasUpdated %}
           <p class="govuk-body">
             <a href="/bulk-update/recommend/check-pending-updates" class="govuk-link">
-              Skip fixing errors and check who you’ll recommend
+              Skip trainees with errors and check who you’ll recommend
             </a>
           </p>
         {% endif %}


### PR DESCRIPTION
Our skip link wasn't clear that we would be skipping trainees / rows with errors rather than just accepting the errors.