### PR TITLE
6408 Stop blocking QTS if placement data missing

### DIFF
--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -1538,7 +1538,7 @@ exports.needsStartDate = function(record) {
   return needsStartDate
 }
 
-// Check if there are outsanding actions (Either adding start date or placements details)
+// Check if there are outstanding actions (Either adding start date or placements details)
 exports.hasOutstandingActions = function(record, data = false) {
 
   data = Object.assign({}, (data || this?.ctx?.data || false))

--- a/app/views/_includes/record-actions.njk
+++ b/app/views/_includes/record-actions.njk
@@ -142,7 +142,7 @@
           text: "The trainee’s ITT starts on " + (record.courseDetails.startDate | govukDate),
           classes: "govuk-!-margin-0"
         }) }}
-        {% elseif record | hasOutstandingActions %}
+        {% elseif record | needsStartDate %}
           {{ govukInsetText({
             text: "This trainee record requires additional details",
             classes: "govuk-!-margin-0"


### PR DESCRIPTION
We want to block QTS from being awaded if there is no start date but allow it even if placement data is missing. I've made a minor change to the logic on the award QTS button to test against ```needsStartDate``` rather than ```hasOutstandingActions```