### PR TITLE
Remove unnecessary v6 code from the prototype

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,126 @@
+# http://EditorConfig.org
+# https://gds-way.cloudapps.digital/manuals/programming-languages/editorconfig
+root = true
+
+[*.java]
+indent_size = 4
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = false
+continuation_indent_size = 8
+
+[*.scss]
+indent_size = 2
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.erb]
+indent_size = 2
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.html]
+indent_size = 2
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.njk]
+indent_size = 2
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.css]
+indent_size = 2
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.js]
+indent_size = 2
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.json]
+indent_size = 2
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 119
+
+[*.rb]
+indent_size = 2
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.sh]
+indent_size = 2
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[Makefile]
+indent_size = 2
+indent_style = tab
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[**vendor**]
+indent_size =
+indent_style =
+charset =
+end_of_line =
+insert_final_newline =
+trim_trailing_whitespace =
+max_line_length =

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,105 @@
+# Common settings that generally should always be used with your language specific settings
+
+# Auto detect text files and perform LF normalization
+*          text=auto
+
+#
+# The above will handle all files NOT found below
+#
+
+# Documents
+*.bibtex   text diff=bibtex
+*.doc      diff=astextplain
+*.DOC      diff=astextplain
+*.docx     diff=astextplain
+*.DOCX     diff=astextplain
+*.dot      diff=astextplain
+*.DOT      diff=astextplain
+*.pdf      diff=astextplain
+*.PDF      diff=astextplain
+*.rtf      diff=astextplain
+*.RTF      diff=astextplain
+*.md       text diff=markdown
+*.mdx      text diff=markdown
+*.tex      text diff=tex
+*.adoc     text
+*.textile  text
+*.mustache text
+*.csv      text eol=crlf
+*.tab      text
+*.tsv      text
+*.txt      text
+*.sql      text
+*.epub     diff=astextplain
+
+# Graphics
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.tif      binary
+*.tiff     binary
+*.ico      binary
+# SVG treated as text by default.
+*.svg      text
+# If you want to treat it as binary,
+# use the following line instead.
+# *.svg    binary
+*.eps      binary
+
+# Scripts
+*.bash     text eol=lf
+*.fish     text eol=lf
+*.ksh      text eol=lf
+*.sh       text eol=lf
+*.zsh      text eol=lf
+# These are explicitly windows files and should use crlf
+*.bat      text eol=crlf
+*.cmd      text eol=crlf
+*.ps1      text eol=crlf
+
+# Serialisation
+*.json     text
+*.toml     text
+*.xml      text
+*.yaml     text
+*.yml      text
+
+# Archives
+*.7z       binary
+*.bz       binary
+*.bz2      binary
+*.bzip2    binary
+*.gz       binary
+*.lz       binary
+*.lzma     binary
+*.rar      binary
+*.tar      binary
+*.taz      binary
+*.tbz      binary
+*.tbz2     binary
+*.tgz      binary
+*.tlz      binary
+*.txz      binary
+*.xz       binary
+*.Z        binary
+*.zip      binary
+*.zst      binary
+
+# Fonts
+*.eot      binary
+*.otf      binary
+*.ttf      binary
+*.woff     binary
+*.woff2    binary
+
+# Text files where line endings should be preserved
+*.patch    -text
+
+#
+# Exclude files from exporting
+#
+
+.gitattributes export-ignore
+.gitignore     export-ignore
+.gitkeep       export-ignore

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
-# Register trainee teachers (prototype)
+# Register trainee teachers prototype
 
