### PR TITLE
Show award date field when trainee recommended

### DIFF
--- a/app/views/_includes/summary-cards/qualification-details.html
+++ b/app/views/_includes/summary-cards/qualification-details.html
@@ -1,33 +1,13 @@
 
 {% set outcomeDate = record.qualificationDetails.outcomeDate | toDateObject %}
 
-{# The prototype doesn’t store an award date, so fake it by adding 1 to the outcomeDate #}
-{% set awardDate = moment(outcomeDate).add(1, 'days') %}
-
 {% set qualificationDetailsRows = [
-  {
-    key: {
-      text: "Date standards met"
-    },
-    value: {
-      text: record.qualificationDetails.outcomeDate | govukDate or 'Not provided'
-    },
-    actions: {
-      items: [
-        {
-          href: recordPath + "/qualification/outcome-date" | addReferrer(referrer),
-          text: "Change",
-          visuallyHiddenText: "date standards met"
-        }
-      ]
-    } if canAmend and false
-  },
   {
     key: {
       text: "Award date"
     },
     value: {
-      text: (awardDate | govukDate or 'Not provided') if record | isAwarded else "Waiting for award"
+      text: (outcomeDate | govukDate or 'Not provided') if record | isAwarded else "Waiting for award - standards met on " + outcomeDate | govukDate
     }
   } if showAwardDateRow,
   {
@@ -70,7 +50,7 @@
   {{ govukSummaryList({
     rows: qualificationDetailsRows
   }) }}
-  
+
 {% endset %}
 
 {% set complete = record.contactDetails | sectionIsComplete %}
@@ -117,6 +97,5 @@
     } if activeTab == 'trainee-details' and data.isAdmin,
     html: qualificationDetailsHtml
   }) }}
-  
-{% endif %}
 
+{% endif %}

--- a/app/views/_includes/summary-cards/qualification-details.html
+++ b/app/views/_includes/summary-cards/qualification-details.html
@@ -1,13 +1,30 @@
 
-{% set outcomeDate = record.qualificationDetails.outcomeDate | toDateObject %}
+{% set outcomeDate = record.qualificationDetails.outcomeDate | govukDate %}
 
 {% set qualificationDetailsRows = [
+  {
+    key: {
+      text: "Date standards met"
+    },
+    value: {
+      text: record.qualificationDetails.outcomeDate | govukDate or 'Not provided'
+    },
+    actions: {
+      items: [
+        {
+          href: recordPath + "/qualification/outcome-date" | addReferrer(referrer),
+          text: "Change",
+          visuallyHiddenText: "date standards met"
+        }
+      ]
+    } if canAmend and false
+  } if not showAwardDateRow,
   {
     key: {
       text: "Award date"
     },
     value: {
-      text: (outcomeDate | govukDate or 'Not provided') if record | isAwarded else "Waiting for award - standards met on " + outcomeDate | govukDate
+      text: (outcomeDate or 'Not provided') if record | isAwarded else "Waiting for award - met standards on " + outcomeDate
     }
   } if showAwardDateRow,
   {


### PR DESCRIPTION
We recently made a change to [show the award date as a separate row](https://github.com/DFE-Digital/register-trainee-teachers-prototype/pull/649/files).

We've now found out that the QTS and EYTS award date will always be the same as the date the standards were met. This means there's no point showing both dates once the trainee has been awarding teaching status.

When the trainee has been recommended for QTS or EYTS, we'll say that they're waiting for their award. We'll also give the date when they were recommended for teaching status.

![CleanShot 2023-05-24 at 16 20 11](https://github.com/DFE-Digital/register-trainee-teachers-prototype/assets/29047487/32a00b45-01b8-4981-85fc-f84220281b07)

Once the trainee has teaching status, we'll just show the date they were awarded it.

![CleanShot 2023-05-24 at 16 20 30](https://github.com/DFE-Digital/register-trainee-teachers-prototype/assets/29047487/782cd415-4c04-4e6a-8862-a1fe754f557e)