### PR TITLE
Revised content for account request page

### DIFF
--- a/app/views/request-an-account.html
+++ b/app/views/request-an-account.html
@@ -5,7 +5,7 @@
 {% set hidePrimaryNav = true %}
 
 
-{% set pageHeading = 'Request an account for Register trainee teachers (Register)' %}
+{% set pageHeading = 'Request an account for Register trainee teachers' %}
 
 {% block content %}
 
@@ -13,37 +13,32 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-9">{{pageHeading}}</h1>
 
-    <h2 class="govuk-heading-m">Who can get a Register account</h2>
-    <p class="govuk-body">You can only get a Register account if you are one of the following:</p>
+    <p class="govuk-body">You can only get a Register trainee teachers (Register) account if you work for either:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>an initial teacher training (ITT) accredited provider</li>
-      <li>a lead school involved in School Direct training routes</li>
+      <li>a lead school involved in School Direct teacher training</li>
     </ul>
-    <h2 class="govuk-heading-m">Steps to get an account</h2>
     <p class="govuk-body">Follow these steps to get an account to use Register.</p>
-    <h2 class="govuk-heading-m">Step 1: Get a DfE Sign-in account</h2>
-    <p class="govuk-body">To use Register, each person in your organisation will need a DfE Sign-in account.</p>
-    <p class="govuk-body">The email address you use for your DfE Sign-in account  must:</p>
+    <h2 class="govuk-heading-m">1. Get a DfE Sign-in account</h2>
+      <p class="govuk-body">You’ll use a DfE Sign-in account to sign in to Register.</p>
+    <p class="govuk-body">The email address you use for your DfE Sign-in account must:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>be a named individual email address, for example jane.doe@example.com</li>
-      <li>have an email domain from your organisation, for example we cannot accept emails that end with @gmail.com or @icloud.com</li>
+      <li>have an email domain belonging to your organisation, for example it cannot end with @gmail.com or @icloud.com</li>
     </ul>
-    <p class="govuk-body">Get a <a href="https://services.signin.education.gov.uk/" class="govuk-link">DfE Sign-in account</a> if you do not already have one.</p>
-    <h2 class="govuk-heading-m">Step 2: Email us to request a Register account</h2>
-    <p class="govuk-body">Once you have a DfE Sign-in account with a named email address, email <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Request a Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a></p>
-    <p class="govuk-body">In your email, tell us:</p>
+    <p class="govuk-body"><a href="https://services.signin.education.gov.uk/" class="govuk-link">Get a DfE Sign-in account</a> if you do not already have one.</p>
+    <h2 class="govuk-heading-m">2. Ask a colleague to request a Register account for you</h2>
+    <p class="govuk-body">Once you have a DfE Sign-in account, ask a colleague who already has a Register account to email <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Request a Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a>.</p>
+    <p class="govuk-body">They’ll need to say that you would like to start using Register and give:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>the name of the accredited provider or lead school you work for</li>
-      <li>that you would like to start using Register</li>
       <li>the email address used for your DfE Sign-in account</li>
     </ul>
-    <p class="govuk-body">If there is more than one person at your organisation who would like to get set up, you can send one email with everyone’s details.</p>
-    <h2 class="govuk-heading-m">Step 3: Start using Register</h2>
-    <p class="govuk-body">Once you’ve sent us the email in Step 2, we will set up your Register account.</p>
-    <p class="govuk-body">We will then email you a link to start using Register.</p>
-    <h2 class="govuk-heading-m">Step 4 (optional): Access to multiple providers or lead schools</h2>
-    <p class="govuk-body">If you need access to multiple providers or lead schools, you do not need to create multiple user accounts.</p>
-    <p class="govuk-body">Once your Register account is set up, you can request that the relevant organisations are added to your account by emailing <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Add multipl organisations to Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a></p>
+    <p class="govuk-body">If more than one person at your organisation needs a Register account, your colleague can send one email with everyone’s details.</p>
+    <p class="govuk-body">You’ll be sent an email with a link once your Register account has been set up.</p>
+    <h2 class="govuk-heading-m">3. Ask for access to additional accredited providers or lead schools (optional)</h2>
+    <p class="govuk-body">Do not create multiple user accounts if you need access to multiple accredited providers or lead schools.</p>
+    <p class="govuk-body">Once your Register account has been set up, email <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Add multiple organisations to Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a> to ask for the other organisations to be added to your account.</p>
   </div>
 </div>
 

--- a/app/views/request-an-account.html
+++ b/app/views/request-an-account.html
@@ -5,7 +5,7 @@
 {% set hidePrimaryNav = true %}
 
 
-{% set pageHeading = 'Request an account for Register trainee teachers' %}
+{% set pageHeading = 'Request an account to use Register trainee teachers' %}
 
 {% block content %}
 
@@ -27,17 +27,19 @@
       <li>have an email domain belonging to your organisation, for example it cannot end with @gmail.com or @icloud.com</li>
     </ul>
     <p class="govuk-body"><a href="https://services.signin.education.gov.uk/" class="govuk-link">Get a DfE Sign-in account</a> if you do not already have one.</p>
