### PR TITLE
Updates to problems feature

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -148,7 +148,7 @@ settings.includeDeclaration = false
 settings.bulkLinksInPrimaryNav = "Show bulk recommend"
 
 // Flow that combines withdrawing and removing in one
-settings.useCombinedRemoveFlow = "false"
+settings.useCombinedRemoveFlow = "true"
 
 settings.academicYearsUiStyle = "Checkboxes"
 

--- a/app/data/trainee-problems.json
+++ b/app/data/trainee-problems.json
@@ -72,7 +72,7 @@
     "type": "forgotten",
     "id": "c4b1fdf1-7ca8-442a-ad19-4078a59f56b0",
     "provider": "University of Lincoln",
-    "date": "2022-09-03T03:08:05.355Z"
+    "date": "2022-09-04T05:39:05.828Z"
   },
   {
     "title": "This trainee may have been forgotten",
@@ -84,45 +84,44 @@
     "type": "forgotten",
     "id": "2caf1de0-12b7-4718-badc-5acc8390251c",
     "provider": "University of Lincoln",
-    "date": "2022-11-02T18:38:53.094Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "45f61cc8-6c00-4bb6-b1d6-31851ab4ab4e",
-      "b4aa9ffe-b1b7-48b8-aad4-fae9aec6f685"
-    ],
-    "type": "duplicate",
-    "id": "b883e78c-8662-4c91-92bc-5ea89b0320f9",
-    "provider": "University of Lincoln",
-    "date": "2022-10-27T06:26:23.070Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "43fcc289-c721-460f-8e14-afcc4e75f4ce",
-      "73679b2d-4d4e-41cd-997c-158fc6e713e9"
-    ],
-    "type": "duplicate",
-    "id": "7c62bb31-85a2-411f-9a21-55fe18ce3471",
-    "provider": "University of Lincoln",
-    "date": "2022-07-30T00:47:11.679Z"
+    "date": "2022-11-03T21:09:53.568Z"
   },
   {
     "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
     "traineeCount": 1,
     "trainees": [
-      "197e029b-2c63-494f-996b-224a23627d8c"
+      "29a510d5-524d-44e1-bc49-0511d0e9daf2"
     ],
     "type": "forgotten",
+    "id": "b883e78c-8662-4c91-92bc-5ea89b0320f9",
+    "provider": "University of Lincoln",
+    "date": "2022-10-28T08:57:23.546Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "9b3fe98f-399b-40ad-b704-36d3c6d18f8e"
+    ],
+    "type": "forgotten",
+    "id": "7c62bb31-85a2-411f-9a21-55fe18ce3471",
+    "provider": "University of Lincoln",
+    "date": "2022-07-31T03:18:12.155Z"
+  },
+  {
+    "title": "These trainees appear to be duplicates",
+    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "traineeCount": 2,
+    "trainees": [
+      "5fff4ed6-a9ee-4492-a573-c3a7bbc0c165",
+      "1bf2620c-437d-4893-b157-70471e993f5c"
+    ],
+    "type": "duplicate",
     "id": "f928da91-024e-4a6a-b665-2b199ce906bc",
     "provider": "University of Lincoln",
-    "date": "2022-09-26T10:29:01.540Z"
+    "date": "2022-09-27T13:00:02.016Z"
   },
   {
     "title": "This trainee may have been forgotten",
@@ -134,32 +133,32 @@
     "type": "forgotten",
     "id": "b4040a4b-c95b-4872-8482-3ea536415639",
     "provider": "University of Lincoln",
-    "date": "2022-10-13T04:44:22.812Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "afb4f05d-8bd1-41c8-b542-0e170db8c0cf"
-    ],
-    "type": "forgotten",
-    "id": "d31d49ca-31db-48a6-af4c-400b7bd2c68b",
-    "provider": "University of Lincoln",
-    "date": "2022-05-17T04:50:14.649Z"
+    "date": "2022-10-14T07:15:23.287Z"
   },
   {
     "title": "These trainees appear to be duplicates",
     "description": "Review these trainees and either withdraw one, or email us with an action to take",
     "traineeCount": 2,
     "trainees": [
-      "fb2552e5-e989-48a1-9e1b-f7525d8a8386",
-      "f5b6bd59-2553-4dbc-8b75-d59366fe8587"
+      "56dca503-8916-44ad-9a69-80f889027456",
+      "41e87643-d427-4595-9aa0-c6825124f9a1"
     ],
     "type": "duplicate",
+    "id": "d31d49ca-31db-48a6-af4c-400b7bd2c68b",
+    "provider": "University of Lincoln",
+    "date": "2022-05-18T07:21:15.123Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "8ee5f380-d5f8-47bc-a18b-5af63a977ac8"
+    ],
+    "type": "forgotten",
     "id": "ed092783-2aaa-4c73-9083-c8b0801b8b79",
-    "provider": "King’s Oak University",
-    "date": "2022-09-13T01:52:08.532Z"
+    "provider": "University of Lincoln",
+    "date": "2022-09-14T04:23:09.007Z"
   },
   {
     "title": "This trainee may have been forgotten",
@@ -171,59 +170,57 @@
     "type": "forgotten",
     "id": "0967b181-e201-4e0a-af49-f4a8a24b78a7",
     "provider": "King’s Oak University",
-    "date": "2022-10-20T14:53:34.871Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "dd64dc31-4e5b-43f1-8782-a153edad3c6a",
-      "cc88e233-20fe-418d-907c-0495ac1e0bcc"
-    ],
-    "type": "duplicate",
-    "id": "ec0ec805-4928-4a77-9802-c08b972cbeaf",
-    "provider": "King’s Oak University",
-    "date": "2022-08-12T15:34:25.743Z"
+    "date": "2022-10-21T17:24:35.349Z"
   },
   {
     "title": "These trainees appear to be duplicates",
     "description": "Review these trainees and either withdraw one, or email us with an action to take",
     "traineeCount": 2,
     "trainees": [
-      "4eb7945f-a1ee-4d0e-a314-396470b49366",
-      "a95d471c-9a7c-4a4c-9db2-2c75211200f0"
+      "53239a7d-861e-47c0-89ce-8341e4a614fa",
+      "45dd6bb5-0474-436d-999d-fcf1a272fb7b"
     ],
     "type": "duplicate",
-    "id": "5e383560-b8ff-4bda-a613-892321bb4255",
+    "id": "ec0ec805-4928-4a77-9802-c08b972cbeaf",
     "provider": "King’s Oak University",
-    "date": "2022-06-28T09:50:00.529Z"
+    "date": "2022-08-13T18:05:26.220Z"
   },
   {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "fd5eab4a-7559-41f7-89c7-42733951036f"
+    ],
+    "type": "forgotten",
+    "id": "5e383560-b8ff-4bda-a613-892321bb4255",
+    "provider": "King’s Oak University",
+    "date": "2022-06-29T12:21:01.005Z"
+  },
+  {
+    "title": "These trainees appear to be duplicates",
+    "description": "Review these trainees and either withdraw one, or email us with an action to take",
     "traineeCount": 2,
     "trainees": [
-      "73016340-9904-4378-822a-83cc7403fe74",
-      "90916ab4-74b5-467b-9971-54d282b21176"
+      "51b4329f-fe02-4730-af07-c1242b5d4cdb",
+      "77f79e9f-bbf6-4fe3-b8da-8ac5b6284f8b"
     ],
     "type": "duplicate",
     "id": "98dcbe3a-5640-47e0-8c86-c85a89dee36a",
     "provider": "King’s Oak University",
-    "date": "2022-09-22T14:24:47.318Z"
+    "date": "2022-09-23T16:55:47.794Z"
   },
   {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
     "trainees": [
-      "a2f8b8aa-553f-4950-9e86-03a617cf23f1",
-      "2f77332c-5188-47fd-8dc4-da49093d182b"
+      "6de4f1bb-e286-4a75-847b-08c6bf12e777"
     ],
-    "type": "duplicate",
+    "type": "forgotten",
     "id": "891db79e-bf23-4ce8-9f0f-10ec55c4d248",
     "provider": "King’s Oak University",
-    "date": "2022-07-23T01:47:21.682Z"
+    "date": "2022-07-24T04:18:22.161Z"
   },
   {
     "title": "This trainee may have been forgotten",
@@ -235,7 +232,7 @@
     "type": "forgotten",
     "id": "f60db38f-b5a3-453a-9605-3f1bf3aff0b1",
     "provider": "King’s Oak University",
-    "date": "2022-09-07T14:49:08.548Z"
+    "date": "2022-09-08T17:20:09.027Z"
   },
   {
     "title": "This trainee may have been forgotten",
@@ -247,542 +244,167 @@
     "type": "forgotten",
     "id": "11141ee4-3fe6-43e8-8488-43977e0fe7f8",
     "provider": "King’s Oak University",
-    "date": "2022-10-25T07:13:44.800Z"
+    "date": "2022-10-26T09:44:45.279Z"
   },
   {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
     "trainees": [
-      "db8b2df8-1ab9-4348-b191-1432da41508f",
-      "116e7d87-ee72-4faa-8956-596865bae972"
+      "53fee8e9-dd2c-41f2-a84c-6d5df78726bb"
     ],
-    "type": "duplicate",
+    "type": "forgotten",
     "id": "2f3bf7fc-fa0a-48ea-81ed-c0037a7cf2a0",
     "provider": "King’s Oak University",
-    "date": "2022-07-22T17:10:05.352Z"
+    "date": "2022-07-23T19:41:05.832Z"
   },
   {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "title": "This draft appears to be a duplicate",
+    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
     "traineeCount": 2,
     "trainees": [
-      "2d5a529d-ca6c-43aa-b9f2-4d6c8e13b271",
-      "62434155-e7c1-4cfa-a3b2-2147c04feafa"
+      "f3a88f9b-53a7-4874-a1e1-e5fe36a6f59d",
+      "837eb63c-2a3b-49ba-8ccf-0fd5cc983b1a"
     ],
     "type": "duplicate",
     "id": "e845f8f5-30d8-4d70-ae90-404f822847fe",
-    "provider": "King’s Oak University",
-    "date": "2022-07-06T11:03:52.788Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "1bd979a7-0529-441a-a407-41db9936bd2c",
-      "07f78381-ef08-4ab9-a677-5fe7efaa823b"
-    ],
-    "type": "duplicate",
-    "id": "aea86549-4598-4ced-a5e2-df9aff60da15",
-    "provider": "King’s Oak University",
-    "date": "2022-06-29T03:34:43.938Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "f7d62ed0-8b97-43fe-82cf-7aa325f272c0",
-      "f25b51e8-8f3b-4f63-9ffe-ed41ec964157"
-    ],
-    "type": "duplicate",
-    "id": "57916d48-a8df-4a32-8631-2da823f9e289",
-    "provider": "King’s Oak University",
-    "date": "2022-06-17T17:28:47.362Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "1e77859f-25f2-49bc-9055-5d3fd636d2ad",
-      "e229a8d3-8cd6-40fc-afc5-28a484e9c436"
-    ],
-    "type": "duplicate",
-    "id": "9e15922f-ee7c-48d1-b83e-3f536da0922d",
-    "provider": "King’s Oak University",
-    "date": "2022-07-28T19:56:37.258Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">6 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "b4016c09-a301-4207-9a16-5aa232494f04"
-    ],
-    "type": "forgotten",
-    "id": "7dddd5f2-ca3b-46de-aac7-d0784f9639d5",
-    "provider": "King’s Oak University",
-    "date": "2022-11-03T10:14:59.315Z"
-  },
-  {
-    "title": "Confirm the deferral is still correct",
-    "description": "This trainee has been deferred for <span class=\"govuk-!-font-weight-bold\">5 years</span>.\n      If the trainee is still deferred, please update their expected end date. If they have left the course you should withdraw them.",
-    "traineeCount": 1,
-    "trainees": [
-      "da70cddd-31e7-4f94-b15e-d4f0085a8029"
-    ],
-    "type": "deferredForgotten",
-    "id": "db0e7006-2c30-4cc9-9521-6eb837456169",
-    "provider": "King’s Oak University",
-    "date": "2022-11-16T13:45:44.565Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">9 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "61e1666c-df51-4efe-ab53-abdbb32b8365"
-    ],
-    "type": "forgotten",
-    "id": "81d6d44c-7bc9-4252-ba2e-0cfa8c814906",
-    "provider": "King’s Oak University",
-    "date": "2022-09-15T08:07:40.915Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "9777872e-6a8a-4fcd-aa8d-beec8512ea80"
-    ],
-    "type": "forgotten",
-    "id": "8107c5f7-9c88-46a2-b63c-a2f849225255",
-    "provider": "King’s Oak University",
-    "date": "2022-11-15T15:03:38.153Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "643d4110-dddd-4bc9-85d6-6b7196f3bd6e"
-    ],
-    "type": "forgotten",
-    "id": "33bef3df-ce1a-492f-ac77-9600715885e2",
-    "provider": "King’s Oak University",
-    "date": "2022-05-28T16:19:47.193Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "ba664661-ec01-4edd-bad2-a53cc6433a1e"
-    ],
-    "type": "forgotten",
-    "id": "66769bd4-188e-486d-9420-96b722ce4460",
-    "provider": "King’s Oak University",
-    "date": "2022-09-19T02:34:53.585Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "bbd145b9-cdbb-4f41-af14-6f0a93e416db"
-    ],
-    "type": "forgotten",
-    "id": "3174c702-a1b8-4447-8008-bd973f39ea12",
     "provider": "Webury Hill SCITT",
