### PR TITLE
Add transfer as a withdrawal option

### DIFF
--- a/app/data/withdrawal-reasons.js
+++ b/app/data/withdrawal-reasons.js
@@ -41,6 +41,7 @@ module.exports = [
     'Problems with their health',
     'Stopped responding to messages',
     'Teaching placement problems',
+    'Transferred to another accredited provider',
     'Unacceptable behaviour',
     'Unhappy with course, provider or employing school',
 


### PR DESCRIPTION
Adds the withdrawal reason of `transferred to another accredited provider`. If we later make a combined remove flow we may remove this again.