### PR TITLE
Update question text to be clear it's about the last day of training

### DIFF
--- a/app/views/_includes/forms/withdraw/date.html
+++ b/app/views/_includes/forms/withdraw/date.html
@@ -12,7 +12,7 @@
     </p>
   {% endset %}
 
-  <h1 class="govuk-heading-l">Withdrawal date</h1>
+  <h1 class="govuk-heading-l">{{pageHeading}}</h1>
 
   {{ govukInsetText({
     html: deferredTextHtml
@@ -61,10 +61,13 @@
   {{ govukRadios({
     fieldset: {
       legend: {
-        text: "When did the trainee withdraw?",
+        text: pageHeading,
         isPageHeading: true,
         classes: "govuk-fieldset__legend--l"
       }
+    },
+    hint: {
+      text: "Date of their last day of training for " + record | getQualificationText
     },
     items: [
       {
@@ -74,7 +77,7 @@
         text: "Yesterday"
       },
       {
-        text: "On another day",
+        text: "Another date",
         conditional: {
           html: customWithdrawalDate
         }

--- a/app/views/_includes/forms/withdraw/date.html
+++ b/app/views/_includes/forms/withdraw/date.html
@@ -67,7 +67,7 @@
       }
     },
     hint: {
-      text: "Date of their last day of training for " + record | getQualificationText
+      text: "This is the last day they trained for " + record | getQualificationText
     },
     items: [
       {

--- a/app/views/_includes/forms/withdraw/date.html
+++ b/app/views/_includes/forms/withdraw/date.html
@@ -67,7 +67,7 @@
       }
     },
     hint: {
-      text: "This is the last day they trained for " + record | getQualificationText
+      text: "This is the last day they trained for " + record | getQualificationText + "."
     },
     items: [
       {

--- a/app/views/record/withdraw/date.html
+++ b/app/views/record/withdraw/date.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_record-form.html" %}
 
-{% set pageHeading = 'When did the trainee withdraw?' %}
+{% set pageHeading = 'Date the trainee withdrew' %}
 
 {% set formAction = "./date-answer" | addReferrer(referrer) %}
   


### PR DESCRIPTION
When we ask for the withdrawal date, we want the last date the trainee was in training. Normally providers give this fine - but where the trainee was previously deferred, we would want the date they started deferral. We try to auto-populate this where we can, but we don't always have a deferral date. In this situation, providers are sometimes providing the date the trainee told them they were withdrawing, not when they were last in training - this could be months or years different.

This attempts to improve the situation by adjusting the legend and adding a heading. We've also adjusted the third radio option:

<img width="1030" alt="Screenshot 2023-02-07 at 16 37 39" src="https://user-images.githubusercontent.com/2204224/217306898-048fca34-c97f-48c2-9255-5a42677b931a.png">


Note we avoided mentioning when they left the course, because for HEIs / undergrads it may be that they're still on their course - it's just that they've left QTS or EYTS.

On production the page design is older, so here's how it would look there:

<img width="1042" alt="Screenshot 2023-02-07 at 16 41 00" src="https://user-images.githubusercontent.com/2204224/217307714-d02d0c6e-3290-4897-a997-f756a658e63e.png">


