### PR TITLE
Say in bulk recommendation guidance that trainee must have met standards in past 12 months

### DIFF
--- a/app/views/guidance/bulk-recommend-trainees.html
+++ b/app/views/guidance/bulk-recommend-trainees.html
@@ -41,6 +41,8 @@ If a trainee’s estimated end date is not in the period covered by the CSV file
 
 The CSV file has a blank column for you to fill in the date when trainees met the QTS or EYTS standards. This may be different to the date when they finish their course or get an academic qualification.
 
+You can only bulk recommend trainees who met the QTS or EYTS standards in the past 12 months. If a trainee met the standards longer ago, you need to recommend them separately in their trainee record.
+
 If a trainee has not met the standards, either delete the row or leave the date blank in the CSV file.
 
 Do not make any other changes to the CSV file.


### PR DESCRIPTION
It’s only possible to bulk recommend trainees who met the standards within the past 12 months. We need to mention this in the guidance.

![image](https://user-images.githubusercontent.com/29047487/231767159-4f1a52da-e4d6-4c97-9557-2cba98154497.png)
