### PR TITLE
Show award date as separate row

### DIFF
--- a/app/views/_includes/summary-cards/qualification-details.html
+++ b/app/views/_includes/summary-cards/qualification-details.html
@@ -1,4 +1,9 @@
 
+{% set outcomeDate = record.qualificationDetails.outcomeDate | toDateObject %}
+
+{# The prototype doesn’t store an award date, so fake it by adding 1 to the outcomeDate #}
+{% set awardDate = moment(outcomeDate).add(1, 'days') %}
+
 {% set qualificationDetailsRows = [
   {
     key: {
@@ -22,7 +27,7 @@
       text: "Award date"
     },
     value: {
-      text: (moment(record.qualificationDetails.outcomeDate).add(1, 'days') | govukDate or 'Not provided') if record | isAwarded else "Waiting for award"
+      text: (awardDate | govukDate or 'Not provided') if record | isAwarded else "Waiting for award"
     }
   } if showAwardDateRow,
   {

--- a/app/views/_includes/summary-cards/qualification-details.html
+++ b/app/views/_includes/summary-cards/qualification-details.html
@@ -19,6 +19,14 @@
   },
   {
     key: {
+      text: "Award date"
+    },
+    value: {
+      text: (moment(record.qualificationDetails.outcomeDate).add(1, 'days') | govukDate or 'Not provided') if record | isAwarded else "Waiting for award"
+    }
+  } if showAwardDateRow,
+  {
+    key: {
       text: "Qualification with " + record | getQualificationText
     },
     value: {

--- a/app/views/record.html
+++ b/app/views/record.html
@@ -30,6 +30,7 @@
     {% include "_includes/summary-cards/trainee-progress.html" %}
 
     {% if record | isAwarded or record | isRecommended %}
+      {% set showAwardDateRow = true %}
       {% include "_includes/summary-cards/qualification-details.html" %}
     {% endif %}
 


### PR DESCRIPTION
Adds a second row to our award summary card to show the award date in addition to the standards met date.

Whilst trainee is recommended:
<img width="999" alt="Screenshot 2023-05-23 at 15 03 25" src="https://github.com/DFE-Digital/register-trainee-teachers-prototype/assets/2204224/27c9705a-48c2-4389-84d1-00bfb2aa3d71">

Once they're awarded teaching status:
<img width="1009" alt="Screenshot 2023-05-22 at 15 43 14" src="https://github.com/DFE-Digital/register-trainee-teachers-prototype/assets/2204224/29c7e61d-234a-4894-bdcd-9df409ca4e7a">

Note the prototype doesn't currently distinguish between standards met date and award date - it just has as single date - therefore for this card I've faked it by adding 1 to the existing day.
