### PR TITLE
Content alterations

### DIFF
--- a/app/views/bulk-update/add-new/confirmation.html
+++ b/app/views/bulk-update/add-new/confirmation.html
@@ -18,11 +18,23 @@
         classes: "govuk-!-margin-bottom-7"
       }) }}
 
+      <p class="govuk-body govuk-body-lead">You can view your trainee records to check if they are correct.</p>
+
       <p class="govuk-body">
         <a href="/records" class="govuk-link">
           View your trainee records
         </a>
       </p>
+
+      <p class="govuk-body">There are 3 ways to check trainee data in Register.</p>
+      <p class="govuk-body">Choose whichever one of the following that suits you:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Use the ‘Reports’ section and export a CSV of your new trainees for the current academic year</li>
+        <li>Export a CSV of your trainees in the ‘Registered trainees’ section, using the ‘start year’ filter to select the current academic year</li>
+        <li>Check your trainees directly in the service one by one</li>
+      </ul>
+
     </div>
   </div>
 

--- a/app/views/bulk-update/add-new/index.html
+++ b/app/views/bulk-update/add-new/index.html
@@ -1,6 +1,6 @@
 {% extends "_templates/_page.html" %}
 
-{% set pageHeading = "Bulk add new draft trainees" %}
+{% set pageHeading = "Bulk add new trainees" %}
 {% set navActive = 'bulk' %}
 
 {% set filteredRecords = data.records | filterRecords(data) %}
@@ -40,7 +40,7 @@
         {{ pageHeading }}
       </h1>
       <p class="govuk-body">
-        Training providers can register their trainees in bulk by creating draft trainee records and adding the required data.
+        Training providers can register their trainees in bulk by creating trainee records and adding the required data.
       </p>
       <h2 class="govuk-heading-m">
         1. Download empty template CSV file
@@ -55,26 +55,16 @@
       <h2 class="govuk-heading-m">
         2. Add new trainee details
       </h2>
-      <p class="govuk-body">
-        Open as a CSV file and add trainee information:
-      </p>
+      <p class="govuk-body">Open as a CSV file to add trainee details in bulk.</p>
+      <p class="govuk-body">You will need to include trainee information such as:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>type of training</li>
-        <li>first name</li>
-        <li>last name</li>
-        <li>date of birth</li>
-        <li>gender</li>
-        <li>nationality</li>
-        <li>personal email address</li>
-        <li>ethnicity</li>
-        <li>disabilities and health conditions</li>
-        <li>degree</li>
+        <li>personal information</li>
         <li>course details</li>
-        <li>funding</li>
+        <li>funding (if eligible)</li>
       </ul>
-      <p class="govuk-body">
-        You can leave non mandatory rows or cells empty if you do not want to upload those fields.
-      </p>
+      <p class="govuk-body">You can leave non mandatory rows or cells empty if you do not want to upload those fields.</p>
+      <!-- Placeholder link added, the guidance hasn't been written yet so we don't have a URL to point to -->
+      <p class="govuk-body">Check <a class="govuk-link" href="#">guidance on how add trainee information to the CSV template</a>.</p>
       <h2 class="govuk-heading-m">
         3. Upload your trainee records
       </h2>


### PR DESCRIPTION
- Mentions of ‘Draft’ removed as newly imprted trainees wouldn’t be set as draft.
- List of required required information generalised as there are currently 45 possible columns
- New content added to the confirmation page.