### PR TITLE
Downgrade inquirer package to v8.2.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "inquirer"
+        versions: ["*"]

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,7 +10,6 @@ const inquirer = require('inquirer')
 const request = require('sync-request')
 const _ = require('lodash');
 
-
 // Local dependencies
 const config = require('../app/config.js')
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "gulp-nodemon": "^2.5.0",
     "gulp-sass": "^5.0.0",
     "gulp-sourcemaps": "^3.0.0",
-    "inquirer": "^11.0.2",
+    "inquirer": "^8.2.6",
     "js-yaml": "^4.1.0",
     "keypather": "^3.0.0",
     "lunr": "^2.3.9",

--- a/start.js
+++ b/start.js
@@ -4,33 +4,7 @@ const fs = require('fs')
 
 checkFiles()
 
-// Local dependencies
-const usageData = require('./lib/usage_data')
-
-// Get usageDataConfig from file, if exists
-const usageDataConfig = usageData.getUsageDataConfig()
-
-if (usageDataConfig.collectUsageData === undefined) {
-  // No recorded answer, so ask for permission
-  const promptPromise = usageData.askForUsageDataPermission()
-  promptPromise.then(function (permissionGranted) {
-    usageDataConfig.collectUsageData = permissionGranted
-    usageData.setUsageDataConfig(usageDataConfig)
-
-    if (permissionGranted) {
-      usageData.startTracking(usageDataConfig)
-    }
-
-    runGulp()
-  })
-} else if (usageDataConfig.collectUsageData === true) {
-  // Opted in
-  usageData.startTracking(usageDataConfig)
-  runGulp()
-} else {
-  // Opted out
-  runGulp()
-}
+runGulp()
 
 // Warn if node_modules folder doesn't exist
 function checkFiles () {


### PR DESCRIPTION
This PR:

- rolls back the last CommonJS version of `inquirer` to v8.2.6
- ignores all `dependabot` updates to `inquirer`
- removes the need to check usage data (which uses `inquirer`)