### PR TITLE
Revert node-sass to v8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lunr": "^2.3.9",
     "marked": "^4.0.17",
     "moment": "^2.27.0",
-    "node-sass": "^9.0.0",
+    "node-sass": "^8.0.0",
     "notifications-node-client": "^8.2.0",
     "nunjucks": "^3.2.3",
     "nunjucks-markdown": "^2.0.1",


### PR DESCRIPTION
`node-sass@9.0.0` breaks the prototype! This PR reverts to `node-sass@v8.0.0`.