### PR TITLE
Add banner for new academic year

### DIFF
--- a/app/views/home.html
+++ b/app/views/home.html
@@ -17,8 +17,8 @@
 {% set traineesWithProblems = registeredTrainees | filterByFunction('recordHasProblem') %}
 {# {% set traineeProblems = data.traineeProblems | filterBySignedIn(data) %} #}
 
-{% set newAcademicYearUpcoming = false %}
-{% set newAcademicYear = true %}
+{% set newAcademicYearUpcoming = true %}
+{% set newAcademicYear = false %}
 
 
 {% block content %}

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -17,10 +17,44 @@
 {% set traineesWithProblems = registeredTrainees | filterByFunction('recordHasProblem') %}
 {# {% set traineeProblems = data.traineeProblems | filterBySignedIn(data) %} #}
 
+{% set newAcademicYearUpcoming = false %}
+{% set newAcademicYear = true %}
+
+
 {% block content %}
+
+{% if newAcademicYearUpcoming %}
+
+  {% set html %}
+    <h3 class="govuk-notification-banner__heading">
+      The 2023 to 2024 academic year will start on 1 August
+    </h3>
+    <p class="govuk-body"><a class="govuk-notification-banner__link" href="#">View dates and deadlines</a> for the upcoming academic year.</p>
+  {% endset %}
+
+  {{ govukNotificationBanner({
+    html: html
+  }) }}
+
+{% elseif newAcademicYear %}
+  {% set html %}
+    <h3 class="govuk-notification-banner__heading">
+      The 2023 to 2024 academic year started on 1 August
+    </h3>
+    <p class="govuk-body"><a class="govuk-notification-banner__link" href="#">View dates and deadlines</a> for this academic year.</p>
+  {% endset %}
+
+  {{ govukNotificationBanner({
+    html: html
+  }) }}
+{% endif %}
+
+
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
+
+
       <span class="govuk-caption-l">{{ data.signedInProviders | andSeparate }}</span>
 
       <h1 class="govuk-heading-xl">{{ pageHeading }}</h1>


### PR DESCRIPTION
Banner to be shown prior to new academic year:

<img width="1112" alt="Screenshot 2023-06-01 at 11 46 33" src="https://github.com/DFE-Digital/register-trainee-teachers-prototype/assets/2204224/dc3aae65-a306-4c86-93ed-52e2587cbcb1">

Banner to be shown after start of new academic year:
<img width="1051" alt="Screenshot 2023-06-01 at 11 47 35" src="https://github.com/DFE-Digital/register-trainee-teachers-prototype/assets/2204224/4664813f-0165-43cf-b798-7ead52b39049">
