### PR TITLE
Remove unnecessary packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "lunr": "^2.3.9",
     "marked": "^15.0.3",
     "moment": "^2.27.0",
-    "notifications-node-client": "^8.2.0",
     "nunjucks": "^3.2.3",
     "nunjucks-markdown": "^2.0.1",
     "pluralize": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     ]
   },
   "devDependencies": {
-    "glob": "^11.0.0",
     "jest": "^29.7.0",
     "markdownlint-cli": "^0.43.0",
     "standard": "^17.1.2",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "stylelint": "^16.11.0",
     "stylelint-config-recommended-scss": "^14.1.0",
     "stylelint-config-standard": "^36.0.1",
-    "stylelint-order": "^6.0.4",
-    "supertest": "^7.0.0"
+    "stylelint-order": "^6.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,11 +68,6 @@
       "app/assets/javascripts/lunr-2.3.9.js"
     ]
   },
-  "greenkeeper": {
-    "ignore": [
-      "nunjucks"
-    ]
-  },
   "devDependencies": {
     "markdownlint-cli": "^0.43.0",
     "standard": "^17.1.2",

--- a/package.json
+++ b/package.json
@@ -61,13 +61,6 @@
     "uuid": "^11.0.3",
     "weighted": "^1.0.0"
   },
-  "standard": {
-    "ignore": [
-      "app/assets/javascripts/jquery-1.11.3.js",
-      "app/assets/javascripts/jquery-3.6.1.min.js",
-      "app/assets/javascripts/lunr-2.3.9.js"
-    ]
-  },
   "devDependencies": {
     "markdownlint-cli": "^0.43.0",
     "standard": "^17.1.2",
@@ -75,5 +68,12 @@
     "stylelint-config-recommended-scss": "^14.1.0",
     "stylelint-config-standard": "^36.0.1",
     "stylelint-order": "^6.0.4"
+  },
+  "standard": {
+    "ignore": [
+      "app/assets/javascripts/jquery-1.11.3.js",
+      "app/assets/javascripts/jquery-3.6.1.min.js",
+      "app/assets/javascripts/lunr-2.3.9.js"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:scripts:fix": "standard --fix",
     "lint:styles": "stylelint 'app/assets/sass/**/*.scss' 'app/views/_components/**/*.scss'",
     "lint:styles:fix": "stylelint 'app/assets/sass/**/*.scss' 'app/views/_components/**/*.scss' --fix",
-    "test": "npm run lint:scripts && gulp generate-assets && jest"
+    "test": "npm run lint:scripts && gulp generate-assets"
   },
   "dependencies": {
     "@faker-js/faker": "^9.0.0",
@@ -74,7 +74,6 @@
     ]
   },
   "devDependencies": {
-    "jest": "^29.7.0",
     "markdownlint-cli": "^0.43.0",
     "standard": "^17.1.2",
     "stylelint": "^16.11.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@faker-js/faker": "^9.0.0",
     "@ministryofjustice/frontend": "^3.1.0",
-    "acorn": "^8.12.1",
     "ansi-colors": "^4.1.1",
     "basic-auth": "^2.0.0",
     "basic-auth-connect": "^1.0.0",


### PR DESCRIPTION
This PR:

- removes:
  - `acorn`
  - `glob`
  - `supertest`
  - `jest`
  - `notifications-node-client`
- reorganises `package.json`