### PR TITLE
Fix deprecated faker API methods

### DIFF
--- a/app/data/accrediting-providers.js
+++ b/app/data/accrediting-providers.js
@@ -1,4 +1,4 @@
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 
 // Seed allows the UUIDs to be consistent each time we run this. The seed should be different than that used by lead-schools.js so we get different UUIDs for each.
 faker.seed(124);

--- a/app/data/accrediting-providers.js
+++ b/app/data/accrediting-providers.js
@@ -345,9 +345,9 @@ const makeObject = (providers, type) => {
       type: "accreditingProvider",
       accreditingProviderType: type,
       id: faker.string.uuid(),
-      ukprn: faker.datatype.number({ min: 100000, max: 999999 }),
+      ukprn: faker.number.int({ min: 100000, max: 999999 }),
       providerCode: faker.random.alphaNumeric(3).toUpperCase(),
-      accreditationId: faker.datatype.number({ min: 1000, max: 9999 }),
+      accreditationId: faker.number.int({ min: 1000, max: 9999 }),
       shouldImportFromApply: faker.random.boolean
     }
   } )

--- a/app/data/accrediting-providers.js
+++ b/app/data/accrediting-providers.js
@@ -346,7 +346,7 @@ const makeObject = (providers, type) => {
       accreditingProviderType: type,
       id: faker.string.uuid(),
       ukprn: faker.number.int({ min: 100000, max: 999999 }),
-      providerCode: faker.random.alphaNumeric(3).toUpperCase(),
+      providerCode: faker.string.alphanumeric(3).toUpperCase(),
       accreditationId: faker.number.int({ min: 1000, max: 9999 }),
       shouldImportFromApply: faker.random.boolean
     }

--- a/app/data/accrediting-providers.js
+++ b/app/data/accrediting-providers.js
@@ -330,10 +330,10 @@ const scitt = [
 // // Returns a smaller set of providers as the real set is too big
 // const getSelectedProviders = (providers, permanentProviders) => {
 //   // One in 50 providers
-//   let reducedProviders = providers.filter((provider, index) => { 
+//   let reducedProviders = providers.filter((provider, index) => {
 //     return (index % 50 === 0)
 //   })
-  
+
 //   reducedProviders = reducedProviders.concat(permanentAccreditingProviders).sort()
 //   return [...new Set(reducedProviders)] // Uniq
 // }
@@ -344,7 +344,7 @@ const makeObject = (providers, type) => {
       name: provider,
       type: "accreditingProvider",
       accreditingProviderType: type,
-      id: faker.datatype.uuid(),
+      id: faker.string.uuid(),
       ukprn: faker.datatype.number({ min: 100000, max: 999999 }),
       providerCode: faker.random.alphaNumeric(3).toUpperCase(),
       accreditationId: faker.datatype.number({ min: 1000, max: 9999 }),

--- a/app/data/accrediting-providers.js
+++ b/app/data/accrediting-providers.js
@@ -348,7 +348,7 @@ const makeObject = (providers, type) => {
       ukprn: faker.number.int({ min: 100000, max: 999999 }),
       providerCode: faker.string.alphanumeric(3).toUpperCase(),
       accreditationId: faker.number.int({ min: 1000, max: 9999 }),
-      shouldImportFromApply: faker.random.boolean
+      shouldImportFromApply: faker.datatype.boolean()
     }
   } )
 }

--- a/app/data/generators/apply-data.js
+++ b/app/data/generators/apply-data.js
@@ -1,4 +1,4 @@
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 const moment    = require('moment')
 const weighted          = require('weighted')
 