-    <h2 class="govuk-heading-m">2. Ask a colleague to request a Register account for you</h2>
-    <p class="govuk-body">Once you have a DfE Sign-in account, ask a colleague who already has a Register account to email <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Request a Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a>.</p>
-    <p class="govuk-body">They’ll need to say that you would like to start using Register and give:</p>
+    <h2 class="govuk-heading-m">2. Get a register account</h2>
+    <p class="govuk-body">Once you have a DfE Sign-in account, you can request a Register account by emailing <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Request a Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a>.</p>
+    <p class="govuk-body">Ask a colleague with an account to send the email if your organisation already uses Register. Otherwise you can send the email yourself.</p>
+    <p class="govuk-body">The email should say that you want to start using Register and include:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>the name of the accredited provider or lead school you work for</li>
       <li>the email address used for your DfE Sign-in account</li>
     </ul>
-    <p class="govuk-body">If more than one person at your organisation needs a Register account, your colleague can send one email with everyone’s details.</p>
-    <p class="govuk-body">You’ll be sent an email with a link once your Register account has been set up.</p>
+    <p class="govuk-body">If more than one person at your organisation needs a Register account, all their details can be included in the same email.</p>
+    <p class="govuk-body"></p>
+    <p class="govuk-body">You’ll be sent an email once your Register account has been set up.</p>
     <h2 class="govuk-heading-m">3. Ask for access to additional accredited providers or lead schools (optional)</h2>
-    <p class="govuk-body">Do not create multiple user accounts if you need access to multiple accredited providers or lead schools.</p>
+    <p class="govuk-body">Do not create multiple user accounts if you need access to additional accredited providers or lead schools.</p>
     <p class="govuk-body">Once your Register account has been set up, email <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Add multiple organisations to Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a> to ask for the other organisations to be added to your account.</p>
   </div>
 </div>

--- a/app/views/request-an-account.html
+++ b/app/views/request-an-account.html
@@ -38,7 +38,7 @@
     <p class="govuk-body">If more than one person in your organisation needs a Register account, all the details can be included in the same email.</p>
     <p class="govuk-body">You’ll be sent an email once your Register account has been set up.</p>
     <h2 class="govuk-heading-m">3. Get access to additional accredited providers or lead schools in Register (optional)</h2>
-    <p class="govuk-body">Once you have a Register account, you can request access to additional organisations. You do not need a separate Register account for each organisation.</p>
+    <p class="govuk-body">Once you have a Register account, you can request access to additional accredited providers or lead schools. You do not need a separate Register account for each organisation.</p>
     <p class="govuk-body">Ask someone with a Register account in the organisation you want to access to send an email requesting access for you.</p>
     <p class="govuk-body">If nobody in the organisation has a Register account, you can send the email yourself.</p>
     <p class="govuk-body">The email should be sent to <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Add multiple organisations to Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a>.</p>

--- a/app/views/request-an-account.html
+++ b/app/views/request-an-account.html
@@ -27,20 +27,21 @@
       <li>have an email domain belonging to your organisation, for example it cannot end with @gmail.com or @icloud.com</li>
     </ul>
     <p class="govuk-body"><a href="https://services.signin.education.gov.uk/" class="govuk-link">Get a DfE Sign-in account</a> if you do not already have one.</p>
-    <h2 class="govuk-heading-m">2. Get a register account</h2>
-    <p class="govuk-body">Once you have a DfE Sign-in account, you can request a Register account by emailing <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Request a Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a>.</p>
-    <p class="govuk-body">Ask a colleague with an account to send the email if your organisation already uses Register. Otherwise you can send the email yourself.</p>
-    <p class="govuk-body">The email should say that you want to start using Register and include:</p>
+    <h2 class="govuk-heading-m">2. Get a Register account</h2>
+    <p class="govuk-body">Once you have a DfE Sign-in account, ask a colleague with a Register account to send an email requesting an account for you.</p>
+    <p class="govuk-body">If nobody in your organisation has a Register account, you can send the email yourself.</p>
+    <p class="govuk-body">The email should be sent to <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Request a Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a>. It should say that you want to start using Register and include:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>the name of the accredited provider or lead school you work for</li>
       <li>the email address used for your DfE Sign-in account</li>
     </ul>
-    <p class="govuk-body">If more than one person at your organisation needs a Register account, all their details can be included in the same email.</p>
-    <p class="govuk-body"></p>
+    <p class="govuk-body">If more than one person in your organisation needs a Register account, all the details can be included in the same email.</p>
     <p class="govuk-body">You’ll be sent an email once your Register account has been set up.</p>
-    <h2 class="govuk-heading-m">3. Ask for access to additional accredited providers or lead schools (optional)</h2>
-    <p class="govuk-body">Do not create multiple user accounts if you need access to additional accredited providers or lead schools.</p>
-    <p class="govuk-body">Once your Register account has been set up, email <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Add multiple organisations to Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a> to ask for the other organisations to be added to your account.</p>
+    <h2 class="govuk-heading-m">3. Get access to additional accredited providers or lead schools in Register (optional)</h2>
+    <p class="govuk-body">Once you have a Register account, you can request access to additional organisations. You do not need a separate Register account for each organisation.</p>
+    <p class="govuk-body">Ask someone with a Register account in the organisation you want to access to send an email requesting access for you.</p>
+    <p class="govuk-body">If nobody in the organisation has a Register account, you can send the email yourself.</p>
+    <p class="govuk-body">The email should be sent to <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Add multiple organisations to Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a>.</p>
   </div>
 </div>
 


### PR DESCRIPTION
We want to link to the 'request account' page from an email but the content is out of date. In particular it says that people should email us to request their own Register account. But they should ask a colleague to email us instead.

I've also made minor improvements throughout.