### PR TITLE
Fixed guidance on what can be done in HESA service

### DIFF
--- a/app/views/guidance/bulk-recommend-trainees.html
+++ b/app/views/guidance/bulk-recommend-trainees.html
@@ -12,7 +12,7 @@ You can [recommend multiple trainees at the same time](/bulk-update/recommend/up
 
 You cannot use this process to indicate that trainees have withdrawn or deferred, or to make changes to trainee records. You need to do this separately for each trainee.
 
-You can also use the Higher Education Statistics Agency (HESA) service if you have access to it. You cannot use it to indicate that trainees have deferred.
+You can also use the Higher Education Statistics Agency (HESA) service if you have access to it. You cannot use it to indicate that trainees have withdrawn.
 
 </div>
 
@@ -39,7 +39,7 @@ If a trainee’s estimated end date is not in the period covered by the CSV file
 
 ### 2. Fill in the date when each trainee met QTS or EYTS standards
 
-The CSV file has a blank column for you to fill in the date when trainees met QTS or EYTS standards. This may be different to the date when they finish their course or get an academic qualification.
+The CSV file has a blank column for you to fill in the date when trainees met the QTS or EYTS standards. This may be different to the date when they finish their course or get an academic qualification.
 
 If a trainee has not met the standards, either delete the row or leave the date blank in the CSV file.
 


### PR DESCRIPTION
We said that users will not be able to use HESA to defer trainees. 

In fact they will be able to do that but they will not be able to use HESA to withdraw trainees.