-    "date": "2022-07-22T14:32:44.972Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "980c11af-3e50-4c32-b5c5-ab3a08c964ef",
-      "edb3912f-787a-486d-949a-ac4704966304"
-    ],
-    "type": "duplicate",
-    "id": "7bbd7054-015b-44d6-9d38-621fd349508c",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-07-06T03:32:43.678Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "dd893f63-9faf-4503-b9a2-7caeb2aa2fa2"
-    ],
-    "type": "forgotten",
-    "id": "302dcaf1-ee25-4184-8651-dfc14c372fe0",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-06-09T20:33:56.189Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "5de487a8-c6db-4375-a272-6e5033f1c0f8"
-    ],
-    "type": "forgotten",
-    "id": "ac0a6762-b321-4019-a558-f85af1c1e276",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-09-30T22:26:13.672Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "0645f80f-7f31-4a3c-a29a-c3878c12818b",
-      "47df0ca1-3d96-4edf-a76d-0a32e2e49995"
-    ],
-    "type": "duplicate",
-    "id": "b3a52e39-4632-4922-ad98-e3bbfeb1209d",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-10-31T22:34:43.943Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "cc0c21e0-f6a6-477c-a8c7-4d2e1787cddd",
-      "7ff77c32-2e9b-450d-bfe5-564bd4188c4b"
-    ],
-    "type": "duplicate",
-    "id": "a5fabc68-d442-4ee9-af87-80025e1b05a4",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-06-20T17:03:12.517Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "1e196e70-6460-4578-ba48-1b7ffa8470c4",
-      "8c3bc239-cbb1-49ec-948a-8113cae19786"
-    ],
-    "type": "duplicate",
-    "id": "3c1edc74-a8b7-4427-b577-a82abe2535a2",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-06-25T23:25:02.512Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "df0f51fc-f794-45d1-a440-e9f673698702",
-      "52a03bd7-1dc6-4798-a7fc-17796a5f331c"
-    ],
-    "type": "duplicate",
-    "id": "ba520c6d-8472-4393-9276-ec508cc91e79",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-08-22T16:01:50.652Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "664d581b-cef2-4c69-8dd0-477baaa7dda4",
-      "13bd8573-a5fd-4ae9-be78-8213dac24d86"
-    ],
-    "type": "duplicate",
-    "id": "e1ccb0ea-ae59-4fd0-90fa-76c236f891ef",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-08-26T07:24:01.142Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "740b1620-5c16-48c6-b4ac-bbc614a56084"
-    ],
-    "type": "forgotten",
-    "id": "d02d7c08-d7dc-4cf6-899d-2555a6933e8a",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-11-14T12:11:23.489Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "f199d8b6-9983-4279-b4c6-c9716fb739ed",
-      "b43899a1-7677-445b-adca-b78f9c44175d"
-    ],
-    "type": "duplicate",
-    "id": "534c705c-73ff-4268-99b1-d929a04a6abd",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-09-23T20:07:10.102Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "e5c54eec-fd0b-406a-b9a1-3fe0d8765e2a"
-    ],
-    "type": "forgotten",
-    "id": "7bc43b98-142f-48b8-b598-05079011d8b9",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-09-23T17:13:29.186Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "78fd6b93-69bb-4857-83a7-ab7564bba1ce"
-    ],
-    "type": "forgotten",
-    "id": "c62c9b35-9846-4278-9cda-2aad6dde9f51",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-08-31T12:15:37.747Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "a4e86140-54ad-474e-aae2-b03ad747162f"
-    ],
-    "type": "forgotten",
-    "id": "dd23479f-0e0d-4edc-88be-baca54c3514b",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-10-25T23:46:47.825Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "395b1a15-169c-4c01-bf23-08252d9785a9"
-    ],
-    "type": "forgotten",
-    "id": "d3f39eec-004c-4166-a7d2-5b6f4895e003",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-10-08T04:35:01.071Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "2dad3c95-0239-44e5-9f41-5b1b2773f6a9",
-      "f90a5e57-c348-423e-8568-a193d1fa99d5"
-    ],
-    "type": "duplicate",
-    "id": "cdcf19d3-18d9-4288-9256-8c2804893a47",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-06-08T21:21:06.014Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "0edc4fc6-0f75-4389-9a33-d470342ff8d6"
-    ],
-    "type": "forgotten",
-    "id": "4433d0a8-e8ee-4dc2-9475-6a500558e2a8",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-09-07T16:22:49.244Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">6 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "4b2771d2-273f-4ef6-b040-c33d681271b3"
-    ],
-    "type": "forgotten",
-    "id": "48d10d1c-e305-446f-bcf6-20d369f52c89",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-11-10T08:24:16.848Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "73c3fe4a-622c-495f-89dc-22506f2ab308"
-    ],
-    "type": "forgotten",
-    "id": "cbdef209-820d-45b4-90d3-12a328248e4b",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-10-17T04:04:41.359Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "738658b6-236a-439c-b648-e450d5042e58",
-      "8ad3bc68-9f80-4a4e-bb0f-d6b975d981d7"
-    ],
-    "type": "duplicate",
-    "id": "44701f6d-8270-4ca3-9141-c9665547ca77",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-09-06T00:42:20.485Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "51164a14-b2a6-4ce0-b199-a9ec469d7a5a"
-    ],
-    "type": "forgotten",
-    "id": "c9ead537-5a5b-410c-927e-b23a7a7617de",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-10-11T11:59:01.846Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "ac3c78ba-3a6b-481f-9e13-896dc9dc764f",
-      "5ba37696-2c2b-49ea-adb0-1b600a86851a"
-    ],
-    "type": "duplicate",
-    "id": "0ea0c2f8-8b8e-4591-989b-e67afd258537",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-11-03T01:05:42.407Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">8 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "534bf1d8-9664-482d-aa2a-32a769714e51"
-    ],
-    "type": "forgotten",
-    "id": "e6c04f71-06a0-4d2b-86fc-c1ce72c4eab7",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-08-13T13:31:25.631Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "fb813148-feb1-49b1-b357-2b2631ed275f",
-      "851c5fe3-bbbd-4082-b27d-ee59f39bcaa6"
-    ],
-    "type": "duplicate",
-    "id": "c4cc5293-89cf-4d39-af95-36ea01e1dfe7",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-07-16T09:35:03.157Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "9634d18a-897c-42b5-9809-e3ecc072b98a",
-      "789be390-9bdb-41f3-b98a-7c163a78b3e7"
-    ],
-    "type": "duplicate",
-    "id": "a3b751af-5ae4-4b54-bec9-d45c5a54def8",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-10-17T22:04:41.006Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "36f25e9d-a6d1-4dc3-82f5-3d8358a7e01b",
-      "326edad8-4c59-4d80-838c-c07ec60a5adc"
-    ],
-    "type": "duplicate",
-    "id": "2a9b3806-d47b-4876-bdfa-2b3a1a1a73ed",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-06-12T05:00:15.504Z"
+    "date": "2022-07-07T13:34:53.270Z"
   },
   {
     "title": "This trainee may have been forgotten",
     "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">7 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
     "traineeCount": 1,
     "trainees": [
-      "298fe48f-5f80-4fe7-827a-b245a3c9f85c"
+      "691acb4e-4f0b-46d4-a372-da45009eff7b"
     ],
     "type": "forgotten",
-    "id": "896e8bb9-d222-4438-92c9-9636745c41cf",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-06-26T07:05:15.882Z"
+    "id": "aea86549-4598-4ced-a5e2-df9aff60da15",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-06-30T06:05:44.421Z"
   },
   {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "3fb78d32-8e7f-4639-9ff6-2ebf15c4ffe2"
-    ],
-    "type": "forgotten",
-    "id": "8cdd282b-a7e6-460e-8a6e-1496446630d6",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-09-08T16:53:04.952Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
+    "title": "These trainees appear to be duplicates",
+    "description": "Review these trainees and either withdraw one, or email us with an action to take",
     "traineeCount": 2,
     "trainees": [
-      "5f59f560-ab89-4619-9e57-b5bf34d835c3",
-      "71ef60b8-ccd6-40eb-8c89-7225ba3caefa"
+      "c6e70c3f-5ba4-48f8-b27a-7fdd3dfeb4a3",
+      "975e93e9-76e2-426e-8cdc-bf477611f826"
     ],
     "type": "duplicate",
-    "id": "e6f96b09-ca10-4aeb-87f4-999caaa4cca9",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-10-22T03:22:11.034Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "75262373-2518-40a7-a378-e71a2828cdbd"
-    ],
-    "type": "forgotten",
-    "id": "35094095-51bb-4337-b153-fb1dd9566154",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-11-13T18:04:28.807Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "2605f5e8-1a28-4e6f-bdf5-5bde9cdf7e48",
-      "574845b5-e433-4054-b8cd-4242e27e72e9"
-    ],
-    "type": "duplicate",
-    "id": "8e7a0edc-eca0-4b52-8fc4-dae9bbf86c27",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-06-25T13:38:42.934Z"
+    "id": "57916d48-a8df-4a32-8631-2da823f9e289",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-06-18T19:59:47.845Z"
   },
   {
     "title": "This trainee may have been forgotten",
     "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
     "traineeCount": 1,
     "trainees": [
-      "354e9246-389f-41e2-944c-a0856b231591"
+      "04ad18c1-4cc2-4d3d-a979-0dc1f07fc6b4"
     ],
     "type": "forgotten",
-    "id": "a3a4203e-0a54-4ce4-b61d-3d438b007705",
+    "id": "9e15922f-ee7c-48d1-b83e-3f536da0922d",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-07-29T22:27:37.743Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">6 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "fe42ccaa-fc0d-44fa-b92c-3e87d93ab46d"
+    ],
+    "type": "forgotten",
+    "id": "7dddd5f2-ca3b-46de-aac7-d0784f9639d5",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-11-04T12:45:59.801Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "2a4f4dc6-8653-4499-ae5c-22d2cdb5a3de"
+    ],
+    "type": "forgotten",
+    "id": "db0e7006-2c30-4cc9-9521-6eb837456169",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-11-17T16:16:45.049Z"
+  },
+  {
+    "title": "This draft appears to be a duplicate",
+    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
+    "traineeCount": 2,
+    "trainees": [
+      "7d12863c-d676-4e6c-8cf0-eecb4fbfc8c4",
+      "122cfc26-7f22-4b3f-b653-d2f945b96842"
+    ],
+    "type": "duplicate",
+    "id": "81d6d44c-7bc9-4252-ba2e-0cfa8c814906",
     "provider": "The John Taylor SCITT",
-    "date": "2022-07-22T05:50:24.229Z"
+    "date": "2022-09-16T10:38:41.398Z"
+  },
+  {
+    "title": "These trainees appear to be duplicates",
+    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "traineeCount": 2,
+    "trainees": [
+      "0edc4fc6-0f75-4389-9a33-d470342ff8d6",
+      "6e3c75e5-7d3c-4216-8404-dec59df4c2cb"
+    ],
+    "type": "duplicate",
+    "id": "8107c5f7-9c88-46a2-b63c-a2f849225255",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-11-16T17:34:38.634Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "12c09449-0a48-42a8-9d5c-aaa6cd882512"
+    ],
+    "type": "forgotten",
+    "id": "33bef3df-ce1a-492f-ac77-9600715885e2",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-05-29T18:50:47.673Z"
+  },
+  {
+    "title": "These trainees appear to be duplicates",
+    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "traineeCount": 2,
+    "trainees": [
+      "096ac33a-dc14-434b-8a6a-bce8812acaec",
+      "75262373-2518-40a7-a378-e71a2828cdbd"
+    ],
+    "type": "duplicate",
+    "id": "66769bd4-188e-486d-9420-96b722ce4460",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-09-20T05:05:54.064Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "f64ba7e1-4b14-4111-b1ad-8916492062ae"
+    ],
+    "type": "forgotten",
+    "id": "3174c702-a1b8-4447-8008-bd973f39ea12",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-07-23T17:03:45.448Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">8 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "9634d18a-897c-42b5-9809-e3ecc072b98a"
+    ],
+    "type": "forgotten",
+    "id": "7bbd7054-015b-44d6-9d38-621fd349508c",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-07-07T06:03:44.155Z"
   }
 ]

