### PR TITLE
Add end year and hesa id to trainee record, reorder rows

### DIFF
--- a/app/data/generators/hesa-data.js
+++ b/app/data/generators/hesa-data.js
@@ -17,9 +17,13 @@ module.exports = record => {
     record.courseDetails.endDate = weighted.select([null, endDate], percentageMissing)
   }
 
+  let hesaId = `2294839475${faker.datatype.number({'min': 1000000, 'max': 9999999})}, 1`
+
   delete record.contactDetails.address
   delete record.contactDetails.addressType
-
+  record.hesa = {
+    id: hesaId
+  }
   return record
 }
 

--- a/app/data/generators/hesa-data.js
+++ b/app/data/generators/hesa-data.js
@@ -17,7 +17,7 @@ module.exports = record => {
     record.courseDetails.endDate = weighted.select([null, endDate], percentageMissing)
   }
 
-  let hesaId = `2294839475${faker.datatype.number({'min': 1000000, 'max': 9999999})}, 1`
+  let hesaId = `2294839475${faker.datatype.number({'min': 1000000, 'max': 9999999})}`
 
   delete record.contactDetails.address
   delete record.contactDetails.addressType

--- a/app/views/_includes/summary-cards/trainee-progress.html
+++ b/app/views/_includes/summary-cards/trainee-progress.html
@@ -55,6 +55,15 @@
   }
 } %}
 
+{% set hesaRow = {
+  key: {
+    text: "HESA ID / Numhus"
+  },
+  value: {
+    text: record.hesa.id or 'Not provided'
+  }
+} %}
+
 {% set regionRow = {
   key: {
     text: "Region"
@@ -109,6 +118,15 @@
       }
     ]
   } if canAmend and false
+} %}
+
+{% set endYearRow = {
+  key: {
+    text: "End year"
+  },
+  value: {
+    text: record.endAcademicYear or 'Not provided'
+  }
 } %}
 
 {% set submittedDateHtml %}
@@ -301,13 +319,16 @@
   providerRow if data.isAdmin or data.settings.userProviders | length > 1,
   recordSourceRow if data.isAdmin,
   trnRow if record.trn,
+  hesaRow if record | sourceIsHESA,
   referenceRow,
   traineeIdRow,
   regionRow if record | requiresField("region"),
-  startYearRow,
+
   pendingTrnRow if record | isPendingTrn,
-  updatedDate,
   recordCreatedRow,
+  updatedDateRow,
+   startYearRow,
+  endYearRow,
   traineeStartDateRow
 ] | removeEmpty %}
 

--- a/app/views/_includes/summary-cards/trainee-progress.html
+++ b/app/views/_includes/summary-cards/trainee-progress.html
@@ -57,7 +57,7 @@
 
 {% set hesaRow = {
   key: {
-    text: "HESA ID / Numhus"
+    text: "HESA ID"
   },
   value: {
     text: record.hesa.id or 'Not provided'
@@ -217,7 +217,7 @@
     text: "Withdrawn",
     classes: record.status | getStatusClass
   })}} <br>
-  {# Withdrawal date: {{record.withdraw.date | govukDate}} <br>  #}
+  <p class="govuk-body">Withdrawal date: {{record.withdraw.date | govukDate}}</p>
 {% endset %}
 
 {% set withdrawnRow = {
@@ -226,6 +226,15 @@
   },
   value: {
     html: withdrawalContentHtml
+  },
+  actions: {
+    items: [
+      {
+        href: recordPath + "/training-year" | addReferrer(referrer),
+        text: "Change",
+        visuallyHiddenText: "start year"
+      }
+    ]
   }
 } %}
 
@@ -323,7 +332,6 @@
   referenceRow,
   traineeIdRow,
   regionRow if record | requiresField("region"),
-
   pendingTrnRow if record | isPendingTrn,
   recordCreatedRow,
   updatedDateRow,

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -97,10 +97,12 @@
 
         {# Upcoming #}
         {% set coursenNotYetStarted = registeredTrainees | filterByFunction('ittInTheFuture') %}
-        <a href="/records?&filterTrainingStatus=Course not started yet" class="status-card status-card--in-training">
-          <span class="status-card__count">{{coursenNotYetStarted | length}}</span>
-          <span class="status-card__status">Course not started yet</span><span class="govuk-visually-hidden"> records. View these records.</span>
-        </a>
+        {% if courseNotYetStarted | length %}
+          <a href="/records?&filterTrainingStatus=Course not started yet" class="status-card status-card--in-training">
+            <span class="status-card__count">{{coursenNotYetStarted | length}}</span>
+            <span class="status-card__status">Course not started yet</span><span class="govuk-visually-hidden"> records. View these records.</span>
+          </a>
+        {% endif %}
 
         {# Actively training #}
         {% set traineesInTraining = registeredTrainees | filterByFunction('isInTraining') %}


### PR DESCRIPTION
Adds HESA ID and End academic year to the trainee record. Start year was already present. Also reorders the fields slightly.

Note the HESA ID row only shows if it's a HESA trainee.

This summary card is getting a bit long and busy - and we should probably think about splitting it in to two in the future.

<img width="1010" alt="Screenshot 2023-01-19 at 17 27 33" src="https://user-images.githubusercontent.com/2204224/213516927-389bd52b-5069-43ad-9e8c-960eb6ff5c22.png">

