### PR TITLE
Removed placements required for qualification text

### DIFF
--- a/app/views/new-record/placements/confirm.html
+++ b/app/views/new-record/placements/confirm.html
@@ -26,7 +26,7 @@
       {% if placementCount < minPlacementsRequired %}
         {% set insetTextHtml %}
           <p class="govuk-body">
-            You need to add the details of at least {{ minPlacementsRequired }} {{ ( record | schoolOrSettingText ) | pluralise(data.settings.minPlacementsRequired) }} before you can recommend this trainee for {{ record | getQualificationText }}. These can be added at any time.
+            You need to add the details of at least {{ minPlacementsRequired }} {{ ( record | schoolOrSettingText ) | pluralise(data.settings.minPlacementsRequired) }}. These can be added at any time.
           </p>
         {% endset %}
 

--- a/app/views/record/placements/confirm.html
+++ b/app/views/record/placements/confirm.html
@@ -26,7 +26,7 @@
       {% if placementCount < minPlacementsRequired %}
         {% set insetTextHtml %}
           <p class="govuk-body">
-            You need to add the details of at least {{ minPlacementsRequired }} {{ ( record | schoolOrSettingText ) | pluralise(data.settings.minPlacementsRequired) }} before you can recommend this trainee for {{ record | getQualificationText }}. These can be added at any time.
+            You need to add the details of at least {{ minPlacementsRequired }} {{ ( record | schoolOrSettingText ) | pluralise(data.settings.minPlacementsRequired) }}. These can be added at any time.
           </p>
         {% endset %}
 


### PR DESCRIPTION
Placements won’t be a requirement for awarding QTS initially. They are required though for the ITC census.