-This prototype is based on the [GOV.UK prototype kit](https://github.com/alphagov/govuk-prototype-kit)
+A service for collecting and managing trainee teacher registration data.
+
+This prototype is based on the:
+
+- [GOV.UK Design System](https://design-system.service.gov.uk/)
+- [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk/docs/)
 
 ## Installation
 
 ### Requirements
 
-- node.js - version 16.x.x or later
+- node.js - version 20.x.x or later
 
 ### Install dependencies
 
@@ -16,7 +21,7 @@ This prototype is based on the [GOV.UK prototype kit](https://github.com/alphago
 
 `npm start`
 
-Go to [http://localhost:3000]() in your browser.
+Go to <http://localhost:3000> in your browser.
 
 ## Deployed prototype
 
@@ -66,20 +71,28 @@ Most training route and funding data is kept in `app/data/training-route-data.js
 
 This file controls:
 
-* The types of training route available
-* What data / task list section each route should have
-* Funding available for each route
-
+- The types of training route available
+- What data / task list section each route should have
+- Funding available for each route
 
 ## Changes needed each academic year
 
 Things that need to be updated in the new academic year:
 
-* Update course generator to generate courses for next year (a year ahead of current), removing the oldest year
-* Update `app/data/years.js` to update the current academic year, removing the oldest year
-* Update `app/data/training-route-data.js` to update the funding available for each route
-* Regenerate courses
-* Regenerate trainees
-* Regenerate trainee problems
+- Update course generator to generate courses for next year (a year ahead of current), removing the oldest year
+- Update `app/data/years.js` to update the current academic year, removing the oldest year
+- Update `app/data/training-route-data.js` to update the funding available for each route
+- Regenerate courses
+- Regenerate trainees
+- Regenerate trainee problems
 
+## Tools
 
+If you’re using [Visual Studio (VS) Code](https://code.visualstudio.com/) for prototyping, we recommend you install the following extensions:
+
+- [GOV.UK Design System snippets](https://marketplace.visualstudio.com/items?itemName=simonwhatley.govuk-design-system-snippets)
+- [EditorConfig for VS Code](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
+- [Nunjucks for VS Code](https://marketplace.visualstudio.com/items?itemName=ronnidc.nunjucks)
+- [Nunjucks snippets](https://marketplace.visualstudio.com/items?itemName=luwenjiechn.nunjucks-vscode-snippets)
+
+We also recommend you update your VS Code settings to make sure you’re trimming whitespace: `Files: Trim Trailing Whitespace`.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This version deploys automatically from merges to master and is the 'latest' ver
 
 ## Design history
 
-URL: https://bat-design-history.netlify.app/register-trainee-teachers/
+URL: <https://bat-design-history.netlify.app/register-trainee-teachers/>
 
 A history of the design of this service
 

--- a/gulp/config.json
+++ b/gulp/config.json
@@ -2,7 +2,6 @@
   "paths": {
     "public": "public/",
     "assets" : "app/assets/",
-    "v6Assets": "app/v6/assets/",
     "nodeModules": "node_modules/",
     "lib": "lib/"
   }

--- a/gulp/copy-assets.js
+++ b/gulp/copy-assets.js
@@ -13,9 +13,3 @@ gulp.task('copy-assets', function () {
     config.paths.assets + '/**'])
     .pipe(gulp.dest(config.paths.public))
 })
-
-gulp.task('copy-assets-v6', function () {
-  return gulp.src(['!' + config.paths.v6Assets + 'sass{,/**/*}',
-    config.paths.v6Assets + '/**'])
-    .pipe(gulp.dest(config.paths.public + '/v6'))
-})

--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -28,20 +28,3 @@ gulp.task('sass', function () {
     .pipe(sourcemaps.write())
     .pipe(gulp.dest(config.paths.public + '/stylesheets/'))
 })
-
-// Backward compatibility with Elements
-
-gulp.task('sass-v6', function () {
-  return gulp.src(config.paths.v6Assets + '/sass/*.scss')
-    .pipe(sourcemaps.init())
-    .pipe(sass({
-      outputStyle: 'expanded',
-      includePaths: [
-        'node_modules/govuk_frontend_toolkit/stylesheets',
-        'node_modules/govuk-elements-sass/public/sass',
-        'node_modules/govuk_template_jinja/assets/stylesheets'
-      ]
-    }).on('error', sass.logError))
-    .pipe(sourcemaps.write())
-    .pipe(gulp.dest(config.paths.public + '/v6/stylesheets/'))
-})

--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -16,14 +16,3 @@ gulp.task('watch-assets', function () {
   return gulp.watch([config.paths.assets + 'images/**',
     config.paths.assets + 'javascripts/**'], { cwd: './' }, gulp.task('copy-assets'))
 })
-
-// Backward compatibility with Elements
-
-gulp.task('watch-sass-v6', function () {
-  return gulp.watch(config.paths.v6Assets + 'sass/**', { cwd: './' }, gulp.task('sass-v6'))
-})
-
-gulp.task('watch-assets-v6', function () {
-  return gulp.watch([config.paths.v6Assets + 'images/**',
-    config.paths.v6Assets + 'javascripts/**'], { cwd: './' }, gulp.task('copy-assets-v6'))
-})

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,16 +22,12 @@ gulp.task('generate-assets', gulp.series(
   'school-search-index',
   gulp.parallel(
     'sass',
-    'copy-assets',
-    'sass-v6',
-    'copy-assets-v6'
+    'copy-assets'
   )
 ))
 gulp.task('watch', gulp.parallel(
   'watch-sass',
-  'watch-assets',
-  'watch-sass-v6',
-  'watch-assets-v6'
+  'watch-assets'
 ))
 gulp.task('default', gulp.series(
   'generate-assets',

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "express-session": "^1.17.2",
     "express-writer": "0.0.4",
     "fancy-log": "^2.0.0",
-    "govuk_template_jinja": "^0.26.0",
     "govuk-elements-sass": "^3.1.3",
     "govuk-frontend": "^4.6.0",
     "govuk-markdown": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "Register trainee teachers prototype",
-  "description": "Prototype for the Register trainee teachers service by the Department for Education",
+  "name": "register-trainee-teachers-prototype",
+  "description": "A prototype for the ‘Register trainee teachers’ service by the Department for Education",
   "version": "9.8.0",
   "private": true,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "express-session": "^1.17.2",
     "express-writer": "0.0.4",
     "fancy-log": "^2.0.0",
-    "govuk-elements-sass": "^3.1.3",
     "govuk-frontend": "^4.6.0",
     "govuk-markdown": "^0.7.0",
     "gulp": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "express-session": "^1.17.2",
     "express-writer": "0.0.4",
     "fancy-log": "^2.0.0",
-    "govuk_frontend_toolkit": "^9.0.1",
     "govuk_template_jinja": "^0.26.0",
     "govuk-elements-sass": "^3.1.3",
     "govuk-frontend": "^4.6.0",

--- a/server.js
+++ b/server.js
@@ -33,23 +33,7 @@ const routes = require('./app/routes.js')
 const utils = require('./lib/utils.js')
 const extensions = require('./lib/extensions/extensions.js')
 
-// Variables for v6 backwards compatibility
-// Set false by default, then turn on if we find /app/v6/routes.js
-var useV6 = false
-var v6App
-var v6Routes
-
-if (fs.existsSync('./app/v6/routes.js')) {
-  v6Routes = require('./app/v6/routes.js')
-  useV6 = true
-}
-
 const app = express()
-
-if (useV6) {
-  console.log('/app/v6/routes.js detected - using v6 compatibility mode')
-  v6App = express()
-}
 
 // Compression
 // https://expressjs.com/en/resources/middleware/compression.html
@@ -155,28 +139,6 @@ app.use(bodyParser.urlencoded({
   extended: true
 }))
 
-// Set up v6 app for backwards compatibility
-if (useV6) {
-  var v6Views = [
-    path.join(__dirname, '/node_modules/govuk_template_jinja/views/layouts'),
-    path.join(__dirname, '/app/v6/views/'),
-    path.join(__dirname, '/lib/v6') // for old unbranded template
-  ]
-  nunjucksConfig.express = v6App
-  var nunjucksV6Env = nunjucks.configure(v6Views, nunjucksConfig)
-
-  // Nunjucks filters
-  utils.addNunjucksFilters(nunjucksV6Env)
-
-  // Set views engine
-  v6App.set('view engine', 'html')
-
-  // Backward compatibility with GOV.UK Elements
-  app.use('/public/v6/', express.static(path.join(__dirname, '/node_modules/govuk_template_jinja/assets')))
-  app.use('/public/v6/', express.static(path.join(__dirname, '/node_modules/govuk_frontend_toolkit')))
-  app.use('/public/v6/javascripts/govuk/', express.static(path.join(__dirname, '/node_modules/govuk_frontend_toolkit/javascripts/govuk/')))
-}
-
 // Add variables that are available in all views
 app.locals.asset_path = '/public/'
 app.locals.useAutoStoreData = (useAutoStoreData === 'true')
@@ -221,9 +183,6 @@ app.use(flash())
 if (useAutoStoreData === 'true') {
   app.use(utils.autoStoreData)
   utils.addCheckedFunction(nunjucksAppEnv)
-  if (useV6) {
-    utils.addCheckedFunction(nunjucksV6Env)
-  }
 }
 
 // Clear all data in session if you open /prototype-admin/clear-data
@@ -271,18 +230,6 @@ if (typeof (routes) !== 'function') {
   app.use('/', routes)
 }
 
-if (useV6) {
-  // Clone app locals to v6 app locals
-  v6App.locals = Object.assign({}, app.locals)
-  v6App.locals.asset_path = '/public/v6/'
-
-  // Create separate router for v6
-  app.use('/', v6App)
-
-  // Docs under the /docs namespace
-  v6App.use('/', v6Routes)
-}
-
 // Strip .html and .htm if provided
 app.get(/\.html?$/i, function (req, res) {
   var path = req.path
@@ -298,13 +245,6 @@ app.get(/\.html?$/i, function (req, res) {
 app.get(/^([^.]+)$/, function (req, res, next) {
   utils.matchRoutes(req, res, next)
 })
-
-if (useV6) {
-  // App folder routes get priority
-  v6App.get(/^([^.]+)$/, function (req, res, next) {
-    utils.matchRoutes(req, res, next)
-  })
-}
 
 // Redirect all POSTs to GETs - this allows users to use POST for autoStoreData
 // EXTRA added by Ed Horsford: preserve query params


### PR DESCRIPTION
In preparation for upgrading to Gulp v5.0.0, this PR removes unnecessary ‘v6’ code from the prototype. This will help simplify the Gulp upgrade.

Included in the change:

- remove reference to v6 in the Gulp scripts
- remove reference to v6 in the `server.js`
- remove `govuk_frontend_toolkit`, `govuk_template_jinja` and `govuk-elements-sass` packages
- miscellaneous updates
  - add `.gitattributes` and `.editorconfig` config files
  - update `readme.md` and `package.json` docs
