### PR TITLE
Updates to manual placement fields

### DIFF
--- a/app/views/_includes/forms/placements/details-manual.html
+++ b/app/views/_includes/forms/placements/details-manual.html
@@ -13,7 +13,7 @@
 
 {{ govukInput({
   label: {
-    text: "School or organisation name",
+    text: "School or setting name",
     classes: "govuk-label--s"
   },
   classes: "govuk-!-width-two-thirds",
@@ -22,11 +22,11 @@
 
 {{ govukInput({
   label: {
-    text: "School unique reference number (URN)",
+    text: "School unique reference number (if available)",
     classes: "govuk-label--s"
   },
-  hint: {
-    text: "Only if this early years setting has a URN" if record | isEarlyYears else "If available"
+  _hint: {
+    text: "Only if this early years setting is a school" if record | isEarlyYears
   },
   classes: "govuk-!-width-one-third",
   value: placementTemp.school.urn if isManualEntry

--- a/app/views/_includes/forms/placements/details-manual.html
+++ b/app/views/_includes/forms/placements/details-manual.html
@@ -10,18 +10,10 @@
 
 {% set isManualEntry = isManualEntry or (placementTemp.school.manualEntry | falsify) %}
 
-{% set schoolOrOrganisation -%}
-  {%- if record | isEarlyYears -%}
-    organisation
-  {%- else -%}
-    school
-  {%- endif -%}
-{%- endset %}
-
 
 {{ govukInput({
   label: {
-    text: (schoolOrOrganisation | sentenceCase) + " name",
+    text: "School or organisation name",
     classes: "govuk-label--s"
   },
   classes: "govuk-!-width-two-thirds",
@@ -34,33 +26,11 @@
     classes: "govuk-label--s"
   },
   hint: {
-    text: "Only if this early years setting has a URN"
-  } if record | isEarlyYears,
+    text: "Only if this early years setting has a URN" if record | isEarlyYears else "If available"
+  },
   classes: "govuk-!-width-one-third",
   value: placementTemp.school.urn if isManualEntry
 } | decorateAttributes(placementTemp, "placementTemp.school.urn"))}}
-
-{# Addresses stored in two ways - this maps between them #}
-{% set address -%}
-  {%- if placementTemp.school.address -%}
-    {{- placementTemp.school.address -}}
-  {%- else -%}
-    {{ [
-    placementTemp.school.addressLine1,
-    placementTemp.school.addressLine2,
-    placementTemp.school.town
-    ] | removeEmpty | separateLines }}
-  {%- endif -%}
-{%- endset %}
-
-{{ govukTextarea({
-  label: {
-    text: "Address",
-    classes: "govuk-label--s"
-  },
-  classes: "govuk-!-width-two-thirds",
-  value: address if isManualEntry
-} | decorateAttributes(placementTemp, "placementTemp.school.address"))}}
 
 {{ govukInput({
   label: {

--- a/app/views/_includes/forms/placements/details-manual.html
+++ b/app/views/_includes/forms/placements/details-manual.html
@@ -22,7 +22,7 @@
 
 {{ govukInput({
   label: {
-    text: "School unique reference number (if available)",
+    text: "School unique reference number (URN) – if it has one",
     classes: "govuk-label--s"
   },
   _hint: {

--- a/app/views/_includes/forms/placements/details.html
+++ b/app/views/_includes/forms/placements/details.html
@@ -51,7 +51,7 @@
 
 <div class="app-js-only">
   {{ govukDetails({
-    summaryText: "Placement school is not listed, or the school is an early years setting",
+    summaryText: "Placement school or setting is not listed",
     html: detailsHtml,
     open: true if placementTemp.school.manualEntry == "true"
   }) }}

--- a/app/views/_includes/summary-cards/placements/single-placement-details.html
+++ b/app/views/_includes/summary-cards/placements/single-placement-details.html
@@ -15,7 +15,8 @@
 
 {% set placementLocationRow = {
   key: {
-    text: "Placement " + record | schoolOrSettingText
+    text: "Placement " + record | schoolOrSettingText,
+    text: "School or setting"
   },
   value: {
     text: placementSchoolHtml | safe or 'Not provided'

--- a/app/views/new-record/placements/details-manual.html
+++ b/app/views/new-record/placements/details-manual.html
@@ -15,7 +15,7 @@
 {# First / Second / Third #}
 {% set ordinalName = ordinalCount | getOrdinalName | sentenceCase %}
 
-{% set pageHeading = ordinalName + " placement " + ( data.record | schoolOrSettingText ) %}
+{% set pageHeading = ordinalName + " placement" %}
 
 {% set formAction = "./details-answer" | addReferrer(referrer) %}
 

--- a/app/views/new-record/placements/details.html
+++ b/app/views/new-record/placements/details.html
@@ -15,7 +15,7 @@
 {# First / Second / Third #}
 {% set ordinalName = ordinalCount | getOrdinalName | sentenceCase %}
 
-{% set pageHeading = ordinalName + " placement school" %}
+{% set pageHeading = ordinalName + " placement" %}
 
 {% set formAction = "./details-answer" | addReferrer(referrer) %}
 

--- a/app/views/new-record/placements/placement-results.html
+++ b/app/views/new-record/placements/placement-results.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_new-record.html" %}
 
-{% set pageHeading = "Placement school search results" %}
+{% set pageHeading = "Placement search results" %}
 {% set schoolType = 'placement' %}
 
 {% set formAction = "./details-answer" | addReferrer(referrer) %}

--- a/app/views/record/placements/details-manual.html
+++ b/app/views/record/placements/details-manual.html
@@ -15,7 +15,7 @@
 {# First / Second / Third #}
 {% set ordinalName = ordinalCount | getOrdinalName | sentenceCase %}
 
-{% set pageHeading = ordinalName + " placement " + ( data.record | schoolOrSettingText ) %}
+{% set pageHeading = ordinalName + " placement" %}
 
 {% set formAction = "./details-answer" | addReferrer(referrer) %}
 

--- a/app/views/record/placements/details.html
+++ b/app/views/record/placements/details.html
@@ -15,7 +15,7 @@
 {# First / Second / Third #}
 {% set ordinalName = ordinalCount | getOrdinalName | sentenceCase %}
 
-{% set pageHeading = ordinalName + " placement school" %}
+{% set pageHeading = ordinalName + " placement" %}
 
 {% set formAction = "./details-answer" | addReferrer(referrer) %}
 

--- a/app/views/record/placements/placement-results.html
+++ b/app/views/record/placements/placement-results.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_record-form.html" %}
 
-{% set pageHeading = "Placement school search results" %}
+{% set pageHeading = "Placement search results" %}
 {% set schoolType = 'placement' %}
 
 {% set formAction = "./details-answer" | addReferrer(referrer) %}


### PR DESCRIPTION
Updates to the manual placement fields:

* Rename the name to `School or setting name` for both manual and early years
* Mention urn is 'if it has one' for manual (@johndoates we may want to consider this)
* Remove address - @claire-hughez is happy that postcode is sufficient
* Try to harmonise the language between non early years and early years
* Try to avoid referring to schools at all where it makes sense - 'First placement' rather than 'First placement school'

## Manual placement details
<img width="1029" alt="Screenshot 2023-06-05 at 14 21 41" src="https://github.com/DFE-Digital/register-trainee-teachers-prototype/assets/2204224/901f43bb-dac4-45be-87a1-ee5dcb0ede50">

## Summary card
<img width="996" alt="Screenshot 2023-06-05 at 14 22 27" src="https://github.com/DFE-Digital/register-trainee-teachers-prototype/assets/2204224/adee51eb-6dca-4eb2-835f-4c35ea9c24b8">

## Early years placement details
<img width="1018" alt="Screenshot 2023-06-05 at 14 22 58" src="https://github.com/DFE-Digital/register-trainee-teachers-prototype/assets/2204224/ebb1f114-0fcf-4d47-8ce0-57e894302267">