--- a/app/data/trainee-problems.json
+++ b/app/data/trainee-problems.json
@@ -67,1941 +67,722 @@
     "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
     "traineeCount": 1,
     "trainees": [
-      "ccb27f98-1fcb-47a4-b78b-ecc602e08f0f"
+      "79a198cf-cd49-4507-b457-d9a2b9ddd501"
     ],
     "type": "forgotten",
     "id": "c4b1fdf1-7ca8-442a-ad19-4078a59f56b0",
     "provider": "University of Lincoln",
-    "date": "2022-08-14T16:23:24.830Z"
+    "date": "2022-09-03T03:08:05.355Z"
   },
   {
     "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">10 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
     "traineeCount": 1,
     "trainees": [
-      "e910165e-93f4-4750-8efa-7c71868b41bf"
+      "647c73cd-3f2c-4a02-a8d6-b7c06e069bb4"
     ],
     "type": "forgotten",
     "id": "2caf1de0-12b7-4718-badc-5acc8390251c",
     "provider": "University of Lincoln",
-    "date": "2022-10-13T23:39:55.292Z"
+    "date": "2022-11-02T18:38:53.094Z"
   },
   {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "title": "This draft appears to be a duplicate",
+    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
     "traineeCount": 2,
     "trainees": [
-      "0275a621-a4ab-46c1-8542-e7f6df44c2a2",
-      "6c3dad10-586b-4a6a-8e2b-7a1fed6bbe2c"
+      "45f61cc8-6c00-4bb6-b1d6-31851ab4ab4e",
+      "b4aa9ffe-b1b7-48b8-aad4-fae9aec6f685"
     ],
     "type": "duplicate",
     "id": "b883e78c-8662-4c91-92bc-5ea89b0320f9",
     "provider": "University of Lincoln",
-    "date": "2022-10-07T12:20:28.142Z"
+    "date": "2022-10-27T06:26:23.070Z"
   },
   {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "title": "This draft appears to be a duplicate",
+    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
     "traineeCount": 2,
     "trainees": [
-      "65983526-4845-4bf3-ab36-8117856de5d4",
-      "a69753b3-69ee-43ac-9cfa-55ae9afefd7a"
+      "43fcc289-c721-460f-8e14-afcc4e75f4ce",
+      "73679b2d-4d4e-41cd-997c-158fc6e713e9"
     ],
     "type": "duplicate",
     "id": "7c62bb31-85a2-411f-9a21-55fe18ce3471",
     "provider": "University of Lincoln",
-    "date": "2022-07-10T18:48:34.691Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "22dad6c2-60a9-4889-8127-d575617a981a",
-      "e5c38e59-2029-4d5c-9282-5bcac2bf6075"
-    ],
-    "type": "duplicate",
-    "id": "f928da91-024e-4a6a-b665-2b199ce906bc",
-    "provider": "University of Lincoln",
-    "date": "2022-09-06T20:34:23.821Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "d88eed60-17cf-4c0b-a435-1a5616abc654",
-      "b6af0f4a-4da2-47da-98c9-36c937f3db7b"
-    ],
-    "type": "duplicate",
-    "id": "b4040a4b-c95b-4872-8482-3ea536415639",
-    "provider": "University of Lincoln",
-    "date": "2022-09-23T12:33:08.798Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "58a0f974-4f8c-475e-9834-7506eb27d349",
-      "80f88902-7456-4bc9-8379-3ec1c47d4465"
-    ],
-    "type": "duplicate",
-    "id": "d31d49ca-31db-48a6-af4c-400b7bd2c68b",
-    "provider": "University of Lincoln",
-    "date": "2022-04-28T08:53:22.577Z"
+    "date": "2022-07-30T00:47:11.679Z"
   },
   {
     "title": "This trainee may have been forgotten",
     "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
     "traineeCount": 1,
     "trainees": [
-      "a69753b3-69ee-43ac-9cfa-55ae9afefd7a"
+      "197e029b-2c63-494f-996b-224a23627d8c"
     ],
     "type": "forgotten",
-    "id": "ed092783-2aaa-4c73-9083-c8b0801b8b79",
+    "id": "f928da91-024e-4a6a-b665-2b199ce906bc",
     "provider": "University of Lincoln",
-    "date": "2022-08-24T13:46:23.601Z"
+    "date": "2022-09-26T10:29:01.540Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "02563af3-662b-46fe-96e3-512030374dc8"
+    ],
+    "type": "forgotten",
+    "id": "b4040a4b-c95b-4872-8482-3ea536415639",
+    "provider": "University of Lincoln",
+    "date": "2022-10-13T04:44:22.812Z"
   },
   {
     "title": "This trainee may have been forgotten",
     "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
     "traineeCount": 1,
     "trainees": [
-      "ffaf27f0-e4d4-4d19-8f11-a017ff9a8e74"
+      "afb4f05d-8bd1-41c8-b542-0e170db8c0cf"
+    ],
+    "type": "forgotten",
+    "id": "d31d49ca-31db-48a6-af4c-400b7bd2c68b",
+    "provider": "University of Lincoln",
+    "date": "2022-05-17T04:50:14.649Z"
+  },
+  {
+    "title": "These trainees appear to be duplicates",
+    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "traineeCount": 2,
+    "trainees": [
+      "fb2552e5-e989-48a1-9e1b-f7525d8a8386",
+      "f5b6bd59-2553-4dbc-8b75-d59366fe8587"
+    ],
+    "type": "duplicate",
+    "id": "ed092783-2aaa-4c73-9083-c8b0801b8b79",
+    "provider": "King’s Oak University",
+    "date": "2022-09-13T01:52:08.532Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "56146959-76f2-40b7-b153-5fe04027d90a"
     ],
     "type": "forgotten",
     "id": "0967b181-e201-4e0a-af49-f4a8a24b78a7",
-    "provider": "University of Lincoln",
-    "date": "2022-09-30T21:41:50.837Z"
+    "provider": "King’s Oak University",
+    "date": "2022-10-20T14:53:34.871Z"
   },
   {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "title": "This draft appears to be a duplicate",
+    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
     "traineeCount": 2,
     "trainees": [
-      "7b490972-5988-4e76-8356-81bbd36751f6",
-      "a3149b25-8436-4a0c-9071-ef5a04b3967f"
+      "dd64dc31-4e5b-43f1-8782-a153edad3c6a",
+      "cc88e233-20fe-418d-907c-0495ac1e0bcc"
     ],
     "type": "duplicate",
     "id": "ec0ec805-4928-4a77-9802-c08b972cbeaf",
-    "provider": "University of Lincoln",
-    "date": "2022-07-24T07:44:50.195Z"
+    "provider": "King’s Oak University",
+    "date": "2022-08-12T15:34:25.743Z"
   },
   {
     "title": "These trainees appear to be duplicates",
     "description": "Review these trainees and either withdraw one, or email us with an action to take",
     "traineeCount": 2,
     "trainees": [
-      "d8e3d206-bd9b-489c-8c4a-057718fa6fdb",
-      "31b8db94-9ea2-431a-8a3d-4343e16aed94"
+      "4eb7945f-a1ee-4d0e-a314-396470b49366",
+      "a95d471c-9a7c-4a4c-9db2-2c75211200f0"
     ],
     "type": "duplicate",
     "id": "5e383560-b8ff-4bda-a613-892321bb4255",
-    "provider": "University of Lincoln",
-    "date": "2022-06-09T08:09:07.829Z"
+    "provider": "King’s Oak University",
+    "date": "2022-06-28T09:50:00.529Z"
   },
   {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "title": "This draft appears to be a duplicate",
+    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
     "traineeCount": 2,
     "trainees": [
-      "ca825dd5-934c-4ebb-8629-cc51ac049623",
-      "17781775-6aea-48c4-86a7-1aeb54be5040"
+      "73016340-9904-4378-822a-83cc7403fe74",
+      "90916ab4-74b5-467b-9971-54d282b21176"
     ],
     "type": "duplicate",
     "id": "98dcbe3a-5640-47e0-8c86-c85a89dee36a",
-    "provider": "University of Lincoln",
-    "date": "2022-09-03T01:01:25.609Z"
+    "provider": "King’s Oak University",
+    "date": "2022-09-22T14:24:47.318Z"
   },
   {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
+    "title": "This draft appears to be a duplicate",
+    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
+    "traineeCount": 2,
     "trainees": [
-      "91747556-c40f-45f5-9d7d-5a6f2b16f673"
+      "a2f8b8aa-553f-4950-9e86-03a617cf23f1",
+      "2f77332c-5188-47fd-8dc4-da49093d182b"
     ],
-    "type": "forgotten",
+    "type": "duplicate",
     "id": "891db79e-bf23-4ce8-9f0f-10ec55c4d248",
-    "provider": "University of Lincoln",
-    "date": "2022-07-03T20:45:27.398Z"
+    "provider": "King’s Oak University",
+    "date": "2022-07-23T01:47:21.682Z"
   },
   {
     "title": "This trainee may have been forgotten",
     "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
     "traineeCount": 1,
     "trainees": [
-      "125d76ff-3d08-47ff-bbde-56ed53ffdc46"
+      "3dcf29db-0e9c-4e21-9b1e-c378b62adc22"
     ],
     "type": "forgotten",
     "id": "f60db38f-b5a3-453a-9605-3f1bf3aff0b1",
-    "provider": "University of Lincoln",
-    "date": "2022-08-19T03:27:53.869Z"
+    "provider": "King’s Oak University",
+    "date": "2022-09-07T14:49:08.548Z"
   },
   {
     "title": "This trainee may have been forgotten",
     "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
     "traineeCount": 1,
     "trainees": [
-      "611d34fa-6b49-4065-a12c-08b89f909081"
+      "5bf5a939-f21f-4cfc-981a-ef417b361cdc"
     ],
     "type": "forgotten",
     "id": "11141ee4-3fe6-43e8-8488-43977e0fe7f8",
-    "provider": "University of Lincoln",
-    "date": "2022-10-05T13:23:51.826Z"
+    "provider": "King’s Oak University",
+    "date": "2022-10-25T07:13:44.800Z"
   },
   {
     "title": "These trainees appear to be duplicates",
     "description": "Review these trainees and either withdraw one, or email us with an action to take",
     "traineeCount": 2,
     "trainees": [
-      "955e34b8-3278-485a-b357-840af96f46a6",
-      "7a7b25b4-d0cd-4658-af81-2688ca67e572"
+      "db8b2df8-1ab9-4348-b191-1432da41508f",
+      "116e7d87-ee72-4faa-8956-596865bae972"
     ],
     "type": "duplicate",
     "id": "2f3bf7fc-fa0a-48ea-81ed-c0037a7cf2a0",
-    "provider": "University of Lincoln",
-    "date": "2022-07-03T12:11:06.733Z"
+    "provider": "King’s Oak University",
+    "date": "2022-07-22T17:10:05.352Z"
   },
   {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
+    "title": "These trainees appear to be duplicates",
+    "description": "Review these trainees and either withdraw one, or email us with an action to take",
     "traineeCount": 2,
     "trainees": [
-      "09a1fa25-3cd7-4f17-9dba-eac462bda75e",
-      "4a6744f9-67ea-4725-a86b-223e8ad78639"
+      "2d5a529d-ca6c-43aa-b9f2-4d6c8e13b271",
+      "62434155-e7c1-4cfa-a3b2-2147c04feafa"
     ],
     "type": "duplicate",
     "id": "e845f8f5-30d8-4d70-ae90-404f822847fe",
-    "provider": "University of Lincoln",
-    "date": "2022-06-17T08:17:22.848Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">7 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "59dd7bd4-0e8d-46eb-9e01-3071eba7023c"
-    ],
-    "type": "forgotten",
-    "id": "aea86549-4598-4ced-a5e2-df9aff60da15",
-    "provider": "University of Lincoln",
-    "date": "2022-06-10T01:47:49.666Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "362e3e05-e5f7-45ae-8b03-2570d8c50f9d"
-    ],
-    "type": "forgotten",
-    "id": "57916d48-a8df-4a32-8631-2da823f9e289",
-    "provider": "University of Lincoln",
-    "date": "2022-05-29T17:14:58.083Z"
+    "provider": "King’s Oak University",
+    "date": "2022-07-06T11:03:52.788Z"
   },
   {
     "title": "These trainees appear to be duplicates",
     "description": "Review these trainees and either withdraw one, or email us with an action to take",
     "traineeCount": 2,
     "trainees": [
-      "edaaa645-49e3-4271-99ba-3b1b26a3c130",
-      "3a138af5-6955-4c14-b6e2-4d5749c41f0b"
+      "1bd979a7-0529-441a-a407-41db9936bd2c",
+      "07f78381-ef08-4ab9-a677-5fe7efaa823b"
+    ],
+    "type": "duplicate",
+    "id": "aea86549-4598-4ced-a5e2-df9aff60da15",
+    "provider": "King’s Oak University",
+    "date": "2022-06-29T03:34:43.938Z"
+  },
+  {
+    "title": "This draft appears to be a duplicate",
+    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
+    "traineeCount": 2,
+    "trainees": [
+      "f7d62ed0-8b97-43fe-82cf-7aa325f272c0",
+      "f25b51e8-8f3b-4f63-9ffe-ed41ec964157"
+    ],
+    "type": "duplicate",
+    "id": "57916d48-a8df-4a32-8631-2da823f9e289",
+    "provider": "King’s Oak University",
+    "date": "2022-06-17T17:28:47.362Z"
+  },
+  {
+    "title": "These trainees appear to be duplicates",
+    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "traineeCount": 2,
+    "trainees": [
+      "1e77859f-25f2-49bc-9055-5d3fd636d2ad",
+      "e229a8d3-8cd6-40fc-afc5-28a484e9c436"
     ],
     "type": "duplicate",
     "id": "9e15922f-ee7c-48d1-b83e-3f536da0922d",
-    "provider": "University of Lincoln",
-    "date": "2022-07-09T14:07:47.969Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "6816b85d-74e9-4e8d-aede-ef6d9a529705",
-      "8fad53ef-693b-47e0-a2cc-5780b0ac075c"
-    ],
-    "type": "duplicate",
-    "id": "7dddd5f2-ca3b-46de-aac7-d0784f9639d5",
-    "provider": "University of Lincoln",
-    "date": "2022-10-14T15:10:43.615Z"
-  },
-  {
-    "title": "Confirm the deferral is still correct",
-    "description": "This trainee has been deferred for <span class=\"govuk-!-font-weight-bold\">5 years</span>.\n      If the trainee is still deferred, please update their expected end date. If they have left the course you should withdraw them.",
-    "traineeCount": 1,
-    "trainees": [
-      "25f682d4-911a-492d-8d72-9e0124ecc8df"
-    ],
-    "type": "deferredForgotten",
-    "id": "db0e7006-2c30-4cc9-9521-6eb837456169",
-    "provider": "University of Lincoln",
-    "date": "2022-10-27T16:54:20.038Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "e910165e-93f4-4750-8efa-7c71868b41bf",
-      "d1019107-4915-45f1-b473-bbcdfd6cbdd9"
-    ],
-    "type": "duplicate",
-    "id": "81d6d44c-7bc9-4252-ba2e-0cfa8c814906",
-    "provider": "University of Lincoln",
-    "date": "2022-08-26T19:43:30.412Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "5f50293a-8442-4a29-9505-5195532f62e2",
-      "ea65fadc-4615-4740-b45c-cf60c8a0b744"
-    ],
-    "type": "duplicate",
-    "id": "8107c5f7-9c88-46a2-b63c-a2f849225255",
     "provider": "King’s Oak University",
