### PR TITLE
Replace del with rimraf

### DIFF
--- a/gulp/clean.js
+++ b/gulp/clean.js
@@ -5,11 +5,12 @@
     - public
 */
 
-const del = require('del')
+const { rimrafSync } = require('rimraf')
 const gulp = require('gulp')
 
 const config = require('./config.json')
 
 gulp.task('clean', (done) => {
-  return del([config.paths.public, '.port.tmp'], done)
+  rimrafSync([config.paths.public, '.port.tmp'])
+  return done()
 })

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "cookie-parser": "^1.4.5",
     "cross-spawn": "^7.0.2",
     "csv-string": "^4.0.1",
-    "del": "^5.1.0",
     "dotenv": "^16.4.5",
     "express": "^4.17.1",
     "express-session": "^1.17.2",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "pluralize": "^8.0.0",
     "portscanner": "^2.1.1",
     "require-dir": "^1.0.0",
+    "rimraf": "^6.0.1",
     "sass": "^1.77.8",
     "seedrandom": "^3.0.5",
     "string": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gulp-nodemon": "^2.5.0",
     "gulp-sass": "^5.0.0",
     "gulp-sourcemaps": "^3.0.0",
-    "inquirer": "^11.0.2",
+    "inquirer": "^8.2.6",
     "js-yaml": "^4.1.0",
     "keypather": "^3.0.0",
     "lunr": "^2.3.9",


### PR DESCRIPTION
This PR replaces the `del` package with `rimraf`. The `del` package no longer supports CommonJS.