### PR TITLE
Removed “Veteran teaching…” from available initiatives

### DIFF
--- a/app/data/training-route-data.js
+++ b/app/data/training-route-data.js
@@ -81,8 +81,7 @@ let defaultRouteData = {
   ],
   initiatives: [
     "Get an International Relocation Payment",
-    "Now Teach",
-    "Veteran teaching undergraduate bursary"
+    "Now Teach"
   ],
   financialSupportAvailable: false
 }


### PR DESCRIPTION
Removed “Veteran teaching undergraduate bursary” from the available initiatives.