-    "date": "2022-10-26T18:19:56.193Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "e2beca3c-4408-4c0c-bf78-0fa2995939da",
-      "da15ea8f-8f86-4169-9e65-1668badb72b3"
-    ],
-    "type": "duplicate",
-    "id": "33bef3df-ce1a-492f-ac77-9600715885e2",
-    "provider": "King’s Oak University",
-    "date": "2022-05-09T18:49:21.739Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "cb689a26-f817-47e2-b3c3-42d5e825d2f4",
-      "5ef27395-e5b4-4c9c-996c-30ab0625f355"
-    ],
-    "type": "duplicate",
-    "id": "66769bd4-188e-486d-9420-96b722ce4460",
-    "provider": "King’s Oak University",
-    "date": "2022-08-30T13:40:00.016Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "93996aaa-342e-4338-8ded-9475520bccc9"
-    ],
-    "type": "forgotten",
-    "id": "3174c702-a1b8-4447-8008-bd973f39ea12",
-    "provider": "King’s Oak University",
-    "date": "2022-07-03T09:34:39.784Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "2f8dd797-2b02-4b3f-867e-02942a4680c1",
-      "00a64773-973a-4d79-813e-86b72d07c96b"
-    ],
-    "type": "duplicate",
-    "id": "7bbd7054-015b-44d6-9d38-621fd349508c",
-    "provider": "King’s Oak University",
-    "date": "2022-06-17T00:48:46.946Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "41222b76-1e05-42c6-a642-5672386ea785",
-      "90044b6c-64d2-4734-9b99-123eb0ce620b"
-    ],
-    "type": "duplicate",
-    "id": "302dcaf1-ee25-4184-8651-dfc14c372fe0",
-    "provider": "King’s Oak University",
-    "date": "2022-05-21T21:24:16.190Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "05713eed-dba2-41b1-85b5-3ad9dd4d6a25",
-      "3c84c7a2-c19c-4b5a-ab63-7bb16ab4f598"
-    ],
-    "type": "duplicate",
-    "id": "ac0a6762-b321-4019-a558-f85af1c1e276",
-    "provider": "King’s Oak University",
-    "date": "2022-09-11T07:54:56.313Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "faa6a6ab-4732-4476-abda-5079686db248",
-      "29e0fc9d-535e-47ed-ba3e-8647d0d6bf55"
-    ],
-    "type": "duplicate",
-    "id": "b3a52e39-4632-4922-ad98-e3bbfeb1209d",
-    "provider": "King’s Oak University",
-    "date": "2022-10-12T03:50:44.086Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "a3e2b980-5cdf-49b3-bd6f-05352e3d77d2",
-      "fadced7e-4e41-4b53-b6c0-f5d8ad1c2c1e"
-    ],
-    "type": "duplicate",
-    "id": "a5fabc68-d442-4ee9-af87-80025e1b05a4",
-    "provider": "King’s Oak University",
-    "date": "2022-06-01T16:25:04.864Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">9 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "3c84c7a2-c19c-4b5a-ab63-7bb16ab4f598"
-    ],
-    "type": "forgotten",
-    "id": "3c1edc74-a8b7-4427-b577-a82abe2535a2",
-    "provider": "King’s Oak University",
-    "date": "2022-06-06T22:04:00.092Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "1b2b2d0e-f909-4442-b32b-99f6a8c97b9a"
-    ],
-    "type": "forgotten",
-    "id": "ba520c6d-8472-4393-9276-ec508cc91e79",
-    "provider": "King’s Oak University",
-    "date": "2022-08-03T06:50:35.601Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "21077fee-c2ce-49c0-af43-7bd68bef6731",
-      "10543dd9-c625-416e-ad30-36cdd28f030d"
-    ],
-    "type": "duplicate",
-    "id": "e1ccb0ea-ae59-4fd0-90fa-76c236f891ef",
-    "provider": "King’s Oak University",
-    "date": "2022-08-06T21:43:05.863Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "74fdd046-427d-496c-9d4b-d4c6eac978ed",
-      "9637903c-27e6-4a82-bb5c-893168eb5dd0"
-    ],
-    "type": "duplicate",
-    "id": "d02d7c08-d7dc-4cf6-899d-2555a6933e8a",
-    "provider": "King’s Oak University",
-    "date": "2022-10-25T15:36:49.043Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "3a80a5d3-0466-4c38-9f05-adbcf3792ae4",
-      "11e12da4-720c-40c4-8289-c1f75396ecf8"
-    ],
-    "type": "duplicate",
-    "id": "534c705c-73ff-4268-99b1-d929a04a6abd",
-    "provider": "King’s Oak University",
-    "date": "2022-09-04T06:33:43.107Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "e8f79ac1-4fb6-4d39-961a-1d5944bc427d"
-    ],
-    "type": "forgotten",
-    "id": "7bc43b98-142f-48b8-b598-05079011d8b9",
-    "provider": "King’s Oak University",
-    "date": "2022-09-04T03:41:01.176Z"
-  },
-  {
-    "title": "Confirm the deferral is still correct",
-    "description": "This trainee has been deferred for <span class=\"govuk-!-font-weight-bold\">4 years</span>.\n      If the trainee is still deferred, please update their expected end date. If they have left the course you should withdraw them.",
-    "traineeCount": 1,
-    "trainees": [
-      "a5a1c7b4-26de-440d-9cfe-57f2a11f8c20"
-    ],
-    "type": "deferredForgotten",
-    "id": "c62c9b35-9846-4278-9cda-2aad6dde9f51",
-    "provider": "King’s Oak University",
-    "date": "2022-08-12T01:52:18.343Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "67fd39b6-dd2b-4c22-9e50-6d2553675f7d"
-    ],
-    "type": "forgotten",
-    "id": "dd23479f-0e0d-4edc-88be-baca54c3514b",
-    "provider": "King’s Oak University",
-    "date": "2022-10-06T05:51:17.619Z"
-  },
-  {
-    "title": "Confirm the deferral is still correct",
-    "description": "This trainee has been deferred for <span class=\"govuk-!-font-weight-bold\">5 years</span>.\n      If the trainee is still deferred, please update their expected end date. If they have left the course you should withdraw them.",
-    "traineeCount": 1,
-    "trainees": [
-      "b4c6146d-21da-4922-a037-da91b01a80ed"
-    ],
-    "type": "deferredForgotten",
-    "id": "d3f39eec-004c-4166-a7d2-5b6f4895e003",
-    "provider": "King’s Oak University",
-    "date": "2022-09-18T13:04:35.338Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "22099dcf-4475-47de-960a-4bc65bdee060",
-      "d8a4077b-82ea-47ad-962c-e054ed8537fb"
-    ],
-    "type": "duplicate",
-    "id": "cdcf19d3-18d9-4288-9256-8c2804893a47",
-    "provider": "King’s Oak University",
-    "date": "2022-05-20T22:19:19.021Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "031ef8bd-15a8-41fe-b333-d8499624534f"
-    ],
-    "type": "forgotten",
-    "id": "4433d0a8-e8ee-4dc2-9475-6a500558e2a8",
-    "provider": "King’s Oak University",
-    "date": "2022-08-19T05:01:02.748Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "4e1f4ae2-7aec-4e5b-bc7d-cbc12f5409a3",
-      "8614265f-aa83-4e9b-b34d-fcddb113415c"
-    ],
-    "type": "duplicate",
-    "id": "48d10d1c-e305-446f-bcf6-20d369f52c89",
-    "provider": "King’s Oak University",
-    "date": "2022-10-21T12:23:35.600Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "5864aa75-9d99-4ad7-9537-0bd1d814d8f1",
-      "be16e643-c4de-4ca7-af74-0001606eb0ac"
-    ],
-    "type": "duplicate",
-    "id": "cbdef209-820d-45b4-90d3-12a328248e4b",
-    "provider": "King’s Oak University",
-    "date": "2022-09-27T11:21:04.740Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "b69ebe1e-2db0-4946-a519-b4c67eef08f8",
-      "07424207-7913-4bb9-ac56-15dbddb2dee3"
-    ],
-    "type": "duplicate",
-    "id": "44701f6d-8270-4ca3-9141-c9665547ca77",
-    "provider": "King’s Oak University",
-    "date": "2022-08-17T13:34:02.390Z"
-  },
-  {
-    "title": "Confirm the deferral is still correct",
-    "description": "This trainee has been deferred for <span class=\"govuk-!-font-weight-bold\">3 years</span>.\n      If the trainee is still deferred, please update their expected end date. If they have left the course you should withdraw them.",
-    "traineeCount": 1,
-    "trainees": [
-      "552f2302-6eb6-48d7-8594-8864f436377d"
-    ],
-    "type": "deferredForgotten",
-    "id": "c9ead537-5a5b-410c-927e-b23a7a7617de",
-    "provider": "King’s Oak University",
-    "date": "2022-09-21T20:01:38.261Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">9 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "1461d90b-c81b-48c2-b03d-e48c9d8f176f"
-    ],
-    "type": "forgotten",
-    "id": "0ea0c2f8-8b8e-4591-989b-e67afd258537",
-    "provider": "King’s Oak University",
-    "date": "2022-10-14T06:04:33.236Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "16f59034-5329-4996-a3c8-452faec7e98b",
-      "5d915f0c-89e5-400e-bf4b-5ffd38930a57"
-    ],
-    "type": "duplicate",
-    "id": "e6c04f71-06a0-4d2b-86fc-c1ce72c4eab7",
-    "provider": "King’s Oak University",
-    "date": "2022-07-25T05:34:22.831Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "025f5e08-b741-4e05-818a-1ebe31789503"
-    ],
-    "type": "forgotten",
-    "id": "c4cc5293-89cf-4d39-af95-36ea01e1dfe7",
-    "provider": "King’s Oak University",
-    "date": "2022-06-27T05:27:33.180Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "01da9ae1-5852-4c72-8da3-d5f33173b2b8"
-    ],
-    "type": "forgotten",
-    "id": "a3b751af-5ae4-4b54-bec9-d45c5a54def8",
-    "provider": "King’s Oak University",
-    "date": "2022-09-28T05:14:57.624Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "1da00293-37d9-485a-b0ab-500e56fafdf2"
-    ],
-    "type": "forgotten",
-    "id": "2a9b3806-d47b-4876-bdfa-2b3a1a1a73ed",
-    "provider": "King’s Oak University",
-    "date": "2022-05-24T05:31:25.516Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "bc5dca24-98f3-4438-a291-21149aaa851d",
-      "aa764eb2-00d2-4d57-afdc-c066d491ef71"
-    ],
-    "type": "duplicate",
-    "id": "896e8bb9-d222-4438-92c9-9636745c41cf",
-    "provider": "King’s Oak University",
-    "date": "2022-06-07T05:41:37.166Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "f48037e4-359d-4f58-aeea-b4c0134d3507",
-      "87977949-e2cf-44aa-9c96-1b82ee44ab75"
-    ],
-    "type": "duplicate",
-    "id": "8cdd282b-a7e6-460e-8a6e-1496446630d6",
-    "provider": "King’s Oak University",
-    "date": "2022-08-20T05:22:59.159Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "ea65fadc-4615-4740-b45c-cf60c8a0b744"
-    ],
-    "type": "forgotten",
-    "id": "e6f96b09-ca10-4aeb-87f4-999caaa4cca9",
-    "provider": "King’s Oak University",
-    "date": "2022-10-02T09:58:03.752Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "bea3d807-66af-4ec6-88ff-5dd36dd56c8a"
-    ],
-    "type": "forgotten",
-    "id": "35094095-51bb-4337-b153-fb1dd9566154",
-    "provider": "King’s Oak University",
-    "date": "2022-10-24T21:36:03.470Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "8874f9cf-a79f-48a6-b91c-7ce95738724c",
-      "cbe7892c-dc0e-4ba8-b3b9-7d0775eb083c"
-    ],
-    "type": "duplicate",
-    "id": "8e7a0edc-eca0-4b52-8fc4-dae9bbf86c27",
-    "provider": "King’s Oak University",
-    "date": "2022-06-06T12:20:59.628Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "f96bafb5-7c9e-411f-8058-42e9bb7220f6",
-      "088f4e25-aba4-40ad-ba0c-3307d450f1f4"
-    ],
-    "type": "duplicate",
-    "id": "a3a4203e-0a54-4ce4-b61d-3d438b007705",
-    "provider": "King’s Oak University",
-    "date": "2022-07-03T00:55:16.430Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "1d9c12b0-89f2-4eb7-9f97-8cb466574fe5"
-    ],
-    "type": "forgotten",
-    "id": "64c4f04e-ec63-47eb-893c-4d97050b6bc5",
-    "provider": "King’s Oak University",
-    "date": "2022-10-09T14:13:38.278Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "4b568f6e-7607-4804-a124-f3799fd759fd",
-      "395f0512-2f60-428c-9b05-34a0fa6a55d1"
-    ],
-    "type": "duplicate",
-    "id": "a06db0b1-dcb5-4369-983d-c9820b150069",
-    "provider": "King’s Oak University",
-    "date": "2022-10-22T21:06:03.310Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "a2faa0eb-385d-4c33-9b0a-80b9b4fc21b3",
-      "8e6a5fb1-425c-4c1f-8597-830465ef7c53"
-    ],
-    "type": "duplicate",
-    "id": "08c89b03-542d-4671-bcbd-f4c6f0b565f0",
-    "provider": "King’s Oak University",
-    "date": "2022-08-22T20:55:07.157Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "b34c02ea-2d0b-4f7c-8834-17f57969a42b",
-      "300ede8f-079d-403f-84a7-c61ddeec3918"
-    ],
-    "type": "duplicate",
-    "id": "2d993f60-b1df-41fc-b175-68663ca5519f",
-    "provider": "King’s Oak University",
-    "date": "2022-06-22T00:51:42.454Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "96ea1f29-4548-410d-83e6-249ff10bc48c",
-      "cc3a2a36-b7f0-4bac-868e-576360dbeb43"
-    ],
-    "type": "duplicate",
-    "id": "98ab5b16-9447-4c1a-bab9-12b7627a7e7d",
-    "provider": "King’s Oak University",
-    "date": "2022-05-04T22:15:11.984Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "5d915f0c-89e5-400e-bf4b-5ffd38930a57"
-    ],
-    "type": "forgotten",
-    "id": "ffc24bee-e83e-4293-ba80-cdee08224252",
-    "provider": "King’s Oak University",
-    "date": "2022-05-29T22:08:31.020Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "a42316c2-e7e0-4026-9132-05f2514ee4e2"
-    ],
-    "type": "forgotten",
-    "id": "cf2728e1-e5c5-4824-a774-86bbe36b0aee",
-    "provider": "King’s Oak University",
-    "date": "2022-06-03T01:52:31.203Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "5a3b1c4c-0c97-48e1-ae26-23ea41e154b4",
-      "1723e7ed-0b95-4460-83b6-cb3d0a7ab998"
-    ],
-    "type": "duplicate",
-    "id": "f17262fb-efca-4de5-9439-ead51832e05d",
-    "provider": "King’s Oak University",
-    "date": "2022-10-13T19:58:24.866Z"
-  },
-  {
-    "title": "Confirm the deferral is still correct",
-    "description": "This trainee has been deferred for <span class=\"govuk-!-font-weight-bold\">4 years</span>.\n      If the trainee is still deferred, please update their expected end date. If they have left the course you should withdraw them.",
-    "traineeCount": 1,
-    "trainees": [
-      "61033e97-81a8-4ffb-8977-122282b8550f"
-    ],
-    "type": "deferredForgotten",
-    "id": "d6cfb390-934f-4702-ac89-e2e10acab724",
-    "provider": "King’s Oak University",
-    "date": "2022-09-10T11:34:31.888Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "7163f0bd-84fc-4bd9-b516-958896947baf"
-    ],
-    "type": "forgotten",
-    "id": "796fa083-899c-445f-ba6f-996d19379a1d",
-    "provider": "King’s Oak University",
-    "date": "2022-06-12T08:26:53.068Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "5f50293a-8442-4a29-9505-5195532f62e2"
-    ],
-    "type": "forgotten",
-    "id": "873d3eaa-07e6-41cb-a53e-52d5ffe8c0a5",
-    "provider": "King’s Oak University",
-    "date": "2022-05-29T00:44:09.048Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "853472e2-8d34-487d-8985-59479a7950f0",
-      "24261d40-338f-4298-89cd-f1d27c70f9e3"
-    ],
-    "type": "duplicate",
-    "id": "1858e854-3acb-45fa-96e9-ba759884f456",
-    "provider": "King’s Oak University",
-    "date": "2022-05-09T11:06:14.297Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "ac2231bb-46d5-483b-899c-8ef87e86e37e"
-    ],
-    "type": "forgotten",
-    "id": "b5bfc39d-3f73-472e-89c9-39f9b2a417bb",
-    "provider": "King’s Oak University",
-    "date": "2022-08-17T23:23:56.966Z"
-  },
-  {
-    "title": "Confirm the deferral is still correct",
-    "description": "This trainee has been deferred for <span class=\"govuk-!-font-weight-bold\">2 years</span>.\n      If the trainee is still deferred, please update their expected end date. If they have left the course you should withdraw them.",
-    "traineeCount": 1,
-    "trainees": [
-      "0249655d-7c35-44e6-8d14-0de4ac4293af"
-    ],
-    "type": "deferredForgotten",
-    "id": "45fe36b5-bcc7-45fa-ac94-fc925546c46b",
-    "provider": "King’s Oak University",
-    "date": "2022-10-12T07:29:59.151Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "e5845525-3106-4554-bc32-35151412c771"
-    ],
-    "type": "forgotten",
-    "id": "9d77ff31-5012-4006-9ce3-ee91e8fc19ff",
-    "provider": "King’s Oak University",
-    "date": "2022-10-02T03:48:16.023Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "19fc2a76-f484-40b7-abc3-283152fd1913",
-      "165dac91-cf14-47ca-83ee-633f02549a29"
-    ],
-    "type": "duplicate",
-    "id": "39cee9ce-d86c-4dee-bc8a-d5af6022ac99",
-    "provider": "King’s Oak University",
-    "date": "2022-10-21T20:29:06.618Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "c3eccadb-1832-4f32-b517-984992a8927a",
-      "a70f6ac1-902d-4787-a7f8-ebcbf74d818a"
-    ],
-    "type": "duplicate",
-    "id": "01ca58aa-4eba-48d7-b9aa-b4aa1995c6fa",
-    "provider": "King’s Oak University",
-    "date": "2022-07-24T19:20:53.777Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "acf05bd6-2a0f-4c28-9206-e72341dd6fe0"
-    ],
-    "type": "forgotten",
-    "id": "48e158a4-7036-4d1c-85c1-e8369ad6268e",
-    "provider": "King’s Oak University",
-    "date": "2022-05-28T05:46:24.191Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "db4ccfdd-e1da-4b67-ab09-67b443f3b2d8"
-    ],
-    "type": "forgotten",
-    "id": "85e36d4b-fb15-4259-ac78-0514c8d6a370",
-    "provider": "King’s Oak University",
-    "date": "2022-05-18T10:22:16.219Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "c14b7be7-0d25-4e77-b555-a5f1289163b5",
-      "a5c44cd4-9920-49dc-9769-f66729bc185a"
-    ],
-    "type": "duplicate",
-    "id": "ab57ced0-6e10-49e7-8fe8-2ff666880be4",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-08-08T08:51:08.747Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "bba5d15a-4fcd-462f-8efe-a9c5ebe4c8d2"
-    ],
-    "type": "forgotten",
-    "id": "d90fd96d-fd13-4633-99df-9518dec02ace",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-05-16T19:21:25.162Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "9c3d92d5-17f5-473d-aca5-98ffb542c690",
-      "55ff4479-f108-4ba5-b4c9-3d4650c93543"
-    ],
-    "type": "duplicate",
-    "id": "c127c207-b0f6-4ac4-8220-51426da25d33",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-07-20T11:47:20.959Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">9 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "1f800f99-b08a-40e3-9cb8-10e575c29d39"
-    ],
-    "type": "forgotten",
-    "id": "bd04086b-cb41-4f66-8623-792067d6c5eb",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-08-20T02:53:16.320Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "24f35622-42fb-4908-9104-7581c1da4b51"
-    ],
-    "type": "forgotten",
-    "id": "320cdefd-6de2-41f0-ad5e-e5219575cb87",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-06-05T12:32:53.081Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "0f65be36-e6ce-40f9-8eb8-29205064c96e",
-      "d404c767-7600-4918-9cb1-0cd67fa35733"
-    ],
-    "type": "duplicate",
-    "id": "92a534ab-9246-45f1-9b8a-0d0b088dc1b7",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-09-19T19:51:51.704Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">8 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "22c151a9-60d3-4960-bef2-9dc10ad6b368"
-    ],
-    "type": "forgotten",
-    "id": "ceb32a02-ed3f-446f-882d-c751dc50c9ed",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-10-22T19:44:40.384Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "b391ef48-ef23-49e4-9d6c-03d168863bde"
-    ],
-    "type": "forgotten",
-    "id": "ee2518c2-a84e-4a46-8c6b-c1b71561f348",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-08-25T07:25:52.687Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "3ef4b9e6-8b8d-4b0c-afa1-744f213e2e16",
-      "c4d8b6af-dc0b-4047-994f-4e87a1e4e711"
-    ],
-    "type": "duplicate",
-    "id": "cb1d8d6c-7e37-49a4-8158-c64c94017efe",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-07-07T04:23:37.142Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "e9572eba-4491-4bc8-b68b-b91f6e3feeca"
-    ],
-    "type": "forgotten",
-    "id": "d6f2aa13-53b8-4d86-949b-b3d190d8348b",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-08-27T17:39:47.703Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">10 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "bf006f72-d252-4b38-959d-ab2ce5fc33f9"
-    ],
-    "type": "forgotten",
-    "id": "52c1ed27-a9e7-4511-818e-80faa5a5377d",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-05-04T23:16:16.808Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "b1ce4ad6-6594-4050-82c9-e25a4f6c5f39",
-      "9afe3be1-cda9-457b-b607-665d0a1e3352"
-    ],
-    "type": "duplicate",
-    "id": "b3cf0ea2-5c65-4971-9be8-b28f04f00bcc",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-05-10T20:03:04.787Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "3bd80cbd-0f57-44e0-8019-dfc1b1d5dc76"
-    ],
-    "type": "forgotten",
-    "id": "55baff00-89b6-43d9-b312-07b43d46d79b",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-07-12T04:58:34.355Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "0a62fe87-11f8-4e85-89a4-fd974ffa61be",
-      "d44c0a56-288a-4af1-9aac-01e10aee2ed3"
-    ],
-    "type": "duplicate",
-    "id": "8db1c72d-00bb-4b1d-8c52-1c2d5317fa75",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-07-28T00:48:33.711Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "a5faf961-8f4b-46f0-a47d-f2bc388007d7",
-      "5ef756e1-dec7-458d-a8fd-8f39a96594ca"
-    ],
-    "type": "duplicate",
-    "id": "be684ac0-7c41-4fa9-bd3a-4b6ca1f37822",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-07-25T20:51:13.449Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "7732adb9-46eb-43f3-8548-63b86005f3a4",
-      "bba5d15a-4fcd-462f-8efe-a9c5ebe4c8d2"
-    ],
-    "type": "duplicate",
-    "id": "e2fe0132-5869-4606-895c-6526450e27ad",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-09-19T18:31:02.136Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "7732adb9-46eb-43f3-8548-63b86005f3a4"
-    ],
-    "type": "forgotten",
-    "id": "095328a5-a086-4815-b1c6-f27a31e70676",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-10-19T02:48:20.646Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "25e9b940-b056-467f-b990-ceb8a24a4265",
-      "4f814a7a-2523-4dd9-bf9a-94393cae1b42"
-    ],
-    "type": "duplicate",
-    "id": "59c99e7e-b2a4-42bc-a736-503a5f0c5a55",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-08-24T09:32:08.949Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "6b0ac0be-0794-4873-a548-3bca91f0a2ae",
-      "730c4e60-545f-4d88-a801-7cf6611278f7"
-    ],
-    "type": "duplicate",
-    "id": "9b82103f-38cd-4a88-85df-391e9e6ba1bd",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-07-20T10:16:37.202Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "ee892440-040f-4075-a853-e568f7dadba3",
-      "585f465f-8839-4aa4-b5de-2621df19966b"
-    ],
-    "type": "duplicate",
-    "id": "9e386fad-0903-4be3-8096-e2bd0fc186b7",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-05-18T14:06:01.505Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "1cb7bf24-cffa-46db-8a7d-41dca6511b0f",
-      "98f91a7a-b691-4525-97c0-1e307111222c"
-    ],
-    "type": "duplicate",
-    "id": "22c81056-b3f1-4cb0-93df-ac325cf776a4",
-    "provider": "Webury Hill SCITT",
-    "date": "2022-05-31T21:23:47.855Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "0389958e-88d4-47da-891f-e146af7113b1"
-    ],
-    "type": "forgotten",
-    "id": "8c9ede10-581a-41ff-a17a-a65d4d02c0da",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-06-18T02:31:13.206Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "ac364c72-b23e-48ff-923e-deaaca3ba0f7",
-      "2a2f7c81-41a4-48ef-bcf7-7040bc00ccb4"
-    ],
-    "type": "duplicate",
-    "id": "afaa9cb0-a931-47da-93f9-6a104a789ce7",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-06-23T23:06:26.817Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "7ef619b9-7daf-4a70-801b-4c6ca2aea59e",
-      "09715646-9f71-485f-bd5f-db1be8ece4c4"
-    ],
-    "type": "duplicate",
-    "id": "a55fbabe-9b3a-46b6-b593-1cbc53b57061",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-09-11T03:41:39.844Z"
-  },
-  {
-    "title": "Confirm the deferral is still correct",
-    "description": "This trainee has been deferred for <span class=\"govuk-!-font-weight-bold\">5 years</span>.\n      If the trainee is still deferred, please update their expected end date. If they have left the course you should withdraw them.",
-    "traineeCount": 1,
-    "trainees": [
-      "d23bc3b1-5840-4442-a5ac-5e7e7d76f24c"
-    ],
-    "type": "deferredForgotten",
-    "id": "6324b826-85c3-4e66-b90b-a0d6d4a01e49",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-08-26T02:43:40.467Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "82ad5b73-02ad-4d78-a25e-5d1ce5c0f847"
-    ],
-    "type": "forgotten",
-    "id": "8e4f2748-cee6-46a4-8603-de1f02cf6558",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-08-11T16:21:02.080Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "c0cf5a8c-2f5c-4e1c-a7e5-be7cc3097695",
-      "9fda4052-c34a-424a-9faa-da58ac945de9"
-    ],
-    "type": "duplicate",
-    "id": "7f9128fb-d72d-4489-a4a5-9e955bdf8534",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-06-23T23:07:00.796Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "7910278c-6f55-4ba6-9a7c-c044c45ed212"
-    ],
-    "type": "forgotten",
-    "id": "172a9ff5-3c53-42b9-8993-c9ee039c39aa",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-06-01T14:43:03.492Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "576aeb6d-f3b3-42a1-9c79-6890060bebd4",
-      "3c02ce46-d85b-41d2-a9b3-a16d614c7df6"
-    ],
-    "type": "duplicate",
-    "id": "bdc46d0c-84c9-44f4-bf42-f555bd2df6ab",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-08-31T03:19:02.957Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "9b4d78c0-fade-4e47-962f-fe258858e1e2",
-      "fa52069c-457b-4770-b85c-a75d7a05e7ae"
-    ],
-    "type": "duplicate",
-    "id": "ee86f9ef-835a-4e5e-b8d7-f086589a9768",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-07-07T14:02:35.282Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "b4404aa0-ab8e-4539-9489-2949de367499"
-    ],
-    "type": "forgotten",
-    "id": "7ca431ae-b4e0-461a-a6ca-2093e0b1ca45",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-09-30T21:14:04.749Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "f7b3cca6-0e23-4fec-a6a3-d17ee8f507c8",
-      "8651c733-d57d-4d9f-b6d8-69855cfd2a27"
-    ],
-    "type": "duplicate",
-    "id": "38f21acd-a20c-4a9e-9ff5-79c143c879f4",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-05-02T17:25:49.743Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "55ee4f91-0084-482f-bff7-cc5a11d00cd4"
-    ],
-    "type": "forgotten",
-    "id": "11dcb5e8-cad3-43e0-8e09-57c24a08bd80",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-05-23T19:53:35.125Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "89d02de9-e772-4ee2-adec-14b148e1625a",
-      "7790c7aa-86a4-4709-a4d4-7aec68f84680"
-    ],
-    "type": "duplicate",
-    "id": "665cf592-eae3-4a69-9be2-8e22fba3c5f4",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-07-15T03:10:29.387Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "80d60ef8-bb4f-435d-a86f-e612b770bc9d",
-      "24028d03-c823-4bc9-812f-9831242aa3a6"
-    ],
-    "type": "duplicate",
-    "id": "a4a2f978-0534-4693-aec8-dae315a6a4ef",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-06-29T01:14:18.491Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "7e012208-e8f8-4e40-8521-ccbb2eeca587"
-    ],
-    "type": "forgotten",
-    "id": "4a56a619-5803-4410-84e0-876c7dab6534",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-08-04T09:26:02.352Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "9a5d19db-a503-4875-8259-ef9914add2ec"
-    ],
-    "type": "forgotten",
-    "id": "2b01d694-aaf2-42fc-9af7-7f86d2621805",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-07-26T03:56:43.252Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "d7bc0e3e-603a-4d1f-a691-9577a797565d"
-    ],
-    "type": "forgotten",
-    "id": "102d3498-a7d2-45d9-9b1b-763a63717e7a",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-07-29T23:31:58.808Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "b18df796-28b9-4be3-8962-0513c642d3fe",
-      "cde3d55e-adce-47a0-8347-6ab5bfeea7bf"
-    ],
-    "type": "duplicate",
-    "id": "c176a292-7609-4630-95bc-063b5e8e0059",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-07-03T23:43:18.631Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">10 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "ef28806e-f635-4dcf-b08f-118763dccbd1"
-    ],
-    "type": "forgotten",
-    "id": "0d5b3c98-5150-411d-8150-8e9043d9b544",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-08-04T23:13:01.431Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "c6d0dd47-86a6-4ee2-862e-ff15b8812d2c"
-    ],
-    "type": "forgotten",
-    "id": "0b4c7ddd-bcc3-4ffc-8bce-b3737ccbcbbb",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-08-09T19:59:40.670Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "58b4744b-3979-402c-8ea3-5e97153ff2a6",
-      "0d4e68bf-17d8-4b6c-ab5e-39a09b919830"
-    ],
-    "type": "duplicate",
-    "id": "10f14d02-c69b-4408-b3ca-e119185812fd",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-10-06T07:30:59.633Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "c6f8b43a-c1e6-4bc7-b73e-05323ecc513b"
-    ],
-    "type": "forgotten",
-    "id": "646dc714-05ee-4f35-b703-6d3ba7d4c6e7",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-10-06T16:02:27.569Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "21e07a7a-50db-4f3c-9f2e-3fc25a569142"
-    ],
-    "type": "forgotten",
-    "id": "fd971a33-7076-41cf-9d19-a3bbd734f32b",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-04-27T20:01:29.534Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "37f6d33b-0a3a-401c-baab-3e3d560baedf"
-    ],
-    "type": "forgotten",
-    "id": "ea98cc5d-d4cb-41a4-beb4-692f9fc32cee",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-09-04T18:40:27.685Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "fa52069c-457b-4770-b85c-a75d7a05e7ae"
-    ],
-    "type": "forgotten",
-    "id": "fc188a67-3fd2-4263-af83-8dcb3708e870",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-08-30T15:35:53.647Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "3f1a761c-2301-48e4-89b0-d57d60553cc8",
-      "37f6d33b-0a3a-401c-baab-3e3d560baedf"
-    ],
-    "type": "duplicate",
-    "id": "22a6ee95-010e-4f11-b7ab-1ae388357dfe",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-05-22T07:28:54.983Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "b4404aa0-ab8e-4539-9489-2949de367499",
-      "29457324-0b8d-4ad7-bf2d-84e8b878cb99"
-    ],
-    "type": "duplicate",
-    "id": "c19ad650-9998-40e4-a92d-61e2f2640b65",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-07-13T20:41:18.415Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "b2f1005d-aaaf-41a6-930b-02b4f357af2d",
-      "fdd8c51c-f28c-41ae-9c70-a62b8f541e12"
-    ],
-    "type": "duplicate",
-    "id": "36345cd3-40bc-4670-b77e-0f2c5e68c01f",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-09-12T00:06:23.286Z"
+    "date": "2022-07-28T19:56:37.258Z"
   },
   {
     "title": "This trainee may have been forgotten",
     "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">6 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
     "traineeCount": 1,
     "trainees": [
-      "29457324-0b8d-4ad7-bf2d-84e8b878cb99"
+      "b4016c09-a301-4207-9a16-5aa232494f04"
     ],
     "type": "forgotten",
-    "id": "1aad55b2-eeb7-4883-be5f-0857e3010a29",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-08-19T14:30:09.133Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "2b750ef1-f035-49ee-883c-90e32af21bb5"
-    ],
-    "type": "forgotten",
-    "id": "62119d12-d4ae-41b2-a1e5-e1e2f46d3dcd",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-06-19T08:16:01.566Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "e86d49e9-0cb1-4633-a9e0-9bea5499a2ca"
-    ],
-    "type": "forgotten",
-    "id": "2cde206e-fa5a-4243-9add-1f0b94696914",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-05-13T04:26:01.202Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "326fbe13-6434-4b8d-bd6e-dea1251351bc",
-      "f6a54967-db0c-42d0-a72d-0c19af975729"
-    ],
-    "type": "duplicate",
-    "id": "79e6c42b-0920-4bae-b886-3925629af457",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-09-20T17:19:03.449Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "5aa1a052-cd79-43aa-a8ab-1967f5dd3f79",
-      "cb88fa5d-90e6-41ed-98c3-d0c8a253baeb"
-    ],
-    "type": "duplicate",
-    "id": "56d2006d-6ad1-463c-89f6-088f369aef33",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-05-09T22:35:30.007Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "2ce93f1b-d3c8-4ed9-abb8-201f8f2322f5",
-      "235c5925-8114-4bd4-9d64-bafb900224cf"
-    ],
-    "type": "duplicate",
-    "id": "efb0ec1a-90ec-428e-9bef-4dd210ff6226",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-06-17T09:25:16.970Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "5c77660d-197f-48d9-912e-26832b16ba04",
-      "2cf0d85b-2307-4911-a8f9-648266822eca"
-    ],
-    "type": "duplicate",
-    "id": "3f7e0779-56f5-4ff7-923b-8074674e1e3f",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-07-31T22:34:46.463Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "7910278c-6f55-4ba6-9a7c-c044c45ed212",
-      "db43988b-28a2-4377-b389-ebdaab665be7"
-    ],
-    "type": "duplicate",
-    "id": "edff2298-d2f9-4ad5-8afb-c442dcafeb37",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-07-15T02:58:45.164Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "d23bc3b1-5840-4442-a5ac-5e7e7d76f24c",
-      "1a65ac71-e94f-4ec6-b8b5-55b68112dbcb"
-    ],
-    "type": "duplicate",
-    "id": "732c87c0-ed6b-419c-96f0-929406ad78ce",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-09-10T02:30:15.592Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "8337e5b0-c8a2-4f37-99c4-3e2b0a5775c6",
-      "de7f7b16-9454-4846-9c33-57fbcd859a06"
-    ],
-    "type": "duplicate",
-    "id": "fb577469-099c-4baf-b948-e76123d31b59",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-05-05T18:07:55.172Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "6f299b9d-d1c0-41b8-8455-815cdae3b6e9",
-      "29b6d10b-8325-4ea9-b23d-23da57b3be5c"
-    ],
-    "type": "duplicate",
-    "id": "6364243c-e5a6-4900-a8e1-359dabcf3ca1",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-09-08T18:08:07.847Z"
+    "id": "7dddd5f2-ca3b-46de-aac7-d0784f9639d5",
+    "provider": "King’s Oak University",
+    "date": "2022-11-03T10:14:59.315Z"
   },
   {
     "title": "Confirm the deferral is still correct",
-    "description": "This trainee has been deferred for <span class=\"govuk-!-font-weight-bold\">2 years</span>.\n      If the trainee is still deferred, please update their expected end date. If they have left the course you should withdraw them.",
+    "description": "This trainee has been deferred for <span class=\"govuk-!-font-weight-bold\">5 years</span>.\n      If the trainee is still deferred, please update their expected end date. If they have left the course you should withdraw them.",
     "traineeCount": 1,
     "trainees": [
-      "6a6fba13-3765-4dc9-a0e6-fff4f28aaa8a"
+      "da70cddd-31e7-4f94-b15e-d4f0085a8029"
     ],
     "type": "deferredForgotten",
-    "id": "84ad7beb-e2bb-4faf-9509-442a740b7a8d",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-04-28T16:48:16.585Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "05ba548f-90b7-420d-870b-569cb190847c",
-      "996836eb-5de0-4ee8-ae13-09a0ef8fe5d8"
-    ],
-    "type": "duplicate",
-    "id": "4f4ebedb-8ece-4b90-b503-eba25475b3fd",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-05-11T18:22:31.701Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "2c43fd38-1b0d-4e93-b3c0-16b3ff437951",
-      "b8980325-f93c-43d6-9690-837cecad596b"
-    ],
-    "type": "duplicate",
-    "id": "df583611-7560-4e1d-9cfc-1bd57bdc4ad9",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-08-18T20:29:25.815Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "0cd44d15-0526-4587-b5a8-6539bfed1d86",
-      "ef28806e-f635-4dcf-b08f-118763dccbd1"
-    ],
-    "type": "duplicate",
-    "id": "473be0da-1111-49a4-bb59-dc29a9cd187f",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-09-11T16:35:53.100Z"
+    "id": "db0e7006-2c30-4cc9-9521-6eb837456169",
+    "provider": "King’s Oak University",
+    "date": "2022-11-16T13:45:44.565Z"
   },
   {
     "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">9 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
     "traineeCount": 1,
     "trainees": [
-      "3c02ce46-d85b-41d2-a9b3-a16d614c7df6"
+      "61e1666c-df51-4efe-ab53-abdbb32b8365"
     ],
     "type": "forgotten",
-    "id": "f2642732-36cf-40f2-ab59-be2eddba3cac",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-08-25T11:51:28.379Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "e0beed7e-4138-4595-a350-80a41c9a95e2"
-    ],
-    "type": "forgotten",
-    "id": "413fb374-df34-4e39-bb89-03f70a186d42",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-05-27T06:54:18.589Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "444a2bfe-a15a-48c6-a035-1b9f90c8c74a"
-    ],
-    "type": "forgotten",
-    "id": "2039b515-8ef1-48d1-ba9a-ad262ab4ef38",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-06-20T08:39:17.761Z"
+    "id": "81d6d44c-7bc9-4252-ba2e-0cfa8c814906",
+    "provider": "King’s Oak University",
+    "date": "2022-09-15T08:07:40.915Z"
   },
   {
     "title": "This trainee may have been forgotten",
     "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
     "traineeCount": 1,
     "trainees": [
-      "1b4478ec-07e6-4d26-a7a8-1e7ac8bb30ae"
+      "9777872e-6a8a-4fcd-aa8d-beec8512ea80"
     ],
     "type": "forgotten",
-    "id": "abbab4f1-41ac-4475-b225-f8359bd05e60",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-10-23T06:05:28.613Z"
+    "id": "8107c5f7-9c88-46a2-b63c-a2f849225255",
+    "provider": "King’s Oak University",
+    "date": "2022-11-15T15:03:38.153Z"
   },
   {
     "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
     "traineeCount": 1,
     "trainees": [
-      "3bbb772d-bb33-41b9-97f0-bafecef76e27"
+      "643d4110-dddd-4bc9-85d6-6b7196f3bd6e"
     ],
     "type": "forgotten",
-    "id": "69bd2789-f4b5-44c0-925f-81e3011512d3",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-07-26T18:15:09.313Z"
+    "id": "33bef3df-ce1a-492f-ac77-9600715885e2",
+    "provider": "King’s Oak University",
+    "date": "2022-05-28T16:19:47.193Z"
   },
   {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
     "trainees": [
-      "edb1272b-096f-4a9c-9f91-b7d9a027b05d",
-      "d3c216c4-04de-4c59-9f4c-2cb0bbfaf8a6"
+      "ba664661-ec01-4edd-bad2-a53cc6433a1e"
     ],
-    "type": "duplicate",
-    "id": "f46d4b5c-74b9-4c81-b50f-f44a4cfd7feb",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-10-06T14:00:22.961Z"
+    "type": "forgotten",
+    "id": "66769bd4-188e-486d-9420-96b722ce4460",
+    "provider": "King’s Oak University",
+    "date": "2022-09-19T02:34:53.585Z"
   },
   {
     "title": "This trainee may have been forgotten",
     "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
     "traineeCount": 1,
     "trainees": [
-      "ac364c72-b23e-48ff-923e-deaaca3ba0f7"
+      "bbd145b9-cdbb-4f41-af14-6f0a93e416db"
     ],
     "type": "forgotten",
-    "id": "405265fa-82b1-4706-8ec0-543e823742d5",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-06-18T15:14:27.940Z"
+    "id": "3174c702-a1b8-4447-8008-bd973f39ea12",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-07-22T14:32:44.972Z"
   },
   {
     "title": "These trainees appear to be duplicates",
     "description": "Review these trainees and either withdraw one, or email us with an action to take",
     "traineeCount": 2,
     "trainees": [
-      "c6f8b43a-c1e6-4bc7-b73e-05323ecc513b",
-      "a6cc5b80-9656-4b0b-9da8-7e00ba1658b2"
+      "980c11af-3e50-4c32-b5c5-ab3a08c964ef",
+      "edb3912f-787a-486d-949a-ac4704966304"
     ],
     "type": "duplicate",
-    "id": "4fb77ffc-dc13-477b-9bbd-a80ca3aba06e",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-05-07T19:04:32.310Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "430ca78d-a6f2-4a15-b0e1-5605f6fb6ffe",
-      "7e012208-e8f8-4e40-8521-ccbb2eeca587"
-    ],
-    "type": "duplicate",
-    "id": "68bdeb08-1398-4ac4-adc0-17a7f54953f4",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-10-17T13:35:54.154Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "996836eb-5de0-4ee8-ae13-09a0ef8fe5d8"
-    ],
-    "type": "forgotten",
-    "id": "302f2cab-9b4c-41f9-b176-5900a4f49595",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-10-14T19:52:54.352Z"
-  },
-  {
-    "title": "This draft appears to be a duplicate",
-    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
-    "traineeCount": 2,
-    "trainees": [
-      "9c12648b-023d-4ed0-b307-d683330b19ba",
-      "c50bf592-91b5-40c6-8fe9-dfc5f9087b81"
-    ],
-    "type": "duplicate",
-    "id": "075755d8-2c23-4c64-92c0-b21ee915f414",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-08-21T03:59:02.341Z"
-  },
-  {
-    "title": "These trainees appear to be duplicates",
-    "description": "Review these trainees and either withdraw one, or email us with an action to take",
-    "traineeCount": 2,
-    "trainees": [
-      "f98c7117-31c8-4172-90db-0adb3546cfe9",
-      "e0beed7e-4138-4595-a350-80a41c9a95e2"
-    ],
-    "type": "duplicate",
-    "id": "4c5b1b92-e137-4a65-b689-3ac9a3541eb2",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-06-19T00:54:23.732Z"
-  },
-  {
-    "title": "This trainee may have been forgotten",
-    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
-    "traineeCount": 1,
-    "trainees": [
-      "7790c7aa-86a4-4709-a4d4-7aec68f84680"
-    ],
-    "type": "forgotten",
-    "id": "3f2eefb8-7f4c-4f6f-a779-033bae056d78",
-    "provider": "The John Taylor SCITT",
-    "date": "2022-09-10T09:10:07.220Z"
+    "id": "7bbd7054-015b-44d6-9d38-621fd349508c",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-07-06T03:32:43.678Z"
   },
   {
     "title": "This trainee may have been forgotten",
     "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
     "traineeCount": 1,
     "trainees": [
-      "0cd44d15-0526-4587-b5a8-6539bfed1d86"
+      "dd893f63-9faf-4503-b9a2-7caeb2aa2fa2"
     ],
     "type": "forgotten",
-    "id": "fa86a80e-d21a-484b-9d64-d4c80f184700",
+    "id": "302dcaf1-ee25-4184-8651-dfc14c372fe0",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-06-09T20:33:56.189Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "5de487a8-c6db-4375-a272-6e5033f1c0f8"
+    ],
+    "type": "forgotten",
+    "id": "ac0a6762-b321-4019-a558-f85af1c1e276",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-09-30T22:26:13.672Z"
+  },
+  {
+    "title": "This draft appears to be a duplicate",
+    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
+    "traineeCount": 2,
+    "trainees": [
+      "0645f80f-7f31-4a3c-a29a-c3878c12818b",
+      "47df0ca1-3d96-4edf-a76d-0a32e2e49995"
+    ],
+    "type": "duplicate",
+    "id": "b3a52e39-4632-4922-ad98-e3bbfeb1209d",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-10-31T22:34:43.943Z"
+  },
+  {
+    "title": "These trainees appear to be duplicates",
+    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "traineeCount": 2,
+    "trainees": [
+      "cc0c21e0-f6a6-477c-a8c7-4d2e1787cddd",
+      "7ff77c32-2e9b-450d-bfe5-564bd4188c4b"
+    ],
+    "type": "duplicate",
+    "id": "a5fabc68-d442-4ee9-af87-80025e1b05a4",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-06-20T17:03:12.517Z"
+  },
+  {
+    "title": "This draft appears to be a duplicate",
+    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
+    "traineeCount": 2,
+    "trainees": [
+      "1e196e70-6460-4578-ba48-1b7ffa8470c4",
+      "8c3bc239-cbb1-49ec-948a-8113cae19786"
+    ],
+    "type": "duplicate",
+    "id": "3c1edc74-a8b7-4427-b577-a82abe2535a2",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-06-25T23:25:02.512Z"
+  },
+  {
+    "title": "These trainees appear to be duplicates",
+    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "traineeCount": 2,
+    "trainees": [
+      "df0f51fc-f794-45d1-a440-e9f673698702",
+      "52a03bd7-1dc6-4798-a7fc-17796a5f331c"
+    ],
+    "type": "duplicate",
+    "id": "ba520c6d-8472-4393-9276-ec508cc91e79",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-08-22T16:01:50.652Z"
+  },
+  {
+    "title": "This draft appears to be a duplicate",
+    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
+    "traineeCount": 2,
+    "trainees": [
+      "664d581b-cef2-4c69-8dd0-477baaa7dda4",
+      "13bd8573-a5fd-4ae9-be78-8213dac24d86"
+    ],
+    "type": "duplicate",
+    "id": "e1ccb0ea-ae59-4fd0-90fa-76c236f891ef",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-08-26T07:24:01.142Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "740b1620-5c16-48c6-b4ac-bbc614a56084"
+    ],
+    "type": "forgotten",
+    "id": "d02d7c08-d7dc-4cf6-899d-2555a6933e8a",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-11-14T12:11:23.489Z"
+  },
+  {
+    "title": "This draft appears to be a duplicate",
+    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
+    "traineeCount": 2,
+    "trainees": [
+      "f199d8b6-9983-4279-b4c6-c9716fb739ed",
+      "b43899a1-7677-445b-adca-b78f9c44175d"
+    ],
+    "type": "duplicate",
+    "id": "534c705c-73ff-4268-99b1-d929a04a6abd",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-09-23T20:07:10.102Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "e5c54eec-fd0b-406a-b9a1-3fe0d8765e2a"
+    ],
+    "type": "forgotten",
+    "id": "7bc43b98-142f-48b8-b598-05079011d8b9",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-09-23T17:13:29.186Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "78fd6b93-69bb-4857-83a7-ab7564bba1ce"
+    ],
+    "type": "forgotten",
+    "id": "c62c9b35-9846-4278-9cda-2aad6dde9f51",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-08-31T12:15:37.747Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "a4e86140-54ad-474e-aae2-b03ad747162f"
+    ],
+    "type": "forgotten",
+    "id": "dd23479f-0e0d-4edc-88be-baca54c3514b",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-10-25T23:46:47.825Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">4 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "395b1a15-169c-4c01-bf23-08252d9785a9"
+    ],
+    "type": "forgotten",
+    "id": "d3f39eec-004c-4166-a7d2-5b6f4895e003",
+    "provider": "Webury Hill SCITT",
+    "date": "2022-10-08T04:35:01.071Z"
+  },
+  {
+    "title": "These trainees appear to be duplicates",
+    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "traineeCount": 2,
+    "trainees": [
+      "2dad3c95-0239-44e5-9f41-5b1b2773f6a9",
+      "f90a5e57-c348-423e-8568-a193d1fa99d5"
+    ],
+    "type": "duplicate",
+    "id": "cdcf19d3-18d9-4288-9256-8c2804893a47",
     "provider": "The John Taylor SCITT",
-    "date": "2022-08-09T20:35:49.556Z"
+    "date": "2022-06-08T21:21:06.014Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "0edc4fc6-0f75-4389-9a33-d470342ff8d6"
+    ],
+    "type": "forgotten",
+    "id": "4433d0a8-e8ee-4dc2-9475-6a500558e2a8",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-09-07T16:22:49.244Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">6 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "4b2771d2-273f-4ef6-b040-c33d681271b3"
+    ],
+    "type": "forgotten",
+    "id": "48d10d1c-e305-446f-bcf6-20d369f52c89",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-11-10T08:24:16.848Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "73c3fe4a-622c-495f-89dc-22506f2ab308"
+    ],
+    "type": "forgotten",
+    "id": "cbdef209-820d-45b4-90d3-12a328248e4b",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-10-17T04:04:41.359Z"
+  },
+  {
+    "title": "These trainees appear to be duplicates",
+    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "traineeCount": 2,
+    "trainees": [
+      "738658b6-236a-439c-b648-e450d5042e58",
+      "8ad3bc68-9f80-4a4e-bb0f-d6b975d981d7"
+    ],
+    "type": "duplicate",
+    "id": "44701f6d-8270-4ca3-9141-c9665547ca77",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-09-06T00:42:20.485Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "51164a14-b2a6-4ce0-b199-a9ec469d7a5a"
+    ],
+    "type": "forgotten",
+    "id": "c9ead537-5a5b-410c-927e-b23a7a7617de",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-10-11T11:59:01.846Z"
+  },
+  {
+    "title": "These trainees appear to be duplicates",
+    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "traineeCount": 2,
+    "trainees": [
+      "ac3c78ba-3a6b-481f-9e13-896dc9dc764f",
+      "5ba37696-2c2b-49ea-adb0-1b600a86851a"
+    ],
+    "type": "duplicate",
+    "id": "0ea0c2f8-8b8e-4591-989b-e67afd258537",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-11-03T01:05:42.407Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">8 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "534bf1d8-9664-482d-aa2a-32a769714e51"
+    ],
+    "type": "forgotten",
+    "id": "e6c04f71-06a0-4d2b-86fc-c1ce72c4eab7",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-08-13T13:31:25.631Z"
+  },
+  {
+    "title": "These trainees appear to be duplicates",
+    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "traineeCount": 2,
+    "trainees": [
+      "fb813148-feb1-49b1-b357-2b2631ed275f",
+      "851c5fe3-bbbd-4082-b27d-ee59f39bcaa6"
+    ],
+    "type": "duplicate",
+    "id": "c4cc5293-89cf-4d39-af95-36ea01e1dfe7",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-07-16T09:35:03.157Z"
+  },
+  {
+    "title": "These trainees appear to be duplicates",
+    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "traineeCount": 2,
+    "trainees": [
+      "9634d18a-897c-42b5-9809-e3ecc072b98a",
+      "789be390-9bdb-41f3-b98a-7c163a78b3e7"
+    ],
+    "type": "duplicate",
+    "id": "a3b751af-5ae4-4b54-bec9-d45c5a54def8",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-10-17T22:04:41.006Z"
+  },
+  {
+    "title": "These trainees appear to be duplicates",
+    "description": "Review these trainees and either withdraw one, or email us with an action to take",
+    "traineeCount": 2,
+    "trainees": [
+      "36f25e9d-a6d1-4dc3-82f5-3d8358a7e01b",
+      "326edad8-4c59-4d80-838c-c07ec60a5adc"
+    ],
+    "type": "duplicate",
+    "id": "2a9b3806-d47b-4876-bdfa-2b3a1a1a73ed",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-06-12T05:00:15.504Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">7 months ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "298fe48f-5f80-4fe7-827a-b245a3c9f85c"
+    ],
+    "type": "forgotten",
+    "id": "896e8bb9-d222-4438-92c9-9636745c41cf",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-06-26T07:05:15.882Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">3 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "3fb78d32-8e7f-4639-9ff6-2ebf15c4ffe2"
+    ],
+    "type": "forgotten",
+    "id": "8cdd282b-a7e6-460e-8a6e-1496446630d6",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-09-08T16:53:04.952Z"
+  },
+  {
+    "title": "This draft appears to be a duplicate",
+    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
+    "traineeCount": 2,
+    "trainees": [
+      "5f59f560-ab89-4619-9e57-b5bf34d835c3",
+      "71ef60b8-ccd6-40eb-8c89-7225ba3caefa"
+    ],
+    "type": "duplicate",
+    "id": "e6f96b09-ca10-4aeb-87f4-999caaa4cca9",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-10-22T03:22:11.034Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">a year ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "75262373-2518-40a7-a378-e71a2828cdbd"
+    ],
+    "type": "forgotten",
+    "id": "35094095-51bb-4337-b153-fb1dd9566154",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-11-13T18:04:28.807Z"
+  },
+  {
+    "title": "This draft appears to be a duplicate",
+    "description": "Review whether this draft is a duplicate and either delete it or withdraw the existing trainee",
+    "traineeCount": 2,
+    "trainees": [
+      "2605f5e8-1a28-4e6f-bdf5-5bde9cdf7e48",
+      "574845b5-e433-4054-b8cd-4242e27e72e9"
+    ],
+    "type": "duplicate",
+    "id": "8e7a0edc-eca0-4b52-8fc4-dae9bbf86c27",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-06-25T13:38:42.934Z"
+  },
+  {
+    "title": "This trainee may have been forgotten",
+    "description": "The expected end date of this trainee was <span class=\"govuk-!-font-weight-bold\">2 years ago</span>.\n      If the trainee is no longer in training you should award or withdraw them. If they are still in training you should\n      update the expected end date of their course.",
+    "traineeCount": 1,
+    "trainees": [
+      "354e9246-389f-41e2-944c-a0856b231591"
+    ],
+    "type": "forgotten",
+    "id": "a3a4203e-0a54-4ce4-b61d-3d438b007705",
+    "provider": "The John Taylor SCITT",
+    "date": "2022-07-22T05:50:24.229Z"
   }
 ]