--- a/app/data/generators/contact-details.js
+++ b/app/data/generators/contact-details.js
@@ -1,25 +1,25 @@
-const { fakerUK: fakerFR } = require('@faker-js/faker')
+const { fakerFR: fakerFR } = require('@faker-js/faker')
 const { fakerUK: faker } = require('@faker-js/faker')
 
 
 module.exports = (personalDetails) => {
   let address, internationalAddress = undefined
-  let county = undefined // faker.address.county()
+  let county = undefined // faker.location.county()
 
   if (personalDetails.isInternationalTrainee) {
-    internationalAddress = `${fakerFR.address.streetAddress()}
-${fakerFR.address.city()}
-${fakerFR.address.state()}
-${fakerFR.address.zipCode()}`
+    internationalAddress = `${fakerFR.location.streetAddress()}
+${fakerFR.location.city()}
+${fakerFR.location.state()}
+${fakerFR.location.zipCode()}`
   }
   else {
 
     address = {
-      line1: faker.address.streetAddress(),
+      line1: faker.location.streetAddress(),
       line2: '',
-      level2: faker.address.city(),
-      level1: personalDetails.isInternationalTrainee ? faker.address.state() : county,
-      postcode: faker.address.zipCode(),
+      level2: faker.location.city(),
+      level1: personalDetails.isInternationalTrainee ? faker.location.state() : county,
+      postcode: faker.location.zipCode(),
       ...(personalDetails.isInternationalTrainee && { country: 'France' })
     }
   }

--- a/app/data/generators/contact-details.js
+++ b/app/data/generators/contact-details.js
@@ -1,4 +1,5 @@
-const { faker } = require('@faker-js/faker')
+const { fakerUK: fakerFR } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 
 
 module.exports = (personalDetails) => {
@@ -6,15 +7,13 @@ module.exports = (personalDetails) => {
   let county = undefined // faker.address.county()
 
   if (personalDetails.isInternationalTrainee) {
-    faker.locale = 'fr'
-    internationalAddress = `${faker.address.streetAddress()}
-${faker.address.city()}
-${faker.address.state()}
-${faker.address.zipCode()}`
-  } 
+    internationalAddress = `${fakerFR.address.streetAddress()}
+${fakerFR.address.city()}
+${fakerFR.address.state()}
+${fakerFR.address.zipCode()}`
+  }
   else {
-    faker.locale = 'en_GB'
-    
+
     address = {
       line1: faker.address.streetAddress(),
       line2: '',

--- a/app/data/generators/course-details.js
+++ b/app/data/generators/course-details.js
@@ -61,7 +61,7 @@ const setSubjectSpecialisms = (courseDetails, pickRandom) => {
           courseDetails.publishSubjects.second = "Modern languages"
           break
       }
-      
+
       courseDetails.subjects = subjects
 
     }
@@ -98,7 +98,7 @@ module.exports = (params, application) => {
   const isNonDraft = utils.isNonDraft(params)
   const isApplyDraft = utils.sourceIsApply(application) && isDraft
   const isManualDraft = utils.sourceIsManual(application) && isDraft
-  
+
   const sectionIsComplete = (params?.courseDetails?.status == "Completed")
 
   // Whether to pretend that missing or ambiguous data hase already been set
@@ -124,7 +124,7 @@ module.exports = (params, application) => {
     // Grab course details from seed courses
     let routeCourses = providerCoursesByYear.filter(course => course.route == application.route)
 
-    // Todo: seed courses for a provider might not align with selected or enabled routes. 
+    // Todo: seed courses for a provider might not align with selected or enabled routes.
     // Think of a better way of handling this
     if (!routeCourses.length) {
       console.log(`No courses found for ${application.route} for ${application.provider}. Using all routes`)
@@ -154,9 +154,9 @@ module.exports = (params, application) => {
     // for them. We're not saving these back to the course though (awkward to do) as we are probably
     // more interested in the new user journey.
     if (pretendDataIsComplete){
-      let randomDay = faker.datatype.number({
-        'min': 1,
-        'max': 28
+      let randomDay = faker.number.int({
+        min: 1,
+        max: 28
       })
       let startDateVague = moment(courseDetails.startDateVague).toDate()
       let startMonth = startDateVague.getMonth() + 1 // Month 0 is Jan
@@ -166,7 +166,7 @@ module.exports = (params, application) => {
     }
 
     // Some Pubish courses are set to `Full time or part time` - when a user adds one of these
-    // courses we’ll assume `Full time` but let the user override it. 
+    // courses we’ll assume `Full time` but let the user override it.
     if (pretendDataIsComplete && courseDetails.studyMode == "Full time or part time"){
       courseDetails.studyMode = "Full time"
     }

--- a/app/data/generators/course-details.js
+++ b/app/data/generators/course-details.js
@@ -1,8 +1,7 @@
 
 const moment            = require('moment')
 const weighted          = require('weighted')
-const { faker }         = require('@faker-js/faker')
-faker.locale            = 'en_GB'
+const { fakerUK: faker }         = require('@faker-js/faker')
 const trainingRouteData = require('./../training-route-data')
 const ittSubjects       = require('./../itt-subjects')
 const courses           = require('./../courses.json')

--- a/app/data/generators/course-generator.js
+++ b/app/data/generators/course-generator.js
@@ -30,9 +30,9 @@ const generateCourseCode = () => {
   let chars = 'ABCDEFGHGKLMNPQRSTWXYZ' // without I or O
   let code = chars.charAt(Math.floor(Math.random() * chars.length));
   for (var i = 0; i < 3; i++){
-    code += faker.datatype.number({
-      'min': 0,
-      'max': 9
+    code += faker.number.int({
+      min: 0,
+      max: 9
     })
   }
   return code

--- a/app/data/generators/course-generator.js
+++ b/app/data/generators/course-generator.js
@@ -82,7 +82,7 @@ const pickRoute = (isPublishCourse = false) => {
 // Return some realistic subjects a primary teacher might train in
 // Only used for 'manually added' trainees
 const getPrimarySubjects = subjectCount => {
-  
+
   // Assumption that all primary courses have `Primary` as the first subject
   let subjects = ["Primary teaching"]
 
@@ -179,7 +179,7 @@ const getSecondaryPublishSubjects = (subjectCount) => {
     subjects = faker.helpers.arrayElement([
       faker.helpers.arrayElement(ittSubjects.corePublishSubjects),
       faker.helpers.arrayElement(nonPrimaryPublishSubjects),
-      // In Publish users pick specific languages - this isn't modelled here - instead we just set 
+      // In Publish users pick specific languages - this isn't modelled here - instead we just set
       // 'Modern languages' and the ui will ask which language. We do include single languages though.
       "Modern languages",
       randomisedLanguages.slice(0,1), // One language
@@ -263,7 +263,7 @@ module.exports = (params) => {
       subjectCount = weighted.select([1,2,3],[0.6,0.3,0.1]) // 40% multiple subjects
       subjects = getSecondarySubjects(subjectCount)
     }
-    
+
   }
 
   publishCourseSubjects = [].concat(publishCourseSubjects) // coerce to array just in case
@@ -330,7 +330,7 @@ module.exports = (params) => {
         }
       }
     }
-    
+
   }
   // Part time
   else {
@@ -373,7 +373,7 @@ module.exports = (params) => {
 
     const code = generateCourseCode() // G568
 
-    const id = faker.datatype.uuid()
+    const id = faker.string.uuid()
 
     // English with biology
     let courseNameShort = `${utils.prettifySubjects(publishCourseSubjects)}`

--- a/app/data/generators/course-generator.js
+++ b/app/data/generators/course-generator.js
@@ -5,8 +5,7 @@
 
 const moment            = require('moment')
 const weighted = require('weighted')
-const { faker }         = require('@faker-js/faker')
-faker.locale            = 'en_GB'
+const { fakerUK: faker }         = require('@faker-js/faker')
 const trainingRouteData = require('./../training-route-data')
 
 const utils             = require('./../../lib/utils.js')

--- a/app/data/generators/dates.js
+++ b/app/data/generators/dates.js
@@ -1,4 +1,4 @@
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 const moment    = require('moment')
 
 // Faker has a bug that faker.helpers.dateBetween requires the input dates to be in order
@@ -122,12 +122,12 @@ module.exports = ({updatedDate, submittedDate, deferredDate, withdrawalDate, qua
     deferredDate = deferredDate || updatedDate
   }
 
-  if (application.status === 'Withdrawn') {    
+  if (application.status === 'Withdrawn') {
     // Make sure withdrawal date is the same as the last updated date
     withdrawalDate = withdrawalDate || updatedDate
   }
 
-  if (application.status.includes('awarded')) {    
+  if (application.status.includes('awarded')) {
     let courseEndDate = application.courseDetails.endDate
 
     qualificationAwardedDate = faker.date.between(

--- a/app/data/generators/degree.js
+++ b/app/data/generators/degree.js
@@ -6,13 +6,13 @@ const degreeInstitutions = require('../degree-instituions')
 module.exports = (params, application) => {
 
   const isApplyDraft = (application.source == 'Apply' && application.status == "Draft")
-  
+
   const item = (faker) => {
     let subject = faker.helpers.arrayElement(degreeData().subjects)
     const predicted = faker.datatype.boolean()
     const endDate = faker.helpers.arrayElement(['2020','2019','2018','2017','2016','2015'])
     const startDate = (parseInt(endDate) - 4).toString()
-    const id = faker.datatype.uuid()
+    const id = faker.string.uuid()
     const sectionIsComplete = (params?.degree?.status == "Completed")
     const invalidAllowed = (params?.invalidAllowed === false) ? false : true
 

--- a/app/data/generators/gcse.js
+++ b/app/data/generators/gcse.js
@@ -1,4 +1,4 @@
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 const weighted  = require('weighted')
 const gcseData  = require('../gcse')
 

--- a/app/data/generators/gcse.js
+++ b/app/data/generators/gcse.js
@@ -116,7 +116,7 @@ module.exports = (isInternationalTrainee, simpleGcseGrades) => {
               comparable: 'GCSE grades A*-C/9-4'
             },
             grade: [{
-              grade: faker.datatype.number({ min: 10, max: 20 })
+              grade: faker.number.int({ min: 10, max: 20 })
             }],
             year
           },
@@ -133,7 +133,7 @@ module.exports = (isInternationalTrainee, simpleGcseGrades) => {
               comparable: 'GCSE (grades A*-C / 9-4)'
             },
             grade: [{
-              grade: faker.datatype.number({ min: 10, max: 20 })
+              grade: faker.number.int({ min: 10, max: 20 })
             }],
             year
           },
@@ -150,7 +150,7 @@ module.exports = (isInternationalTrainee, simpleGcseGrades) => {
               comparable: 'GCSE (grades A*-C / 9-4)'
             },
             grade: [{
-              grade: faker.datatype.number({ min: 10, max: 20 })
+              grade: faker.number.int({ min: 10, max: 20 })
             }],
             year
           }

--- a/app/data/generators/hesa-data.js
+++ b/app/data/generators/hesa-data.js
@@ -1,4 +1,4 @@
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 const moment    = require('moment')
 const weighted   = require('weighted')
 

--- a/app/data/generators/hesa-data.js
+++ b/app/data/generators/hesa-data.js
@@ -17,11 +17,10 @@ module.exports = record => {
     record.courseDetails.endDate = weighted.select([null, endDate], percentageMissing)
   }
 
-  let hesaId = `2294839475${faker.datatype.number({'min': 1000000, 'max': 9999999})}`
+  let hesaId = `2294839475${faker.number.int({min: 1000000, max: 9999999})}`
 
   record.hesa = {
     id: hesaId
   }
   return record
 }
-

--- a/app/data/generators/iqts-data.js
+++ b/app/data/generators/iqts-data.js
@@ -1,4 +1,4 @@
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 
 const countries = require('../countries')
 const countriesExcludingUK = countries.filter(country => country != "United Kingdom")

--- a/app/data/generators/personal-details.js
+++ b/app/data/generators/personal-details.js
@@ -1,5 +1,4 @@
-const { faker }  = require('@faker-js/faker')
-faker.locale     = 'en_GB'
+const { fakerUK: faker }  = require('@faker-js/faker')
 const weighted   = require('weighted')
 
 module.exports = () => {

--- a/app/data/generators/placement.js
+++ b/app/data/generators/placement.js
@@ -1,5 +1,5 @@
 const weighted  = require('weighted')
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 
 const allSchools = require('../gis-schools.js')
 

--- a/app/data/generators/placement.js
+++ b/app/data/generators/placement.js
@@ -14,7 +14,7 @@ module.exports = (params) => {
       school,
       // startMonth,
       // duration,
-      id: faker.datatype.uuid()
+      id: faker.string.uuid()
     }
   }
 
@@ -53,7 +53,7 @@ module.exports = (params) => {
     return {}
   } else {
     return {
-      items: items, 
+      items: items,
       status
     }
   }

--- a/app/data/generators/reference-number.js
+++ b/app/data/generators/reference-number.js
@@ -1,4 +1,4 @@
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 const moment    = require('moment')
 
 // Two letters followed by four numbers

--- a/app/data/generators/reference-number.js
+++ b/app/data/generators/reference-number.js
@@ -8,9 +8,9 @@ const generateReference = () => {
   let getRandomChar = () => chars.charAt(Math.floor(Math.random() * chars.length));
   let code = getRandomChar() + getRandomChar()
   for (var i = 0; i < 4; i++){
-    code += faker.datatype.number({
-      'min': 0,
-      'max': 9
+    code += faker.number.int({
+      min: 0,
+      max: 9
     })
   }
   return code

--- a/app/data/generators/route.js
+++ b/app/data/generators/route.js
@@ -1,4 +1,4 @@
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 const moment    = require('moment')
 const weighted  = require('weighted')
 

--- a/app/data/generators/schools.js
+++ b/app/data/generators/schools.js
@@ -2,7 +2,7 @@
 
 const moment      = require('moment')
 const weighted    = require('weighted')
-const { faker }   = require('@faker-js/faker')
+const { fakerUK: faker }   = require('@faker-js/faker')
 const allSchools  = require('../gis-schools.js')
 
 // Using the urn to match against
@@ -13,8 +13,6 @@ const leadSchoolUrns = require('./../lead-schools.js').selected.map(school => sc
 const filteredSchools = allSchools.filter(school => leadSchoolUrns.includes(school?.urn))
 
 const trainingRouteData = require('../training-route-data')
-
-faker.locale  = 'en_GB'
 
 const requiresLeadSchool = params => {
   let routeData = trainingRouteData.trainingRoutes[params.route]

--- a/app/data/generators/training-details.js
+++ b/app/data/generators/training-details.js
@@ -2,10 +2,8 @@
 
 const moment      = require('moment')
 const weighted    = require('weighted')
-const { faker }   = require('@faker-js/faker')
+const { fakerUK: faker }   = require('@faker-js/faker')
 const schools     = require('../gis-schools.js')
-
-faker.locale  = 'en_GB'
 
 // Not all trainees have start dates - but to get these statuses you must have
 const statusesWhereTraineesMustHaveStarted = [

--- a/app/data/generators/training-details.js
+++ b/app/data/generators/training-details.js
@@ -19,7 +19,7 @@ const statusesWhereTraineesMustHaveStarted = [
 module.exports = (params) => {
 
   // Todo: make traineeId closer to what Providers user (20/21-1234, etc)
-  const traineeIdNumber = faker.random.alphaNumeric(8).toUpperCase()
+  const traineeIdNumber = faker.string.alphanumeric(8).toUpperCase()
 
   // Much better to use submitted date
   let commencementDate = params?.submittedDate || faker.date.between(

--- a/app/data/generators/trn.js
+++ b/app/data/generators/trn.js
@@ -1,4 +1,4 @@
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 
 const statusesWithoutTRNs = [
   "Draft",

--- a/app/data/generators/trn.js
+++ b/app/data/generators/trn.js
@@ -10,7 +10,7 @@ module.exports = application => {
   let trn
 
   if (!statusesWithoutTRNs.includes(application.status)){
-    trn = faker.datatype.number({
+    trn = faker.number.int({
       'min': 1000000,
       'max': 9999999
     })

--- a/app/data/lead-schools.js
+++ b/app/data/lead-schools.js
@@ -66,7 +66,7 @@ let selectedLeadSchools = [
   // },
   // {
   //   name: "Tarporley High School and Sixth Form College",
-  //   postcode: "CW6 0BL", 
+  //   postcode: "CW6 0BL",
   //   urn: "138483"
   // },
   // {
@@ -97,7 +97,7 @@ module.exports = {
     return {
       type: "leadSchool",
       ...school,
-      id: faker.datatype.uuid()
+      id: faker.string.uuid()
     }
   })
 }

--- a/app/data/lead-schools.js
+++ b/app/data/lead-schools.js
@@ -1,4 +1,4 @@
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 
 // Seed allows the UUIDs to be consistent each time we run this. The seed should be different than that used by lead-schools.js so we get different UUIDs for each.
 faker.seed(123);

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -79,7 +79,7 @@ exports.getOrdinalName = integer => {
     'ninth',
     'tenth'
   ]
-  
+
   if (!_.isNumber(integer) || integer < 1 || integer > 10){
     console.log("Error in getOrdinalName: input out of bounds")
     return ""
@@ -224,7 +224,7 @@ exports.setAcademicYears = record => {
 
 // Calculates academic years for a trainee
 // Academic years are all the years that the trainee was in training for
-// A trainee that started in 2019 to 2020 and is still in training in 2022 to 2023 
+// A trainee that started in 2019 to 2020 and is still in training in 2022 to 2023
 // will have academic years of: ['2019 to 2020','2020 to 2021', '2021 to 2022', '2022 to 2023']
 
 // For finished trainees, it'll be all the years between start year and end year. For trainees
@@ -636,7 +636,7 @@ exports.getFinancialSupport = record => {
 
   // Allocation subject may be falsy. For some routes this will mean we can’t calulate the financialSupport
   // for Early years, it doesn't matter
-  let allocationSubject = exports.getAllocationSubject(record) 
+  let allocationSubject = exports.getAllocationSubject(record)
   return exports.getFinancialSupportByRouteAndSubject(record.route, allocationSubject)
 }
 
@@ -793,7 +793,7 @@ exports.updatePublishCourse = function(course, data=false){
     return foundCourse
   })
 
-  if (!foundCourse) console.log(`Error: course ${course?.courseNameLong} not found, so couldn’t be 
+  if (!foundCourse) console.log(`Error: course ${course?.courseNameLong} not found, so couldn’t be
     updated`)
 
   // This overwrites the one we found by reference. There's probably a cleaner way of
@@ -837,7 +837,7 @@ exports.routeHasPublishCourses = function(record){
 // Lowercase array excluding some proper nouns
 exports.dynamicLowercase = input => {
   if (!input) return input
-  
+
   // These things shouldn’t get lowercased
   let ignoreSubjects = [
   "Arabic",
@@ -1214,7 +1214,7 @@ exports.isPreviousYears = record => {
 exports.getEndAcademicYear = record => record.endAcademicYear
 
 // Use the course duration to derive an end academic year
-// This is used where we don’t have course end dates - such as for 
+// This is used where we don’t have course end dates - such as for
 // HESA records
 exports.calculateCourseEndAcademicYear = record => {
   if (record?.courseDetails?.duration){
@@ -1279,7 +1279,7 @@ exports.dateHesaRecordUnlocked = record => {
   return moment(`${endCalendarYear}-04-14`).format("YYYY-MM-DD")
 }
 
-/* 
+/*
   A HESA record should be read only if:
   - its not finishing this academic year
   - or its finishing this year, but today’s date is before the cut-off
@@ -1313,7 +1313,7 @@ exports.isHesaAndLocked = record => {
 exports.isCurrentYear = record => {
   let isStartingThisYear = record?.academicYear == years.currentAcademicYear
 
-  // HESA records are sometimes missing course end dates. If 
+  // HESA records are sometimes missing course end dates. If
   let endAcademicYear
   if (record?.courseDetails?.endDate){
     endAcademicYear = exports.dateToAcademicYear(record?.courseDetails?.endDate)
@@ -1324,7 +1324,7 @@ exports.isCurrentYear = record => {
     }
     else if (exports.isPartTime(record)){
       endAcademicYear = record?.academicYear + 1
-    } 
+    }
     else if (exports.isFullTime(record)){
       endAcademicYear = record?.academicYear
     }
@@ -1381,7 +1381,7 @@ exports.routeIsEarlyYears = route => {
   return route && route.includes("Early years")
 }
 
-// Used by placements - for Early years the locations you go to are settings and not 
+// Used by placements - for Early years the locations you go to are settings and not
 // necessarily schools
 exports.schoolOrSettingText = record => {
   if (exports.isEarlyYears(record)) {
@@ -1457,7 +1457,7 @@ exports.recordIsComplete = function(record, data=false ) {
   let recordIsComplete = requiredSections.every(section => {
 
     let sectionStatus = record[section]?.status == "Completed"
-    
+
     // Default
     if (exports.sourceIsManual(record)){
       return sectionStatus
@@ -1542,7 +1542,7 @@ exports.needsStartDate = function(record) {
 exports.hasOutstandingActions = function(record, data = false) {
 
   data = Object.assign({}, (data || this?.ctx?.data || false))
-  
+
   let hasOutstandingActions = false
 
   if (exports.needsStartDate(record)) {
@@ -1913,7 +1913,7 @@ exports.filterRecords = (records, data, filters = {}) => {
         return specialismsMatch || allocationSubjectsMatch || publishSubjectsMatch || publishAllocationSubjectsMatch
 
       })
-      
+
     })
   }
 
@@ -2185,7 +2185,7 @@ exports.sortRecordsByDateUpdated = records => {
 // Look up provider data using the provider name.
 // Works with strings and arrays of strings
 // eg
-// "Coventry University" => 
+// "Coventry University" =>
 // {
 //   name: 'Coventry University',
 //   type: 'accreditingProvider'
@@ -2420,7 +2420,7 @@ exports.updateRecord = (data, newRecord, timelineMessage) => {
 
   // Must be a new record
   if (!newRecord.id){
-    newRecord.id = faker.datatype.uuid()
+    newRecord.id = faker.string.uuid()
     records.push(newRecord)
   }
   // Is an existing record
@@ -2525,7 +2525,7 @@ exports.addToErrorArray = function(item){
   if (!this?.ctx?.data){
     console.log("Error with addToErrorArray: ctx not passed in")
     return false
-  } 
+  }
   let errorArray = this.ctx?.data?.temp?.errorArray || []
   errorArray.push(item)
   _.set(this.ctx, 'data.temp.errorArray', errorArray)
@@ -2561,7 +2561,7 @@ exports.stripPlaceholders = (value, items=false) => {
 Highlight invalid summary list rows
 
 This is filter patches in the ability to highlight rows on a summary list which
-contain invalid answers. 
+contain invalid answers.
 
 We indicate invalid answers by prefacing them with the string **invalid** or **missing**
 
@@ -2569,7 +2569,7 @@ This filter loops through each row, looking for this string in value.html or val
 If found, it adds some classes and messaging, and moves the action link within the value.
 
 It also pushes the name of the row with the error to a temporary array stored
-in the Nunjucks context. This is a hacky way that we can get a list of each of the 
+in the Nunjucks context. This is a hacky way that we can get a list of each of the
 errors visible in a set of summary lists without knowing about the data structure of a
 record. The very act of running this filter on each summary list builds up this array.
 We can then use that array to display a summary at the top of the page. This is combined
@@ -2608,7 +2608,7 @@ exports.highlightInvalidRows = function(rows, params=false) {
       // Values are stored two possible places
       let value = theRow?.value?.html || theRow?.value?.text || ""
       if (_.isString(value)) value = value.trim()
-      
+
       if (featureEnabled){
 
         if (params?.treatEmptyAsMissing && (!value || value == "")) {
@@ -2721,7 +2721,7 @@ exports.markSummaryRow = function(row, params) {
   _.set(row, "value.html", exports.stripPlaceholders(value))// strip any placeholder tags
 
   // Generate an id so we can anchor to this row
-  let id = `summary-list--row-invalid--${faker.datatype.uuid()}`
+  let id = `summary-list--row-invalid--${faker.string.uuid()}`
 
   let message, linkText, linkTextAppendHidden
 
@@ -2799,7 +2799,7 @@ exports.markInput = function(data, params){
   let valueCleaned = exports.stripPlaceholders(data.value) // strip any placeholder tags
 
   // Generate an id so we can anchor to this row
-  let id = data?.id || `app-input-invalid--${faker.datatype.uuid()}`
+  let id = data?.id || `app-input-invalid--${faker.string.uuid()}`
 
   let message
 
@@ -2824,7 +2824,7 @@ exports.markInput = function(data, params){
   }
   else if (type == 'missing'){
     message = `${key} is missing`
-    
+
     data.errorMessage = {
       html: message
     }
@@ -2839,16 +2839,16 @@ exports.markInput = function(data, params){
 
 exports.markInputError = function(data) {
   return exports.markInput.apply(this, [data, 'error'])
-} 
+}
 
 exports.markInputInvalid = function(data) {
   return exports.markInput.apply(this, [data, 'invalid'])
-} 
+}
 
 exports.markInputMissing = function(data) {
   return exports.markInput.apply(this, [data, 'missing'])
-} 
-// Take in a form object to 
+}
+// Take in a form object to
 
 exports.highlightInvalidInputs = function(data, params={}){
 

--- a/app/routes/bulk-update-routes.js
+++ b/app/routes/bulk-update-routes.js
@@ -6,7 +6,7 @@ const seedRandom = require('seedrandom')
 const url = require('url')
 const utils = require('./../lib/utils')
 const weighted = require('weighted')
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 
 let randomSeeded = new seedRandom("recommend")
 

--- a/app/routes/existing-record-routes.js
+++ b/app/routes/existing-record-routes.js
@@ -20,9 +20,9 @@ module.exports = router => {
     else {
       if (newRecord.status == 'Pending TRN'){
         newRecord.status = 'TRN received'
-        newRecord.trn = String(faker.datatype.number({
-          'min': 1000000,
-          'max': 9999999
+        newRecord.trn = String(faker.number.int({
+          min: 1000000,
+          max: 9999999
         }))
         utils.deleteTempData(data)
         utils.updateRecord(data, newRecord, "TRN received")

--- a/app/routes/existing-record-routes.js
+++ b/app/routes/existing-record-routes.js
@@ -1,4 +1,4 @@
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 const path      = require('path')
 const moment    = require('moment')
 const filters   = require('./../filters.js')()

--- a/app/routes/funding-routes.js
+++ b/app/routes/funding-routes.js
@@ -6,7 +6,7 @@ const seedRandom = require('seedrandom')
 const url = require('url')
 const utils = require('./../lib/utils')
 const weighted = require('weighted')
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 
 module.exports = router => {
 

--- a/app/routes/organisations-and-users-routes.js
+++ b/app/routes/organisations-and-users-routes.js
@@ -6,7 +6,7 @@ const seedRandom = require('seedrandom')
 const url = require('url')
 const utils = require('./../lib/utils')
 const weighted = require('weighted')
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 
 module.exports = router => {
 

--- a/app/routes/reports-routes.js
+++ b/app/routes/reports-routes.js
@@ -6,7 +6,7 @@ const path = require('path')
 const url = require('url')
 const utils = require('./../lib/utils')
 const weighted = require('weighted')
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 
 
 module.exports = router => {

--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -190,7 +190,7 @@ module.exports = router => {
         else {
           res.redirect(`${recordPath}/schools/employing-school${referrer}`)
         }
-        
+
       }
       else {
 
@@ -218,7 +218,7 @@ module.exports = router => {
     if (schoolSearchTerm){
       let results = false
       let resultsCount = 0
-      
+
       results = utils.searchSchools(schools, schoolSearchTerm)
       resultsCount = results.length
       results = results.slice(0, 15) // truncate results
@@ -306,7 +306,7 @@ module.exports = router => {
       else {
         res.redirect(`${recordPath}/schools/confirm${referrer}`)
       }
-      
+
     }
 
   })
@@ -560,7 +560,7 @@ module.exports = router => {
     // They’ve chosen to enter details manually
     else if (selectedCourse == "Other"){
 
-      // User has swapped from a publish to a non-publish course. Delete existing publish data 
+      // User has swapped from a publish to a non-publish course. Delete existing publish data
       // but preserve everything else
       if (record?.courseDetails?.isPublishCourse){
         record.courseDetails = utils.deletePublishCourseReferences(record.courseDetails)
@@ -636,7 +636,7 @@ module.exports = router => {
 
         }
 
-        // For apply records we let them pick a Publish course which 
+        // For apply records we let them pick a Publish course which
         // might have a different route.
         if (record.route != record.courseDetails.route){
           console.log(`The selected Publish course’s route does not match the draft’s route. Draft route changed to ${record.courseDetails.route}`)
@@ -699,12 +699,12 @@ module.exports = router => {
         subjectsArray = [courseDetails?.subjects?.first].concat(subjectsArray)
       }
       // It’s possible a second subject has already been set. If so, just add it to the end.
-      // This means if the provider picked two languages, the existing second subject would get pushed 
+      // This means if the provider picked two languages, the existing second subject would get pushed
       // to the third slot
       else if (courseDetails?.subjects?.second) {
         subjectsArray.push(courseDetails.subjects.second)
       }
-      // If there's a null entry that means we've got an unmapped Publish subject - add that to the 
+      // If there's a null entry that means we've got an unmapped Publish subject - add that to the
       // end so we don’t forget about it
       else if (courseDetails?.subjects?.second === null) {
         subjectsArray.push(null)
@@ -788,13 +788,13 @@ module.exports = router => {
     // Handle users going back to change phase. If so, clear out existing subjects which are now
     // invalid
     let isPrimary = (phase == "Primary")
-    if (isPrimary &&  record?.courseDetails?.subjects?.first && 
+    if (isPrimary &&  record?.courseDetails?.subjects?.first &&
         !record?.courseDetails?.subjects?.first.toLowerCase().includes("primary")){
       delete record.courseDetails.subjects
       delete record.courseDetails.ageRange
     }
     let isSecondary = (phase == "Secondary")
-    if (isSecondary &&  record?.courseDetails?.subjects?.first && 
+    if (isSecondary &&  record?.courseDetails?.subjects?.first &&
         record?.courseDetails?.subjects?.first.toLowerCase().includes("primary")){
       delete record.courseDetails.subjects
       delete record.courseDetails.ageRange
@@ -808,7 +808,7 @@ module.exports = router => {
       res.redirect(`${recordPath}/course-details/details${referrer}`)
     }
   })
- 
+
   router.post(['/:recordtype/:uuid/course-details/details-answer','/:recordtype/course-details/details-answer'], function (req, res) {
     const data = req.session.data
     let record = data.record
@@ -824,7 +824,7 @@ module.exports = router => {
     let isPrimary = (record.courseDetails?.phase == "Primary")
 
     if (isPrimary) {
-      // Primary captures subjects using combined radio options - we need to split this in to 
+      // Primary captures subjects using combined radio options - we need to split this in to
       // separate subjects. Where 'another' is selected, we'll preserve any second and third subjects.
       record.courseDetails.subjects = utils.mapPrimarySubjectsToSubjectSpecialisms(courseDetails?.primarySubjectsCombined, courseDetails.subjects)
       delete record.courseDetails?.primarySubjectsCombined
@@ -837,7 +837,7 @@ module.exports = router => {
     courseDetails.subjects = utils.arrayToOrdinalObject(subjectsArray)
 
     // It’s possible for a user to change the specialism to something completely
-    // different than the selected Publish course. If this happens, delete the 
+    // different than the selected Publish course. If this happens, delete the
     // Publish course references and pretend it’s a manual course.
     if (courseDetails.isPublishCourse){
       let allocationSubject = utils.getAllocationSubject(courseDetails)
@@ -974,7 +974,7 @@ module.exports = router => {
           // records without a dregree anyway.
           utils.updateRecord(data, data.record)
         }
-        
+
       }
       else res.redirect(utils.getReferrerDestination(req.query.referrer))
     }
@@ -999,7 +999,7 @@ module.exports = router => {
     delete data.degreeTemp
     let referrer = utils.getReferrer(req.query.referrer)
 
-    newDegree.id = faker.datatype.uuid()
+    newDegree.id = faker.string.uuid()
 
     let existingDegrees = _.get(data, "record.degree.items") || []
     let degreeIndex = req.params.index
@@ -1010,7 +1010,7 @@ module.exports = router => {
       newDegree = Object.assign({}, existingDegrees[degreeIndex], newDegree)
     }
 
-    // This is a hack because the autocomplete doesn’t pick the righ type 
+    // This is a hack because the autocomplete doesn’t pick the righ type
     // in the select - so we defer to the autocomplete value instead
     let selectedTypeRawAutocomplete = req.body?._autocompleteRawValue_degreeTypeUK
     if (selectedTypeRawAutocomplete){
@@ -1075,15 +1075,15 @@ module.exports = router => {
   // =============================================================================
   // Placements
   // =============================================================================
-  
+
   // Record: Can they add placements? Sends them onwards or marks placements complete
   router.post(['/:recordtype/:uuid/placements/can-add-placement-answer','/:recordtype/placements/can-add-placement-answer'], function (req, res) {
     const data = req.session.data
-    
+
     let recordPath = utils.getRecordPath(req)
     let referrer = utils.getReferrer(req.query.referrer)
     let record = data.record // copy record
-    
+
     if (!record?.placement?.hasPlacements) {
       res.redirect(`${recordPath}/placements/can-add-placement${referrer}`)
     }
@@ -1098,7 +1098,7 @@ module.exports = router => {
       utils.updateRecord(data, record)
 
       if (record.placement.hasPlacements == 'Not yet'){
-    
+
         // send them back to the record
         if (referrer){
           res.redirect(utils.getReferrerDestination(req.query.referrer))
@@ -1107,14 +1107,14 @@ module.exports = router => {
           res.redirect(`${recordPath}`)
         }
       }
-    } 
+    }
     // Draft specific routes
     else if (req.params.recordtype != 'record') {
       if (record.placement.hasPlacements == 'Not yet') {
-        
+
         // mark the Placements section as complete
         _.set(record,'placement.status',"Completed")
-        
+
         // send them to the confirmation
         if (referrer){
           res.redirect(utils.getReferrerDestination(req.query.referrer))
@@ -1128,7 +1128,7 @@ module.exports = router => {
     else {
       res.redirect(`${recordPath}/placements/can-add-placement${referrer}`)
     }
-    
+
   })
 
   // Add a placement - generate a UUID and send the user to it
@@ -1136,7 +1136,7 @@ module.exports = router => {
     const data = req.session.data
     let recordPath = utils.getRecordPath(req)
     let referrer = utils.getReferrer(req.query.referrer)
-    let placementUuid = faker.datatype.uuid()
+    let placementUuid = faker.string.uuid()
     let record = data.record
 
     res.redirect(`${recordPath}/placements/${placementUuid}/details${referrer}`)
@@ -1173,8 +1173,8 @@ module.exports = router => {
       results = utils.searchSchools(schools, schoolSearchTerm)
       resultsCount = results.length
       results = results.slice(0, 15) // truncate results
-      res.render(`${req.params.recordtype}/placements/placement-results`, { 
-        searchResults: results, 
+      res.render(`${req.params.recordtype}/placements/placement-results`, {
+        searchResults: results,
         resultsCount,
         placementUuid })
     }
@@ -1196,12 +1196,12 @@ module.exports = router => {
     let placements = data.record?.placement?.items || []
     let placementIndex = placements.findIndex(placement => placement.id == placementUuid)
     let minPlacementsRequired = data.settings.minPlacementsRequired
-    
+
     if (_.get(data, "record.placement.items[" + placementIndex + "]")){
       _.pullAt(data.record.placement.items, [placementIndex]) //delete item at index
       // Clear data if there are no more degrees - so the task list thinks the section is not started
       req.flash('success', 'Placement removed')
-      
+
       // Delete degree section if it’s empty
       if (data.record.placement.items.length == 0){
         delete data.record.placement
@@ -1220,7 +1220,7 @@ module.exports = router => {
     }
     if (!data.record?.placement){
       res.redirect(`${recordPath}/placements/can-add-placement${referrer}`)
-    } 
+    }
     // else if (referrer){
     //   res.redirect(utils.getReferrerDestination(req.query.referrer))
     // }
@@ -1284,7 +1284,7 @@ module.exports = router => {
     // Look up school using uuid
     const lookUpSchool = (item, schoolUuid) => {
       const schools = getSchools() // deferred to here so we don't load schools if it's a manual entry
-      
+
       let foundSchool = schools.find(school => school.uuid == schoolUuid)
       if (foundSchool){
         item.school = Object.assign({}, foundSchool)

--- a/app/routes/shared-edit-routes.js
+++ b/app/routes/shared-edit-routes.js
@@ -1,4 +1,4 @@
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 const path      = require('path')
 const moment    = require('moment')
 const utils     = require('./../lib/utils')

--- a/app/routes/support-routes.js
+++ b/app/routes/support-routes.js
@@ -6,7 +6,7 @@ const seedRandom = require('seedrandom')
 const url = require('url')
 const utils = require('./../lib/utils')
 const weighted = require('weighted')
-const { faker } = require('@faker-js/faker')
+const { fakerUK: faker } = require('@faker-js/faker')
 
 // In function because this is too big to pass around in session
 const getSchools = () => {
@@ -230,7 +230,7 @@ module.exports = router => {
         navActive: 'organisations'
       })
     }
-    
+
   })
 
   // Render organisation pages, passing along the organisation UUID
@@ -281,7 +281,7 @@ module.exports = router => {
     const data = req.session.data
     let uuid = req.params.uuid
     let provider = data.providers.all.find(provider => provider.id == uuid)
-    
+
     // Use our own render as some templates live at /index.html
     let providerUrl = `/support/organisations/${uuid}`
 
@@ -323,12 +323,12 @@ module.exports = router => {
     const allSchools = getSchools()
 
     // const first100Schools = allSchools.slice(0, 100)
-    
+
     res.render('support/schools/index', {
       schools: allSchools,
       navActive: 'schools'
     })
-    
+
 
   })
 

--- a/app/views/_includes/summary-cards/support/user.html
+++ b/app/views/_includes/summary-cards/support/user.html
@@ -51,7 +51,7 @@
         text: "DfE Sign-in UID"
       },
       value: {
-        text: faker.datatype.uuid()
+        text: faker.string.uuid()
       },
       actions: {
         items: [

--- a/app/views/_includes/support/organisation-card.njk
+++ b/app/views/_includes/support/organisation-card.njk
@@ -44,7 +44,7 @@
         {% endif %} #}
 
         {# Provider code #}
-        <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-1">Provider code: {{ provider.providerCode or faker.random.alphaNumeric(3) | upper }}</p>
+        <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-1">Provider code: {{ provider.providerCode or faker.string.alphanumeric(3) | upper }}</p>
 
         {# URN or UKPRN #}
         {% if provider.urn %}

--- a/app/views/_includes/support/organisation-card.njk
+++ b/app/views/_includes/support/organisation-card.njk
@@ -14,7 +14,7 @@
       </h3>
 
       <span class="app-application-card_tag-container">
-        
+
         <span style="display: inline-block;">
           {{govukTag({
             text: providerTypeString,
@@ -50,9 +50,9 @@
         {% if provider.urn %}
           <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-1">URN: {{provider.urn}}</p>
         {% else %}
-          <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-1">UKRPRN: {{ provider.ukprn or faker.datatype.number({
-            'min': 1000000,
-            'max': 9999999
+          <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-1">UKRPRN: {{ provider.ukprn or faker.number.int({
+            min: 1000000,
+            max: 9999999
           })}}</p>
         {% endif %}
 
@@ -101,7 +101,7 @@
               {{ (provider.courseDetails.subjects | prettifySubjects | falsify ) or provider.courseDetails.courseNameShort }}
             {% endif %}
           {% endset %}
-          
+
           <span class="govuk-visually-hidden">Course: </span>{{ subjects }}</p>
         <p class="govuk-body govuk-!-font-size-16 govuk-hint govuk-!-margin-bottom-0">
           <span class="govuk-visually-hidden">Route: </span>{{ provider.route }}</p>

--- a/app/views/_includes/support/school-card.njk
+++ b/app/views/_includes/support/school-card.njk
@@ -25,7 +25,7 @@
             })}}
           </span>
         {% endif %}
-        
+
         {# <span style="display: inline-block;">
           {{govukTag({
             text: school | getStatusText,
@@ -54,9 +54,9 @@
         {% endif %}
 
         {% if school.ukprn %}
-          <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-1">UKRPRN: {{ school.ukprn or faker.datatype.number({
-            'min': 1000000,
-            'max': 9999999
+          <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-1">UKRPRN: {{ school.ukprn or faker.number.int({
+            min: 1000000,
+            max: 9999999
           })}}</p>
         {% endif %}
 
@@ -64,12 +64,12 @@
           <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-1">Postcode: {{ school.postcode}}</p>
         {% endif %}
 
-        
+
       </div>
 
       <div>
 
-        
+
       </div>
 
     </div>

--- a/scripts/generate-courses.js
+++ b/scripts/generate-courses.js
@@ -5,8 +5,7 @@
 
 const fs            = require('fs')
 const path          = require('path')
-const { faker }     = require('@faker-js/faker')
-faker.locale        = 'en_GB'
+const { fakerUK: faker }     = require('@faker-js/faker')
 const weighted      = require('weighted')
 const moment        = require('moment')
 const _             = require('lodash')
@@ -49,7 +48,7 @@ const generateFakeCourses = () => {
   providers.forEach(provider => {
     let providerCourses = []
     let courseCount = generateCourseCount() // semi-random number of courses per provider
-    
+
     // Hardcode lots courses our default providers
     // A separate setting limits this later so that we can quickly change the number of courses offered in the ui
     if (provider.name == "King’s Oak University" || provider.name == "University of Buckingham") courseCount = 100

--- a/scripts/generate-records.js
+++ b/scripts/generate-records.js
@@ -5,8 +5,7 @@
 // Re-run this script after generating new courses
 const fs                = require('fs')
 const path              = require('path')
-const { faker }         = require('@faker-js/faker')
-faker.locale            = 'en_GB'
+const { fakerUK: faker }         = require('@faker-js/faker')
 const moment            = require('moment')
 const _                 = require('lodash')
 const weighted          = require('weighted')

--- a/scripts/generate-records.js
+++ b/scripts/generate-records.js
@@ -82,7 +82,7 @@ const generateFakeApplication = (params = {}) => {
   }
 
   application.diversity       = (params.diversity === null) ? undefined : { ...generateDiversity(), ...params.diversity }
-  application.id              = params.id || faker.datatype.uuid()
+  application.id              = params.id || faker.string.uuid()
   application.personalDetails = (params.personalDetails === null) ? undefined : { ...generatePersonalDetails(), ...params.personalDetails }
   application.provider        = params.provider || faker.helpers.arrayElement(providers).name
   application.accreditingProviderType    = params.accreditingProviderType || "SCITT" // TODO: this should look up the accrediting provider type from the provider's name
@@ -97,7 +97,7 @@ const generateFakeApplication = (params = {}) => {
 
   // TODO: fix this hack. We ignore the status except where it's draft.
   application.status          = (params.status == "Draft" || params.isSeed) ? params.status : generateStatus(application)
- 
+
   if (application.status == "Deferred") {
     application.previousStatus = "TRN received" // set a state to go back to
   }
@@ -145,7 +145,7 @@ const generateFakeApplication = (params = {}) => {
 
   // A Levels - not used currently
   // application.gce = (params.gce === null) ? undefined : generateGce(faker, isInternationalTrainee)
-  
+
   let requiredSections = trainingRouteData.trainingRoutes[application.route].sections
 
   // Lead and employing school
@@ -162,12 +162,12 @@ const generateFakeApplication = (params = {}) => {
 
   // Undergraduate Qualification
   if (requiredSections.includes('undergraduateQualification')) {
-    application.undergraduateQualification           = (params.undergraduateQualification === null) ? undefined : { ...generateUndergraduateQualification(), ...params.undergraduateQualification }  
+    application.undergraduateQualification           = (params.undergraduateQualification === null) ? undefined : { ...generateUndergraduateQualification(), ...params.undergraduateQualification }
   }
-  
+
   // Placements
   if (requiredSections.includes('placement')) {
-    application.placement        = (params.placement === null) ? undefined : { ...generatePlacement(application), ...params.placement } 
+    application.placement        = (params.placement === null) ? undefined : { ...generatePlacement(application), ...params.placement }
   }
 
   // iQTS
@@ -177,7 +177,7 @@ const generateFakeApplication = (params = {}) => {
 
   // Make sure statuses match qualifications
   let routeQualifications = trainingRouteData.trainingRoutes[application.route].qualifications
-  if (routeQualifications.includes('EYTS')) {  
+  if (routeQualifications.includes('EYTS')) {
     application.status = application.status.replace('QTS', 'EYTS')
   }
 
@@ -310,7 +310,7 @@ const generateFakeApplicationsForProvider = (provider, year, count) => {
     }
   }
 
-  const stubApplication = {} 
+  const stubApplication = {}
 
   // Todo: make these drafts more random
   stubApplication.draft = {
@@ -437,7 +437,7 @@ const generateFakeApplicationsForProvider = (provider, year, count) => {
         provider: provider.name,
         accreditingProviderType: provider.accreditingProviderType,
         academicYearSimple: year
-      }, 
+      },
       ...stubApplication[statusPick]
     }
 
@@ -485,4 +485,3 @@ const generateApplicationsFile = (filePath) => {
 }
 
 generateApplicationsFile(path.join(__dirname, '../app/data/records.json'))
-

--- a/scripts/generate-schools.js
+++ b/scripts/generate-schools.js
@@ -120,9 +120,9 @@ const generateSchool = (params = {}) => {
   let ukprn, addressLine1, town, postcode
 
   if (hasAddress) {
-    addressLine1 = params.addressLine1 || faker.address.streetAddress()
+    addressLine1 = params.addressLine1 || faker.location.streetAddress()
     town = params.town || weighted.select(placesData.weightedCities)
-    let fakePostcode = faker.address.zipCode()
+    let fakePostcode = faker.location.zipCode()
     if (town == "London"){
       fakePostcode = fakePostcode.split(" ").pop()
       fakePostcode = `${faker.helpers.arrayElement(cardinalDirections)}${faker.number.int({min: 1, max: 20})} ${fakePostcode}`

--- a/scripts/generate-schools.js
+++ b/scripts/generate-schools.js
@@ -1,8 +1,7 @@
-const { faker }  = require('@faker-js/faker')
+const { fakerUK: faker }  = require('@faker-js/faker')
 const fs         = require('fs')
 const path       = require('path')
 const weighted   = require('weighted')
-faker.locale     = 'en_GB'
 const placesData = require('../app/data/places.js')
 const fakePlaces = placesData.fakePlaces
 

--- a/scripts/generate-schools.js
+++ b/scripts/generate-schools.js
@@ -95,7 +95,7 @@ generators.generateSchoolWithUncommonName = () => {
 
 
 // Frequency of mix between common school names, faith names, and uncommon names
-// Chosen arbitrarily to provide a mix of very similar names, familiar names, and 
+// Chosen arbitrarily to provide a mix of very similar names, familiar names, and
 // less common names.
 let schoolNameMix = {
   generateSchoolWithCommonName: 0.5,
@@ -108,8 +108,8 @@ const generateSchool = (params = {}) => {
   let selectedGenerator = weighted.select(schoolNameMix)
 
   let schoolName = params.schoolName || generators[selectedGenerator]()
-  let uuid = params.uuid || faker.datatype.uuid()
-  
+  let uuid = params.uuid || faker.string.uuid()
+
   // 5 or 6 digits
   let urn = params.urn || faker.datatype.number({
     'min': 100000,
@@ -207,4 +207,3 @@ generateSchoolsFile(path.join(__dirname, '../app/data/fake-schools.json'))
 // cortedCities.forEach(city =>{
 //   weightedCities[city] = city / 1000
 // })
-

--- a/scripts/generate-schools.js
+++ b/scripts/generate-schools.js
@@ -111,9 +111,9 @@ const generateSchool = (params = {}) => {
   let uuid = params.uuid || faker.string.uuid()
 
   // 5 or 6 digits
-  let urn = params.urn || faker.datatype.number({
-    'min': 100000,
-    'max': 9999999
+  let urn = params.urn || faker.number.int({
+    min: 100000,
+    max: 9999999
   })
 
   // Not all schools have addresses
@@ -126,7 +126,7 @@ const generateSchool = (params = {}) => {
     let fakePostcode = faker.address.zipCode()
     if (town == "London"){
       fakePostcode = fakePostcode.split(" ").pop()
-      fakePostcode = `${faker.helpers.arrayElement(cardinalDirections)}${faker.datatype.number({'min': 1, 'max': 20})} ${fakePostcode}`
+      fakePostcode = `${faker.helpers.arrayElement(cardinalDirections)}${faker.number.int({min: 1, max: 20})} ${fakePostcode}`
     }
     postcode = params.postcode || fakePostcode
   }

--- a/scripts/generate-trainee-problems.js
+++ b/scripts/generate-trainee-problems.js
@@ -146,7 +146,7 @@ const generateTraineeProblem = (provider, providerTrainees) => {
   problem.type = randomProblemType
   // Remap duplicate drafts as regular duplicate type
   if (problem.type == 'duplicateDraft') problem.type = "duplicate"
-  problem.id = faker.datatype.uuid()
+  problem.id = faker.string.uuid()
   problem.provider = provider.name
   problem.date = randomDateInPast(12, 0)
 

--- a/scripts/generate-trainee-problems.js
+++ b/scripts/generate-trainee-problems.js
@@ -4,8 +4,7 @@
 
 const fs            = require('fs')
 const path          = require('path')
-const { faker }     = require('@faker-js/faker')
-faker.locale        = 'en_GB'
+const { fakerUK: faker }     = require('@faker-js/faker')
 const weighted      = require('weighted')
 const moment        = require('moment')
 const _             = require('lodash')

--- a/scripts/generate-users.js
+++ b/scripts/generate-users.js
@@ -4,8 +4,7 @@
 
 const fs            = require('fs')
 const path          = require('path')
-const { faker }     = require('@faker-js/faker')
-faker.locale        = 'en_GB'
+const { fakerUK: faker }     = require('@faker-js/faker')
 const weighted      = require('weighted')
 const moment        = require('moment')
 const _             = require('lodash')

--- a/scripts/generate-users.js
+++ b/scripts/generate-users.js
@@ -30,7 +30,7 @@ const generateUser = (provider, role='team member') => {
 
   let user = {}
 
-  user.id = faker.datatype.uuid()
+  user.id = faker.string.uuid()
   let firstName = faker.name.firstName()
   let familyName = faker.name.lastName()
   user.fullName = `${firstName} ${familyName}`
@@ -40,7 +40,7 @@ const generateUser = (provider, role='team member') => {
 
   // Shuffle the possible permissions - used so that we can pick the first n and to get some selected randomly
   let shuffledPermissions = faker.helpers.shuffle(permissions.allUserPermissions[provider.type])
-  
+
   let userPermissions = []
 
   // Team members have a varied number of permissions


### PR DESCRIPTION
Faker has updated several of its API methods. This PR fixes the deprecation warnings.

| Old | New |
| --- | --- |
| faker.address | faker.location |
| faker.datatype.number | faker.number.int |
| faker.datatype.uuid | faker.string.uuid |
| faker.random.alphaNumeric | faker.string.alphanumeric |
| faker.random.boolean | faker.datatype.boolean |

Faker locales have also changed:

| Old | New |
| --- | --- |
| faker.locale = 'en_GB' | const { fakerUK: faker } = require('@faker-js/faker') |
| faker.locale = 'fr' | const { fakerFR: fakerFR } = require('@faker-js/faker') |