### PR TITLE
Replaced links which were removed for research

### DIFF
--- a/app/views/home.html
+++ b/app/views/home.html
@@ -43,9 +43,9 @@
           {# {% if applyPendingRecordsCount > 0 %}
             <li><a class="govuk-link" href="/drafts/apply-importable">{{ applyPendingRecordsCount }} Apply offer available to import</a></li>
           {% endif %} #}
-          {# {% if applyPendingRecordsCount > 0 %}
+          {% if applyPendingRecordsCount > 0 %}
             <li><a class="govuk-link" href="/drafts/apply-importable">Import applications from Apply with conditions pending ({{applyPendingRecordsCount}})</a></li>
-          {% endif %} #}
+          {% endif %}
 
           {% if isAuthorised('addTrainees') %}
             <li class="govuk-!-margin-bottom-0">
@@ -159,11 +159,11 @@
         {% set traineesThatCanBeRecommended = filteredRecords | filterByReadyToRecommend %}
         {% set traineeCount = traineesThatCanBeRecommended | length %}
         {# Bulk recommend #}
-        {# <a href="/bulk-update/recommend/upload" class="status-card">
-          <span class="status-card__count">{{traineeCount}}</span> #}
+        <a href="/bulk-update/recommend/upload" class="status-card">
+          <span class="status-card__count">{{traineeCount}}</span>
           {# <span class="status-card__status">{{data.years.currentAcademicYear}} academic year</span><span class="govuk-visually-hidden"> records. View these records.</span> #}
-          {# <span class="status-card__status">Trainees you can bulk recommend for QTS or EYTS</span><span class="govuk-visually-hidden"> records. View these records.</span>
-        </a> #}
+          <span class="status-card__status">Trainees you can bulk recommend for QTS or EYTS</span><span class="govuk-visually-hidden"> records. View these records.</span>
+        </a>
 
         {# Incomplete #}
         {% set incompleteTrainees = registeredTrainees | filterByIncomplete %}


### PR DESCRIPTION
In a previous pull request we [removed a couple of links to new functionality from the home page](https://github.com/DFE-Digital/register-trainee-teachers-prototype/pull/640). We did this because we had research coming up and we did not want to distract participants, who would be asked to start on the home page.

We can now add these links back to the page.