--- a/app/views/_includes/record-problems/banner.njk
+++ b/app/views/_includes/record-problems/banner.njk
@@ -40,25 +40,31 @@
     {{ title }}
   </h3>
 
-  {% for problem in recordProblems | sort(attribute='type') %}
 
-    {% if countOfIssues > 1 %}
-      <h4 class="govuk-heading-s">
-        {{ problemHeadings[problem.type] }}
-      </h4>
-    {% endif %}
-    {% include "_includes/record-problems/" + problem.type + ".njk" %}
+    {% for problem in recordProblems | sort(attribute='type') %}
 
-  {% endfor %}
+        {% if countOfIssues > 1 %}
+
+          <h4 class="govuk-heading-s">
+            {{loop.index}}. {{ problemHeadings[problem.type] }}
+          </h4>
+
+        {% endif %}
+
+        {% include "_includes/record-problems/" + problem.type + ".njk" %}
+
+    {% endfor %}
+
 
   {# Add incomplete to the end #}
   {% if isIncomplete %}
-    {% if countOfIssues > 1 %}
-      <h3 class="govuk-heading-s">
-        {{ problemHeadings.incomplete }}
-      </h3>
-    {% endif %}
-    {% include "_includes/record-problems/incomplete.njk" %}
+
+      {% if countOfIssues > 1 %}
+        <h3 class="govuk-heading-s">
+         {{countOfIssues}}. {{ problemHeadings.incomplete }}
+        </h3>
+      {% endif %}
+      {% include "_includes/record-problems/incomplete.njk" %}
 
   {% endif %}
 
@@ -67,6 +73,7 @@
 {# Checking the status rather than canAmend, as we want the banner to show on locked hesa records #}
 {% if (countOfIssues > 0) and record.status | canBeAmended %}
   {{ govukNotificationBanner({
-    html: notificationBannerHtml
+    html: notificationBannerHtml,
+    titleText: "Problem" | pluralise(countOfIssues)
   }) }}
 {% endif %}

--- a/scripts/generate-trainee-problems.js
+++ b/scripts/generate-trainee-problems.js
@@ -171,7 +171,7 @@ const generateFakeTraineeProblems = () => {
     // let activeTrainees = providerTrainees.filter( trainee => utils.isActiveStatus(trainee) )
 
     // Create random number of problems per provider with some limits
-    let numberOfTraineeProblemsToCreate = utils.getRandomArbitrary(5, Math.min(providerTrainees.length / 5, 20))
+    let numberOfTraineeProblemsToCreate = utils.getRandomArbitrary(5, Math.min(providerTrainees.length / 5, 10))
 
     console.log(`Generating ${numberOfTraineeProblemsToCreate} problems`)
 

--- a/scripts/generate-trainee-problems.js
+++ b/scripts/generate-trainee-problems.js
@@ -171,7 +171,7 @@ const generateFakeTraineeProblems = () => {
     // let activeTrainees = providerTrainees.filter( trainee => utils.isActiveStatus(trainee) )
 
     // Create random number of problems per provider with some limits
-    let numberOfTraineeProblemsToCreate = utils.getRandomArbitrary(20, Math.min(providerTrainees.length / 3, 60))
+    let numberOfTraineeProblemsToCreate = utils.getRandomArbitrary(5, Math.min(providerTrainees.length / 5, 20))
 
     console.log(`Generating ${numberOfTraineeProblemsToCreate} problems`)
 


### PR DESCRIPTION
Changes ahead of user research:
* Enable the combined removal flow we designed a while back - which should work better where users are removing a duplicate record
* Reduce the overall number of problems generated.
* When there are more than one problem, they are numbered
* Tweaking the seed records
* Adding a new `/set-up` url so we can give participants a url to sign them in to the right user, without them seeing the prototype