### PR TITLE
Add extra tab for admins

### DIFF
--- a/app/views/_components/sub-navigation/template.njk
+++ b/app/views/_components/sub-navigation/template.njk
@@ -8,7 +8,7 @@
       {% if item %}
 
         <li class="app-sub-navigation__item">
-          <a class="app-sub-navigation__link" {{ 'aria-current="page"' | safe if item.active }} href="{{ item.href }}" {%- for attribute, value in item.attributes -%} {{ attribute }}="{{ value }}"{% endfor %}>
+          <a class="app-sub-navigation__link {{- ' ' + item.classes if item.classes}}" {{ 'aria-current="page"' | safe if item.active }} href="{{ item.href }}" {%- for attribute, value in item.attributes -%} {{ attribute }}="{{ value }}"{% endfor %}>
             {{- item.html | safe if item.html else item.text -}}
           </a>
         </li>

--- a/app/views/_includes/record-sub-nav.njk
+++ b/app/views/_includes/record-sub-nav.njk
@@ -16,6 +16,11 @@
     text: "Timeline",
     href: recordPath + '/timeline',
     active: (activeTab == "timeline")
-  }
+  },
+  {
+    text: "Admin",
+    href: recordPath + '/admin',
+    active: (activeTab == "admin")
+  } if data.isAdmin
   ]
 }) }}

--- a/app/views/_includes/summary-cards/record-admin/hesa.html
+++ b/app/views/_includes/summary-cards/record-admin/hesa.html
@@ -1,0 +1,181 @@
+
+{% set code %}
+
+{% markdown %}
+```
+{
+  "data": [
+    {
+      "id": "11fc0d3b2f",
+      "type": "application",
+      "attributes": {
+        "support_reference": "AB1234",
+        "status": "awaiting_provider_decision",
+        "updated_at": "2019-06-13 10:44:31 UTC",
+        "submitted_at": "2019-06-13 10:44:31 UTC",
+        "recruited_at": "2019-06-13 23:59:59 UTC",
+        "candidate": {
+          "id": "C5432",
+          "first_name": "Boris",
+          "last_name": "Brown",
+          "date_of_birth": "1985-02-13",
+          "nationality": [
+            "NL"
+          ],
+          "domicile": "XF",
+          "uk_residency_status": "UK Citizen",
+          "uk_residency_status_code": "B",
+          "fee_payer": "02",
+          "english_main_language": true,
+          "english_language_qualifications": "Name: TOEFL, Grade: 20, Awarded: 1999",
+          "other_languages": "I am bilingual in Finnish and English",
+          "disability_disclosure": "I am dyslexic",
+          "gender": "male",
+          "disabilities": [
+            "blind"
+          ],
+          "ethnic_group": "Asian or Asian British",
+          "ethnic_background": "Chinese"
+        },
+        "contact_details": {
+          "address_line1": "45 Dialstone Lane",
+          "address_line2": "Stockport",
+          "address_line3": "Greater Manchester",
+          "address_line4": "England",
+          "postcode": "SK2 6AA",
+          "country": "GB",
+          "email": "boris.brown@example.com",
+          "phone_number": "07700 900000"
+        },
+        "course": {
+          "recruitment_cycle_year": 2020,
+          "training_provider_code": "2FR",
+          "training_provider_type": "scitt",
+          "accredited_provider_type": "university",
+          "accredited_provider_code": "2FR",
+          "course_code": "3CVK",
+          "course_uuid": "24a9590e-6b40-4096-9967-36b0a5904706",
+          "site_code": "K",
+          "study_mode": "full_time"
+        },
+        "qualifications": {
+          "gcses": [
+            {
+              "id": 123,
+              "qualification_type": "BA",
+              "degree_type_uuid": "7022c4c2-ec9a-4eec-98dc-315bfeb1ef3a",
+              "non_uk_qualification_type": "High School Diploma",
+              "subject": "History and Politics",
+              "subject_uuid": "917f70f0-5dce-e911-a985-000d3ab79618",
+              "grade": "AA*B",
+              "grade_uuid": "8741765a-13d8-4550-a413-c5a860a59d25",
+              "start_year": "1989",
+              "award_year": "1992",
+              "institution_details": "University of Huddersfield",
+              "institution_uuid": "5c9e1d2d-3fa2-e811-812b-5065f38ba241",
+              "equivalency_details": "Enic: 4000123456 - Between GCSE and GCSE AS Level - Equivalent to GCSE C",
+              "comparable_uk_degree": "masters_degree"
+            }
+          ],
+          "degrees": [
+            {
+              "id": 123,
+              "qualification_type": "BA",
+              "degree_type_uuid": "7022c4c2-ec9a-4eec-98dc-315bfeb1ef3a",
+              "non_uk_qualification_type": "High School Diploma",
+              "subject": "History and Politics",
+              "subject_uuid": "917f70f0-5dce-e911-a985-000d3ab79618",
+              "grade": "AA*B",
+              "grade_uuid": "8741765a-13d8-4550-a413-c5a860a59d25",
+              "start_year": "1989",
+              "award_year": "1992",
+              "institution_details": "University of Huddersfield",
+              "institution_uuid": "5c9e1d2d-3fa2-e811-812b-5065f38ba241",
+              "equivalency_details": "Enic: 4000123456 - Between GCSE and GCSE AS Level - Equivalent to GCSE C",
+              "comparable_uk_degree": "masters_degree"
+            }
+          ],
+          "other_qualifications": [
+            {
+              "id": 123,
+              "qualification_type": "BA",
+              "degree_type_uuid": "7022c4c2-ec9a-4eec-98dc-315bfeb1ef3a",
+              "non_uk_qualification_type": "High School Diploma",
+              "subject": "History and Politics",
+              "subject_uuid": "917f70f0-5dce-e911-a985-000d3ab79618",
+              "grade": "AA*B",
+              "grade_uuid": "8741765a-13d8-4550-a413-c5a860a59d25",
+              "start_year": "1989",
+              "award_year": "1992",
+              "institution_details": "University of Huddersfield",
+              "institution_uuid": "5c9e1d2d-3fa2-e811-812b-5065f38ba241",
+              "equivalency_details": "Enic: 4000123456 - Between GCSE and GCSE AS Level - Equivalent to GCSE C",
+              "comparable_uk_degree": "masters_degree"
+            }
+          ],
+          "missing_gcses_explanation": "Maths GCSE or equivalent: I will take Maths GCSE at my local training provider on 18th August 2020"
+        },
+        "hesa_itt_data": null
+      }
+    }
+  ]
+}
+```
+{% endmarkdown %}
+{% endset %}
+
+{% set collectionData %}
+  {{ govukDetails({
+  summaryText: "2021-05-17",
+  html: code
+}) }}
+{% endset %}
+
+
+{% set hesaRows = [
+  {
+    key: {
+      text: "CC21053"
+    },
+    value: {
+      text: collectionData | safe
+    },
+    actions: {
+      items: [{
+        href: recordPath + "/personal-details/edit" | addReferrer(referrer),
+        text: "Change",
+        visuallyHiddenText: "name"
+      }]
+    } if canAmend
+  },
+  {
+    key: {
+      text: "CC22053"
+    },
+    value: {
+      text: collectionData | safe
+    },
+    actions: {
+      items: [{
+        href: recordPath + "/personal-details/edit" | addReferrer(referrer),
+        text: "Change",
+        visuallyHiddenText: "date of birth"
+      }]
+    } if canAmend
+  }
+] | removeEmpty %}
+
+{% set hesaHtml %}
+  {{ govukSummaryList({
+    rows: hesaRows,
+    attributes: {
+      style: "overflow:hidden;"
+    }
+  }) }}
+{% endset %}
+
+{{ appSummaryCard({
+  classes: "govuk-!-margin-bottom-6",
+  titleText: "HESA",
+  html: hesaHtml
+}) }}

--- a/app/views/_includes/summary-cards/record-admin/hesa.html
+++ b/app/views/_includes/summary-cards/record-admin/hesa.html
@@ -124,9 +124,16 @@
 {% endmarkdown %}
 {% endset %}
 
-{% set collectionData %}
+{% set collectionData1 %}
   {{ govukDetails({
-  summaryText: "2021-05-17",
+  summaryText: "17 May 2021 at 5.43pm",
+  html: code
+}) }}
+{% endset %}
+
+{% set collectionData2 %}
+  {{ govukDetails({
+  summaryText: "4 December 2022 at 1.07pm",
   html: code
 }) }}
 {% endset %}
@@ -135,10 +142,10 @@
 {% set hesaRows = [
   {
     key: {
-      text: "CC21053"
+      text: "Collection C21053"
     },
     value: {
-      text: collectionData | safe
+      text: collectionData1 | safe
     },
     actions: {
       items: [{
@@ -150,10 +157,10 @@
   },
   {
     key: {
-      text: "CC22053"
+      text: "Collection C22053"
     },
     value: {
-      text: collectionData | safe
+      text: collectionData2 | safe
     },
     actions: {
       items: [{

--- a/app/views/record/admin.html
+++ b/app/views/record/admin.html
@@ -1,0 +1,16 @@
+{% extends "_templates/_record.html" %}
+
+{% set backLink = '/records' %}
+{% set backText = 'All registered trainees' %}
+{% set pageHeading = data.record.personalDetails.shortName %}
+{% set activeTab = 'admin' %}
+
+{% block tabContent %}
+
+  {% set referrer = recordPath + "/admin" %}
+
+  {% set canAmend = false %}
+
+  {% include "_includes/summary-cards/record-admin/hesa.html" %}
+
+{% endblock %}


### PR DESCRIPTION
This adds an extra tab to trainee records that is only shown to admins.

The idea is that this tab can be used to contain extra metadata or options about a record that are only for admins.

To start, we can use it to access HESA data.

<img width="1008" alt="Screenshot 2022-12-15 at 17 19 13" src="https://user-images.githubusercontent.com/2204224/207926312-392b703f-5a5c-4b9f-8848-9d2b849ad520.png">

