### PR TITLE
Update markdown

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -42,6 +42,7 @@ $govuk-assets-path: "/dist/govuk/assets/";
 @import "components/button-as-link";
 @import "components/cookie-banner";
 @import "components/invalid-answer";
+@import "components/markdown";
 @import "components/organisation-switcher";
 @import "components/record-header";
 @import "components/record-actions";

--- a/app/assets/sass/components/_markdown.scss
+++ b/app/assets/sass/components/_markdown.scss
@@ -1,0 +1,90 @@
+.app-markdown {
+	h1 {
+		@extend %govuk-heading-l;
+	}
+
+	h2 {
+		@extend %govuk-heading-m;
+	}
+
+	h3 {
+		@extend %govuk-heading-s;
+	}
+
+	h4 {
+		@extend %govuk-heading-s;
+	}
+
+	p {
+    @extend %govuk-body-m;
+  }
+
+	strong,
+  b {
+    @include govuk-typography-weight-bold;
+  }
+
+  ul,
+  ol {
+    @extend %govuk-list;
+  }
+
+  ol {
+    @extend %govuk-list--number;
+  }
+
+  ul {
+    @extend %govuk-list--bullet;
+  }
+
+	hr {
+    @extend %govuk-section-break;
+    @extend %govuk-section-break--visible;
+    @extend %govuk-section-break--xl;
+  }
+
+	table {
+    @include govuk-font($size: 19);
+    @include govuk-text-colour;
+    @include govuk-responsive-margin(6, "bottom");
+    border-spacing: 0;
+    border-collapse: collapse;
+    width: 100%;
+  }
+
+  th {
+    @include govuk-typography-weight-bold;
+    border-bottom: 1px solid $govuk-border-colour;
+    padding: govuk-em(govuk-spacing(2), 19px) govuk-em(govuk-spacing(4), 19px) govuk-em(govuk-spacing(2), 19px) 0;
+    text-align: left;
+    vertical-align: text-top;
+  }
+
+  td {
+    border-bottom: 1px solid $govuk-border-colour;
+    padding: govuk-em(govuk-spacing(2), 19px) govuk-em(govuk-spacing(4), 19px) govuk-em(govuk-spacing(2), 19px) 0;
+    text-align: left;
+    vertical-align: text-top;
+  }
+
+  th:last-child,
+  td:last-child {
+    padding-right: 0;
+  }
+
+  caption {
+    @include govuk-typography-weight-bold;
+    display: table-caption;
+  	text-align: left;
+  }
+
+	blockquote {
+		@extend .govuk-inset-text;
+		margin-left: 0px;
+	}
+
+	img {
+		max-width: 100%;
+	}
+
+}

--- a/app/filters/strings.js
+++ b/app/filters/strings.js
@@ -4,7 +4,8 @@
 const string = require('string')
 const _ = require('lodash')
 const { marked } = require('marked')
-const GovukHTMLRenderer = require('govuk-markdown')
+const { gfmHeadingId } = require('marked-gfm-heading-id')
+
 // Leave this filters line
 const filters = {}
 
@@ -90,30 +91,26 @@ filters.stringLiteral = function (str) {
 
 // Format text using markdown
 // Documentation at https://marked.js.org/
-filters.markdown = (input, params = {}) => {
-  marked.setOptions({
-    renderer: new GovukHTMLRenderer(),
-    headerIds: true,
-    headingsStartWith: params.headingsStartWith ?? 'xl',
-    smartypants: true
-  })
-
-  // Offset headings - useful where embedded content
-  // needs to start at h2 rather than h1
-  // https://marked.js.org/using_pro#walk-tokens
-  const headingOffset = params.headingOffset ?? 0
-  const walkTokens = (token) => {
-    if (token.type === 'heading') {
-      token.depth += headingOffset
-    }
-  }
-
-  marked.use({ walkTokens })
-
-  if (input) return marked(input)
-  else {
+filters.markdown = (markdown) => {
+  if (!markdown) {
     console.log('Error with markdown: no input given')
+    return null
   }
+
+  marked.use(gfmHeadingId())
+
+  const text = markdown.replace(/\\r/g, '\n').replace(/\\t/g, ' ')
+  const html = marked.parse(text)
+
+  // Add govuk-* classes
+  let govukHtml = html.replace(/<p>/g, '<p class="govuk-body">')
+  govukHtml = govukHtml.replace(/<ol>/g, '<ol class="govuk-list govuk-list--number">')
+  govukHtml = govukHtml.replace(/<ul>/g, '<ul class="govuk-list govuk-list--bullet">')
+  govukHtml = govukHtml.replace(/<h2/g, '<h2 class="govuk-heading-l"')
+  govukHtml = govukHtml.replace(/<h3/g, '<h3 class="govuk-heading-m"')
+  govukHtml = govukHtml.replace(/<h4/g, '<h4 class="govuk-heading-s"')
+
+  return govukHtml
 }
 
 // Checks if a string starts with something

--- a/app/views/_includes/cookie-banner.njk
+++ b/app/views/_includes/cookie-banner.njk
@@ -1,7 +1,7 @@
 {% if shouldShowCookieMessage %}
   <div class="app-cookie-banner">
     <p class="app-cookie-banner__message">
-      {{cookieText | safe }}
+      {{ cookieText | safe }}
     </p>
   </div>
 {% endif %}

--- a/app/views/_includes/summary-cards/record-admin/dqt.njk
+++ b/app/views/_includes/summary-cards/record-admin/dqt.njk
@@ -1,7 +1,5 @@
 
 {% set code %}
-
-{% markdown %}
 ```
 {
   "data": [
@@ -121,20 +119,19 @@
   ]
 }
 ```
-{% endmarkdown %}
 {% endset %}
 
 {% set collectionData1 %}
   {{ govukDetails({
   summaryText: "17 May 2021 at 5:43pm",
-  html: code
+  html: code | markdown
 }) }}
 {% endset %}
 
 {% set collectionData2 %}
   {{ govukDetails({
   summaryText: "4 December 2022 at 1:07pm",
-  html: code
+  html: code | markdown
 }) }}
 {% endset %}
 

--- a/app/views/_includes/summary-cards/record-admin/hesa.njk
+++ b/app/views/_includes/summary-cards/record-admin/hesa.njk
@@ -1,7 +1,5 @@
 
 {% set code %}
-
-{% markdown %}
 ```
 {
   "data": [
@@ -121,20 +119,19 @@
   ]
 }
 ```
-{% endmarkdown %}
 {% endset %}
 
 {% set collectionData1 %}
   {{ govukDetails({
   summaryText: "17 May 2021 at 5:43pm",
-  html: code
+  html: code | markdown
 }) }}
 {% endset %}
 
 {% set collectionData2 %}
   {{ govukDetails({
   summaryText: "4 December 2022 at 1:07pm",
-  html: code
+  html: code | markdown
 }) }}
 {% endset %}
 

--- a/app/views/_templates/_guidance-page.njk
+++ b/app/views/_templates/_guidance-page.njk
@@ -1,34 +1,24 @@
 {% extends "layout.njk" %}
 
 {% if not backLink %}
-    {% set backLink      = 'javascript:history.back();' %}
+  {% set backLink = 'javascript:history.back();' %}
 {% endif %}
 {% if not backText %}
-    {% set backText      = 'Back'  %}
+  {% set backText = 'Back'  %}
 {% endif %}
 
 {% if backLink == 'false' %}
-    {% set backLink = false %}
+  {% set backLink = false %}
 {% endif %}
 
 {% if backText == 'false' %}
-    {% set backText = '' %}
+  {% set backText = '' %}
 {% endif %}
-
 
 {% block pageTitle %}
   {{ pageHeading }} - {{serviceName}} - GOV.UK
 {% endblock %}
 
-{# {% set breadcrumbs  = {
-  items: [
-    {
-      text: "How to use this service",
-      href: "/guidance"
-    }
-  ]
-} %}
- #}
 {% set backLink = '/guidance' %}
 {% set backText = "How to use this service" %}
 
@@ -47,13 +37,9 @@
   {% include "_includes/app-flash-message.njk" %}
 
   <div class="govuk-grid-row">
-    <div class="{{ gridColumn or 'govuk-grid-column-two-thirds-from-desktop' }}">
-      {% markdown %}
-        {% block guidanceContent %}
-
-        {% endblock %}
-      {% endmarkdown %}
+    <div class="app-markdown {{ gridColumn or 'govuk-grid-column-two-thirds-from-desktop' }}">
+      <h1 class="govuk-heading-xl">{{ pageHeading }}</h1>
+      {{ guidanceContent | markdown | safe }}
     </div>
    </div>
-
 {% endblock %}

--- a/app/views/guidance/about-register-trainee-teachers.njk
+++ b/app/views/guidance/about-register-trainee-teachers.njk
@@ -1,18 +1,17 @@
 {% extends "_templates/_guidance-page.njk" %}
 
-{% set pageHeading = 'About Register trainee teachers' %}
+{% set pageHeading = "About Register trainee teachers" %}
 
-{% block guidanceContent %}
-
-# About Register trainee teachers
+{% set guidanceContent %}
+{# # About Register trainee teachers #}
 
 Register trainee teachers (Register) is the service that Initial Teacher Training (ITT) providers use to provide the Department for Education (DfE) with trainee data.
 
 The DfE uses trainee data in Register to:
-* allocate the correct amount of funding to training providers and eligible trainees
-* create the ITT census publication
-* create the ITT performance profiles publication
-* inform policy development
+- allocate the correct amount of funding to training providers and eligible trainees
+- create the ITT census publication
+- create the ITT performance profiles publication
+- inform policy development
 
 Register replaced the Database of Trainee Teachers and Providers (DTTP) in 2022.
 
@@ -22,9 +21,9 @@ Register replaced the Database of Trainee Teachers and Providers (DTTP) in 2022.
 
 Accredited providers can use Register to perform tasks for their trainees, such as:
 
-* withdrawing or deferring trainees from their course
-* getting a teacher reference number (TRN)
-* recommending trainees for qualified teacher status (QTS) or early years teacher status (EYTS)
+- withdrawing or deferring trainees from their course
+- getting a teacher reference number (TRN)
+- recommending trainees for qualified teacher status (QTS) or early years teacher status (EYTS)
 
 Accredited providers can view funding information for the current academic year for eligible trainees. From the main navigation bar under ‘Funding’, you will see monthly payments paid and predicted to be paid for scholarships and bursaries.
 
@@ -32,22 +31,21 @@ Accredited providers can view funding information for the current academic year 
 
 Lead partners that deliver School Direct ITT courses in partnership with accredited providers can use Register to:
 
-* view trainee records where you’re their lead partner
-* view funding information for the current academic year for eligible trainees
+- view trainee records where you’re their lead partner
+- view funding information for the current academic year for eligible trainees
 
-Lead partners access to Register is <strong class="govuk-!-font-weight-bold">view only</strong>. As a lead partner you cannot:
+Lead partners access to Register is **view only**. As a lead partner you cannot:
 
-* add a trainee record
-* change trainee records
-* view draft trainee records
-* view a trainee’s diversity information
-
-{% include "_includes/guidance/training-status-homepage.md" %}
-
-{% set detailsContent %}
+- add a trainee record
+- change trainee records
+- view draft trainee records
+- view a trainee’s diversity information
 
 {% include "_includes/guidance/training-status-homepage.md" %}
-{% endset %}
+
+{# {% set detailsContent %}
+{% include "_includes/guidance/training-status-homepage.md" %}
+{% endset %} #}
 
 ## How trainee data is used in the initial teacher training (ITT) census publication
 
@@ -71,9 +69,6 @@ Training providers who use HESA should submit their data through HESA. Your data
 
 Read more about how to [register your trainees through HESA](https://www.register-trainee-teachers.service.gov.uk/guidance/registering-trainees-through-hesa).
 
-
-
-
 ### Who you must register
 
 You must register all trainees who start their training, even if they decide to drop out after the first few weeks. If they do drop out, you can withdraw them.
@@ -86,9 +81,9 @@ Once you have registered your trainees, you’ll need to check your data is corr
 
 Do this in Register by:
 
-* using the ‘Reports’ section and exporting a CSV of your new trainees for the 2023 to 2024 academic year
-* exporting a CSV of your trainees in the ‘Registered trainees’ section, using the ‘start year’ filter to select the current academic year
-* checking your trainees directly in the service one by one
+- using the ‘Reports’ section and exporting a CSV of your new trainees for the 2023 to 2024 academic year
+- exporting a CSV of your trainees in the ‘Registered trainees’ section, using the ‘start year’ filter to select the current academic year
+- checking your trainees directly in the service one by one
 
 Once you are confident your new trainee data is correct, a senior person from your organisation (this should be a different person to who submitted the data) must sign it off at the end of October every academic year.
 
@@ -99,5 +94,4 @@ Every academic year the DfE publishes data on GOV.UK of how many people have suc
 Training providers must update their trainee data every January from the previous academic year.
 
 For example, in January 2024 a training provider should update their trainee data for the 2022 to 2023 academic year. This data will be published in July 2024 on GOV.UK. The data published on GOV.UK will be the performance profiles of trainees who successfully completed their training in the 2022 to 2023 academic year.
-
-{% endblock %}
+{% endset %}

--- a/app/views/guidance/bulk-add-new-by-csv.njk
+++ b/app/views/guidance/bulk-add-new-by-csv.njk
@@ -2,33 +2,24 @@
 {% extends "layout.njk" %}
 
 {% if not backLink %}
-{% set backLink      = 'javascript:history.back();' %}
+  {% set backLink = 'javascript:history.back();' %}
 {% endif %}
 {% if not backText %}
-{% set backText      = 'Back'  %}
+  {% set backText = 'Back'  %}
 {% endif %}
 
 {% if backLink == 'false' %}
-{% set backLink = false %}
+  {% set backLink = false %}
 {% endif %}
 
 {% if backText == 'false' %}
-{% set backText = '' %}
+  {% set backText = '' %}
 {% endif %}
 
 {% block pageTitle %}
-{{ pageHeading }} - {{serviceName}} - GOV.UK
+  {{ pageHeading }} - {{serviceName}} - GOV.UK
 {% endblock %}
 
-{# {% set breadcrumbs  = {
-items: [
-{
-text: "How to use this service",
-href: "/guidance"
-}
-]
-} %}
-#}
 {% set backLink = '/guidance' %}
 {% set backText = "How to use this service" %}
 

--- a/app/views/guidance/bulk-recommend-trainees.njk
+++ b/app/views/guidance/bulk-recommend-trainees.njk
@@ -1,23 +1,18 @@
 {% extends "_templates/_guidance-page.njk" %}
 
-{% set pageHeading = 'Bulk recommend trainees' %}
+{% set pageHeading = "Bulk recommend trainees for QTS or EYTS" %}
 
-{% block guidanceContent %}
-
-# Bulk recommend trainees for QTS or EYTS
+{% set guidanceContent %}
+{# # Bulk recommend trainees for QTS or EYTS #}
 
 You can use Register trainee teachers (Register) to bulk recommend multiple trainees at the same time for qualified teacher status (QTS) or early years teacher status (EYTS).
 
-<div class="govuk-inset-text">
-
-You cannot use this process to record other training outcomes or to change trainee or course details.
-
-Find out [how to withdraw, defer, reinstate or recommend an individual trainee for QTS or EYTS
+> You cannot use this process to record other training outcomes or to change trainee or course details.
+>
+> Find out [how to withdraw, defer, reinstate or recommend an individual trainee for QTS or EYTS
 ](/record-outcomes).
-
-You can change other trainee or course details in an individual trainee’s record. You can also use the Higher Education Statistics Agency (HESA) service if you have access to it.
-
-</div>
+>
+> You can change other trainee or course details in an individual trainee’s record. You can also use the Higher Education Statistics Agency (HESA) service if you have access to it.
 
 ## How to bulk recommend trainees for QTS or EYTS
 
@@ -78,5 +73,4 @@ If you skip the errors, you’ll only be able to recommend trainees whose data d
 After you submit your recommendations, the Teaching Regulation Agency (TRA) will award the trainees with QTS or EYTS within 3 working days.
 
 The DfE will later send an email to the trainees to tell them that their certificates are available to download from the Access your Teacher Qualifications service.
-
-{% endblock %}
+{% endset %}

--- a/app/views/guidance/check-data.njk
+++ b/app/views/guidance/check-data.njk
@@ -1,220 +1,114 @@
 {% extends "_templates/_guidance-page.njk" %}
 
-{% set pageHeading = 'Check what data you need to provide to register trainees manually' %}
+{% set pageHeading = "Check what data you need to provide to register trainees manually" %}
 
-{% block guidanceContent %}
+{% set guidanceContent %}
 
+This information is mainly for school centred initial teacher training providers (SCITTs) that use this service to manually register their trainees.
 
-<h1 class="govuk-heading-l govuk-!-margin-bottom-9">{{pageHeading}}</h1>
+You’ll need the following information about a trainee to register them manually in Register.
 
+### Personal details
 
-<p class='govuk-body'>This information is mainly for school centred initial teacher training providers (SCITTs) that use this service to manually register their trainees.</p>
-<p class='govuk-body'>You’ll need the following information about a trainee to register them manually in Register.</p>
+- First names
+- Middle names
+- Last or family name
+- Date of birth
+- Sex
+- Nationality
 
-<h3 class="govuk-heading-m">Personal details</h3>
+---
 
-<ul class='govuk-list'>
-  <li>
-    First names
-  </li>
-  <li>
-    Middle names
-  </li>
-  <li>
-    Last or family name
-  </li>
-  <li>
-    Date of birth
-  </li>
-  <li>
-    Sex
-  </li>
-  <li>
-    Nationality
-  </li>
-</ul>
+### Contact details
 
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+- Address
+- Email address
 
-<h3 class='govuk-heading-m'>Contact details</h3>
+---
 
-<ul class='govuk-list'>
-  <li>
-    Address
-  </li>
-  <li>
-    Email address
-  </li>
-</ul>
+### Diversity information (optional)
 
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+If the trainee chose not to share this information during the application process, do not ask for it for the purpose of registering them.
 
-<h3 class='govuk-heading-m'>Diversity information (optional)</h3>
+- Ethnicity
+- Disability
 
-<div class="govuk-inset-text">
-    If the trainee chose not to share this information during the application process, do not ask for it for the purpose of registering them.
-</div>
+---
 
-<ul class='govuk-list'>
-  <li>
-    Ethnicity
-  </li>
-  <li>
-    Disability
-  </li>
-</ul>
+### Degrees
 
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+### If it’s a UK degree
 
-<h3 class='govuk-heading-m'>Degrees</h3>
+- Type (for example, BA or BSc)
+- Awarding institution
+- Subject
+- Grade
+- Graduation year
 
-<h3 class='govuk-heading-s'>If it’s a UK degree</h3>
+#### If it’s not a UK degree
 
-<ul class='govuk-list'>
-  <li>
-    Type (for example, BA or BSc)
-  </li>
-  <li>
-    Awarding institution
-  </li>
-  <li>
-    Subject
-  </li>
-  <li>
-    Grade
-  </li>
-  <li>
-    Graduation year
-  </li>
-</ul>
+- Country where the degree was obtained
+- Subject
+- UK ENIC comparable degree (if provided)
+- Graduation year
 
-<h4 class='govuk-heading-s'>If it’s not a UK degree</h4>
+---
 
-<ul class='govuk-list'>
-  <li>
-    Country where the degree was obtained
-  </li>
-  <li>
-    Subject
-  </li>
-  <li>
-    UK ENIC comparable degree (if provided)
-  </li>
-  <li>
-    Graduation year
-  </li>
-</ul>
+### Course details
 
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+#### If it’s a course on Publish teacher training courses
 
-<h3 class='govuk-heading-m'>Course details</h3>
+- Which Publish course
+- Subject specialisms
+- Full or part time
+- ITT start date
+- Expected end date
 
-<h4 class='govuk-heading-s'>If it’s a course on Publish teacher training courses</h4>
+#### If it's not a course on Publish teacher training courses
 
-<ul class='govuk-list'>
-  <li>
-    Which Publish course
-  </li>
-  <li>
-    Subject specialisms
-  </li>
-  <li>
-    Full or part time
-  </li>
-  <li>
-    ITT start date
-  </li>
-  <li>
-    Expected end date
-  </li>
-</ul>
+- Primary or secondary
+- Subjects
+- Age range
+- Full or part time (not for assessment only)
+- ITT start date
+- Expected end date
 
-<h4 class='govuk-heading-s'>If it's not a course on Publish teacher training courses</h4>
+#### If it's a course leading to Early Years Teacher Status (EYTS)
 
-<ul class='govuk-list'>
-  <li>
-    Primary or secondary
-  </li>
-  <li>
-    Subjects
-  </li>
-  <li>
-    Age range
-  </li>
-  <li>
-    Full or part time (not for assessment only)
-  </li>
-  <li>
-    ITT start date
-  </li>
-  <li>
-    Expected end date
-  </li>
-</ul>
+- Full or part time
+- ITT start date
+- Expected end date
 
-<h4 class='govuk-heading-s'>If it's a course leading to Early Years Teacher Status (EYTS)</h4>
+---
 
-<ul class='govuk-list'>
-  <li>
-    Full or part time
-  </li>
-  <li>
-    ITT start date
-  </li>
-  <li>
-    Expected end date
-  </li>
-</ul>
+### Trainee start date
 
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+- Trainee start date
 
-<h3 class='govuk-heading-m'>Trainee start date</h3>
+---
 
-<ul class='govuk-list'>
-  <li>
-    Trainee start date
-  </li>
-</ul>
+### Lead partners and employing schools
 
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+These are only required for School direct and Teaching apprenticeship routes.
 
-<h3 class='govuk-heading-m'>
-Lead partners and employing schools</h3>
+---
 
-<p class="govuk-body">These are only required for School direct and Teaching apprenticeship routes.</p>
+### Funding details
 
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+- Whether the trainee is on a training initiative
 
-<h3 class='govuk-heading-m'>Funding details</h3>
+### For courses with bursaries, scholarships or grants available
 
-<ul class='govuk-list'>
-  <li>
-    Whether the trainee is on a training initiative
-  </li>
-</ul>
-<h3 class='govuk-heading-s'>For courses with bursaries, scholarships or grants available</h3>
-<ul class='govuk-list'>
-  <li>
-    Whether you’re applying for a bursary for the trainee
-  </li>
-  <li>
-    Whether you’re applying for a grant for the trainee
-  </li>
-  <li>
-    Whether the trainee is applying for a scholarship
-  </li>
-</ul>
+- Whether you’re applying for a bursary for the trainee
+- Whether you’re applying for a grant for the trainee
+- Whether the trainee is applying for a scholarship
 
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+---
 
-<h3 class='govuk-heading-m'>Placement details</h3>
+### Placement details
 
-<div class="govuk-inset-text">
+You should keep a record of the location of the trainee’s placements.
 
-  <p class="govuk-body">You should keep a record of the location of the trainee’s placements.</p>
+You cannot currently provide this data but you’ll be asked to provide it later in the 2023 to 2024 academic year.
 
-  <p class="govuk-body">You cannot currently provide this data but you’ll be asked to provide it later in the 2023 to 2024 academic year.</p>
-
-</div>
-
-{% endblock %}
+{% endset %}

--- a/app/views/guidance/dates-and-deadlines.njk
+++ b/app/views/guidance/dates-and-deadlines.njk
@@ -1,115 +1,22 @@
 {% extends "_templates/_guidance-page.njk" %}
 
-{% set pageHeading = 'Dates and deadlines' %}
+{% set pageHeading = "Dates and deadlines for training providers for " + data.years.academicYears[0] + " academic year" %}
 
-{% block guidanceContent %}
+{% set guidanceContent %}
+## Deadlines for all training providers
 
-<h1 class="govuk-heading-l govuk-!-margin-bottom-9">{{pageHeading}} for training providers for the {{ data.years.academicYears[0] }} academic year</h1>
+| Date | What happens |
+| --- | --- |
+| 11&nbsp;October&nbsp;2023 | The second Wednesday of October every academic year is called the ‘census date’. If a new trainee starts their course after this date, they will not be included in the ITT census publication. This is why it’s important to add your new trainees as they start their training. |
+| 31&nbsp;October&nbsp;2023 | A senior person from your organisation must sign off your new trainee data on or before this date. This should be a different person to the one who submitted the data. This data will be used for the ITT census publication. |
+| 31&nbsp;January&nbsp;2024 | A senior person from your organisation must sign off your 2022 to 2023 trainee outcomes on or before this date. This should be a different person to the one who submitted the data. Some of this data will be used for the ITT performance profiles publication. |
 
-<!-- TODO: Replace this caption with an escaped or string interpolated 'data.years.currentAcademicYear' variable - Andrew Scrivener 29/06/2023 -->
-<!-- TODO: Fix Prettier formatting for embedded Nunjucks - Andrew Scrivener 29/06/2023 -->
-{{ govukTable({
-caption: "Deadlines for all training providers",
-captionClasses: "govuk-table__caption--m",
-firstCellIsHeader: false,
-head: [
-{
-text: "Date",
-classes: 'govuk-!-width-one-third'
-},
-{
-text: "What happens"
-}
-],
-rows: [
-[
-{
-html: "11 October 2023" | nowrap
-},
-{
-text: "The second Wednesday of October every academic year is called the ‘census date’. If a new trainee starts their course after this date, they will not be included in the ITT census publication. This is why it’s important to add your new trainees as they start their training."
-}
-],
-[
-{
-html: "31 October 2023" | nowrap
-},
-{
-text: "A senior person from your organisation must sign off your new trainee data on or before this date. This should be a different person to the one who submitted the data. This data will be used for the ITT census publication."
-}
-],
-[
-{
-html: "31 January 2024" | nowrap
-},
-{
-text: "A senior person from your organisation must sign off your 2022 to 2023 trainee outcomes on or before this date. This should be a different person to the one who submitted the data. Some of this data will be used for the ITT performance profiles publication."
-}
-]
-]
-} ) }}
+## Deadlines for higher education institutions (HEIs) that use HESA
 
-{# Done here so they can each be nowrapped on their own lines #}
-{% set combinedDatesContent %}
-{{ "16 to 31 January 2023" | nowrap | safe }}
-{{ "17 to 28 April 2023" | nowrap | safe }}
-{{ "17 to 31 July 2023" | nowrap | safe }}
+| Date | What happens |
+| --- | --- |
+| 1&nbsp;September&nbsp;2023 | HESA data collection system opens. Training providers can start submitting their ITT trainee data to the DfE through HESA. |
+| 17&nbsp;October&nbsp;2023 | First data submission required to HESA. Training providers should have started submitting data by this date. |
+| 31&nbsp;October&nbsp;2023 | HESA data collection system closes. ITT trainee data must be submitted and signed off on or before the data collection system closes. Not doing this, will mean the DfE has inaccurate data which could affect the ITT census publication. |
+| 15&nbsp;to&nbsp;31&nbsp;January&nbsp;2024<br>15 to 30 April 2024<br>15 to 31 July 2024 | ITT data collection update periods where you can update your trainee data through HESA if anything has changed. Data will be imported into Register. You do not need to sign off your data during these update periods. |
 {% endset %}
-
-{% set combinedDatesContent2 %}
-{{ "15 to 31 January 2024" | nowrap | safe }}
-{{ "15 to 30 April 2024" | nowrap | safe }}
-{{ "15 to 31 July 2024" | nowrap | safe }}
-{% endset %}
-
-<!-- TODO: Replace this caption with an escaped or string interpolated 'data.years.currentAcademicYear' variable - Andrew Scrivener 29/06/2023 -->
-{{ govukTable({
-caption: "Deadlines for higher education institutions (HEIs) that use HESA",
-captionClasses: "govuk-table__caption--m",
-firstCellIsHeader: false,
-head: [
-{
-text: "Date",
-classes: 'govuk-!-width-one-third'
-},
-{
-text: "What happens"
-}
-],
-rows: [
-[
-{
-html: "1 September 2023" | nowrap
-},
-{
-text: "HESA data collection system opens. Training providers can start submitting their ITT trainee data to the DfE through HESA."
-}
-],
-[
-{
-html: "17 October 2023" | nowrap
-},
-{
-text: "First data submission required to HESA. Training providers should have started submitting data by this date."
-}
-],
-[
-{
-html: "31 October 2023" | nowrap
-},
-{
-text: "HESA data collection system closes. ITT trainee data must be submitted and signed off on or before the data collection system closes. Not doing this, will mean the DfE has inaccurate data which could affect the ITT census publication."
-}
-],
-[
-{
-html: combinedDatesContent2
-},
-{
-text: "ITT data collection update periods where you can update your trainee data through HESA if anything has changed. Data will be imported into Register. You do not need to sign off your data during these update periods."
-}
-]
-]
-} ) }}
-
-{% endblock %}

--- a/app/views/guidance/hesa-register-data-mapping.njk
+++ b/app/views/guidance/hesa-register-data-mapping.njk
@@ -2,8 +2,9 @@
 
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
+{% from "_components/sub-navigation/macro.njk" import appSubNavigation %}
 
-{% set pageHeading = 'Check the data mapping between HESA and Register trainee teachers' %}
+{% set pageHeading = "Check the data mapping between HESA and Register trainee teachers" %}
 {% set gridColumn = "govuk-grid-column-full" %}
 
 {# Page notes:
@@ -157,13 +158,10 @@ For school placements (HESA field PLMNTSCH), although we collect and use this da
 } %}
 
 {# Page begins #}
-{% block guidanceContent %}
+{% set guidanceContent %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-
-    # {{ pageHeading }}
-
     Use the table to check how data maps between HESA and Register trainee teachers (Register) for the {{ data.years.academicYears[0] }} academic year.
 
     Where possible, these tables follow the same order as the CSV export and a trainee’s record in Register.
@@ -191,7 +189,7 @@ For school placements (HESA field PLMNTSCH), although we collect and use this da
   }) }}
 
   {# Route will tell us what tab’s content to render #}
-  {{ allTableContent[activeTab].content  | safe}}
+  {{ allTableContent[activeTab].content | markdown | safe }}
 
 {% elseif data.settings.hesaGuidanceStyle == 'accordion' %}
 
@@ -203,7 +201,7 @@ For school placements (HESA field PLMNTSCH), although we collect and use this da
         text: item.name
       },
       content: {
-        html: item.content
+        html: item.content | markdown
       }
     }) %}
   {% endfor %}
@@ -218,9 +216,9 @@ For school placements (HESA field PLMNTSCH), although we collect and use this da
 
   {% for key, tabData in allTableContent %}
     <h2 class="govuk-heading-m">{{tabData.name}}</h2>
-    {{ tabData.content | safe }}
+    {{ tabData.content | markdown | safe }}
   {% endfor %}
 
 {% endif %}
 
-{% endblock %}
+{% endset %}

--- a/app/views/guidance/index.njk
+++ b/app/views/guidance/index.njk
@@ -32,7 +32,7 @@
       </li>
       <li>
       <li>
-        <a class="govuk-link" href="/guidance/registering-trainees-through-hesa">Registering trainees through HESA</a>
+        <a class="govuk-link" href="/guidance/registering-trainees-through-hesa">Register trainees through HESA (Higher Education Statistics Agency)</a>
       </li>
       <li>
         <a class="govuk-link" href="/guidance/bulk-add-new-by-csv">Adding new trainees by CSV</a>

--- a/app/views/guidance/manually-registering-trainees.njk
+++ b/app/views/guidance/manually-registering-trainees.njk
@@ -1,21 +1,13 @@
 {% extends "_templates/_guidance-page.njk" %}
 
-{% set pageHeading = 'Registering trainees manually in this service' %}
+{% set pageHeading = "Registering trainees manually in this service" %}
 
-{% block guidanceContent %}
-
-# Register trainees manually in this service
-
+{% set guidanceContent %}
 Training providers can register their trainees manually in the Register trainee teachers (Register) service by creating draft trainee records and adding the required data.
 
 To prepare for adding trainee records manually [check what data you need to provide](https://www.register-trainee-teachers.service.gov.uk/guidance/check-data).
 
 {% include "_includes/guidance/training-status-homepage.md" %}
-
-{% set detailsContent %}
-
-{% include "_includes/guidance/training-status-homepage.md" %}
-{% endset %}
 
 ## Get a teacher reference number (TRN)
 
@@ -33,16 +25,16 @@ Applications imported from Apply into Register will become draft trainee records
 
 On a trainee record from Apply you’ll see:
 
-* the course the trainee applied for
-* the trainee’s personal details
+- the course the trainee applied for
+- the trainee’s personal details
 
 ### What to do with draft records from Apply
 
 To register trainees that come from Apply, you’ll need to check if their data is correct and add any further data about their training. This can include:
 
-* checking their course is correct (if their course has changed, you can update this in Register)
-* fixing any mistakes that you know of
-* providing any further training data, such as if the trainee will get funding or who their lead or employing school will be
+- checking their course is correct (if their course has changed, you can update this in Register)
+- fixing any mistakes that you know of
+- providing any further training data, such as if the trainee will get funding or who their lead or employing school will be
 
 Note, once an application is imported into Register, any changes you make to the application in Apply (after it’s in ‘recruited’ status) will not show in Register. Changes to trainee data in Register will also not reflect in Apply. At the moment, our integration only works to bring applications into Register.
 
@@ -50,17 +42,7 @@ Note, once an application is imported into Register, any changes you make to the
 
 There are 3 ways to check trainee data in Register. Choose whichever one of the following that suits you:
 
-* Use the new ‘Reports’ section and export a CSV of your new trainees for the current academic year
-* Export a CSV of your trainees in the ‘Registered trainees’ section, using the ‘start year’ filter to select the current academic year
-* Check your trainees directly in the service one by one
-
-<!--
-{% include "_includes/guidance/placements.md" %}
-
-{% set detailsContent %}
-
-{% include "_includes/guidance/placements.md" %}
+- Use the new ‘Reports’ section and export a CSV of your new trainees for the current academic year
+- Export a CSV of your trainees in the ‘Registered trainees’ section, using the ‘start year’ filter to select the current academic year
+- Check your trainees directly in the service one by one
 {% endset %}
--->
-
-{% endblock %}

--- a/app/views/guidance/performance-profiles.njk
+++ b/app/views/guidance/performance-profiles.njk
@@ -1,26 +1,17 @@
 {% extends "_templates/_guidance-page.njk" %}
 
-
 {% set endYear = data.years.currentAcademicYear | academicYearToYear + 1 %}
 
 {% set performanceProfilesDate = endYear + "-1-31" %}
 
 {% if data.settings.signOffPeriods == "performanceProfiles" %}
-
-{% set pageHeading = 'Sign off your list of trainees from {{ data.years.previousAcademicYear }} for the performance profiles publication' %}
-
+  {% set pageHeading = "Sign off your list of trainees from " + data.years.previousAcademicYear + "for the performance profiles publication" %}
 {% else %}
-
-{% set pageHeading = 'Signing off your list of trainees for the performance profiles publication' %}
-
+  {% set pageHeading = "Signing off your list of trainees for the performance profiles publication" %}
 {% endif %}
 
-{% block guidanceContent %}
-
+{% set guidanceContent %}
 {% if data.settings.signOffPeriods == "performanceProfiles" %}
-
-# Sign off your list of trainees from {{ data.years.previousAcademicYear }} for the performance profiles publication
-
 You need to sign off your list of trainee teachers from the {{ data.years.previousAcademicYear }} academic year by {{ performanceProfilesDate | govukDate('YYYY-M-D') }} at 11:59pm.
 
 This is so that the data can be included in the annual initial teacher training performance profiles publication. This will be published on GOV.UK.
@@ -46,18 +37,18 @@ You need to fix any mistakes before you sign off the data. How you do this depen
 
 ### Providers of school centred initial teacher training (SCITTs)
 
-If the trainee is shown in this service as awarded or withdrawn, you should email [becomingateacher@digital.education.gov.uk](becomingateacher@digital.education.gov.uk?subject=Fix%20mistake%20in%202021%20to%202022%20data%20for%20performance%20profiles%20publication).
+If the trainee is shown in this service as awarded or withdrawn, you should email [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk?subject=Fix%20mistake%20in%202021%20to%202022%20data%20for%20performance%20profiles%20publication).
 
 If the trainee is shown in this service as actively training or deferred, you should make the change in this service.
 
 ### Higher education institutions (HEIs)
 
-If the trainee is shown in this service as awarded or withdrawn, you should email [becomingateacher@digital.education.gov.uk](becomingateacher@digital.education.gov.uk?subject=Fix%20mistake%20in%202021%20to%202022%20data%20for%20performance%20profiles%20publication).
+If the trainee is shown in this service as awarded or withdrawn, you should email [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk?subject=Fix%20mistake%20in%202021%20to%202022%20data%20for%20performance%20profiles%20publication).
 
 If the trainee is shown in this service as actively training or deferred, you should:
 
 - make the change through the Higher Education Statistics Agency (HESA) if the trainee was registered through HESA and is in the {{ data.years.currentAcademicYear }} initial teacher training (ITT) collection
-- email [becomingateacher@digital.education.gov.uk](becomingateacher@digital.education.gov.uk?subject=Fix%20mistake%20in%202021%20to%202022%20data%20for%20performance%20profiles%20publication) if the trainee was registered through HESA but is not in the {{ data.years.currentAcademicYear }} ITT collection
+- email [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk?subject=Fix%20mistake%20in%202021%20to%202022%20data%20for%20performance%20profiles%20publication) if the trainee was registered through HESA but is not in the {{ data.years.currentAcademicYear }} ITT collection
 - make the change in this service if the trainee was not registered through HESA
 
 ## Sign off your trainee data
@@ -71,8 +62,6 @@ Read the [ITT performance profiles methodology (opens in a new tab)](https://exp
 Some trainees will not be included in the ITT performance profiles publication. For example, trainees who withdrew within 90 days of the course start will not be included.
 
 {% else %}
-
-# Signing off your list of trainees for the performance profiles publication
 
 Each year you need to sign off your list of trainee teachers from the previous academic year. You’ll be told by email when you need to do this.
 
@@ -103,7 +92,5 @@ A senior person from your organisation will need to complete a form to sign off 
 Read the ITT performance profiles methodology (opens in a new tab) to find out how your trainee data will be used.
 
 Some trainees will not be included in the ITT performance profiles publication. For example, trainees who withdrew within 90 days of the course start will not be included.
-
 {% endif %}
-
-{% endblock %}
+{% endset %}

--- a/app/views/guidance/registering-trainees-through-hesa.njk
+++ b/app/views/guidance/registering-trainees-through-hesa.njk
@@ -1,11 +1,8 @@
 {% extends "_templates/_guidance-page.njk" %}
 
-{% set pageHeading = 'Registering trainees directly in this service' %}
+{% set pageHeading = "Register trainees through HESA (Higher Education Statistics Agency)" %}
 
-{% block guidanceContent %}
-
-# Register trainees through HESA (Higher Education Statistics Agency)
-
+{% set guidanceContent %}
 Training providers that use HESA can register their trainees by submitting data through the HESA data collection system.
 
 Your trainee data will then be imported into the Register trainee teachers service (Register).
@@ -16,23 +13,17 @@ You’ll be able to view or export trainee data, including your trainees’ teac
 
 {% include "_includes/guidance/training-status-homepage.md" %}
 
-{% set detailsContent %}
-
-{% include "_includes/guidance/training-status-homepage.md" %}
-{% endset %}
-
 ## Check data imported into Register from HESA
 
 You can check your trainee data once it has been imported into Register. At any time you can:
 
-* export a CSV file listing your trainees from the ‘Registered trainees’ section, using the ‘academic year’ or ‘start year’ filter to select the current academic year
-* check your trainees directly in the service one by one
+- export a CSV file listing your trainees from the ‘Registered trainees’ section, using the ‘academic year’ or ‘start year’ filter to select the current academic year
+- check your trainees directly in the service one by one
 
 In the CSV export from the ‘Registered trainees’ section, we’ve included a column called ‘hesa_updated_at’ which shows you the last time a record was updated through HESA. Use this column to check that all your new trainees have imported into Register from HESA.
 
 You can also export CSV files from the ‘Reports’ section when you need to sign off your:
 
-* new trainees for the census in October
-* trainee outcomes from the previous academic year for performance profiles in January
-
-{% endblock %}
+- new trainees for the census in October
+- trainee outcomes from the previous academic year for performance profiles in January
+{% endset %}

--- a/app/views/guidance/withdraw-defer-reinstate-or-recommend-a-trainee.njk
+++ b/app/views/guidance/withdraw-defer-reinstate-or-recommend-a-trainee.njk
@@ -1,11 +1,8 @@
 {% extends "_templates/_guidance-page.njk" %}
 
-{% set pageHeading = 'Withdraw, defer, reinstate or recommend a trainee for teaching standards' %}
+{% set pageHeading = "Withdraw, defer, reinstate or recommend a trainee for QTS or EYTS" %}
 
-{% block guidanceContent %}
-
-# Withdraw, defer, reinstate or recommend a trainee for QTS or EYTS
-
+{% set guidanceContent %}
 You must use Register trainee teachers (Register) to:
 
 - withdraw a trainee from teacher training
@@ -41,10 +38,9 @@ You should recommend a trainee for QTS or EYTS as soon as they meet the teaching
 
 You do not need to record in Register when a trainee got a PGCE or completed an undergraduate course. You just need to record when they met the standards for QTS or EYTS.
 
-You can sign into Register to recommend a trainee for QTS or EYTS from within their trainee record. You can also recommend multiple trainees at the same time. <a class="govuk-link" href="https://www.register-trainee-teachers.service.gov.uk/guidance/bulk-recommend-trainees">Find out how to bulk recommend trainees for QTS or EYTS</a>.
+You can sign into Register to recommend a trainee for QTS or EYTS from within their trainee record. You can also recommend multiple trainees at the same time. [Find out how to bulk recommend trainees for QTS or EYTS](https://www.register-trainee-teachers.service.gov.uk/guidance/bulk-recommend-trainees).
 
 After you recommend a trainee for QTS or EYTS, the Teaching Regulation Agency (TRA) will award them with teaching status within 3 working days.
 
 The DfE will later send an email to the trainees to tell them that their certificates are available to download from the Access your Teacher Qualifications service.
-
-{% endblock %}
+{% endset %}

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -60,7 +60,7 @@
 {% endblock %}
 
 {% block pageTitle %}
-  {{  pageTitle }}
+  {{ pageTitle }}
 {% endblock %}
 
 {% block header %}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,13 +2,10 @@
 const fs = require('fs')
 
 // NPM dependencies
-const getKeypath = require('keypather/get')
-const marked = require('marked')
 const path = require('path')
 const portScanner = require('portscanner')
 const inquirer = require('inquirer')
 const request = require('sync-request')
-const _ = require('lodash')
 
 // Local dependencies
 const config = require('../app/config.js')
@@ -188,18 +185,6 @@ exports.matchRoutes = function (req, res, next) {
   }
 
   renderPath(path, res, next)
-}
-
-// Try to match a request to a markdown file and render it
-exports.matchMdRoutes = function (req, res) {
-  const docsPath = '/../docs/documentation/'
-  if (fs.existsSync(path.join(__dirname, docsPath, req.params[0] + '.md'), 'utf8')) {
-    const doc = fs.readFileSync(path.join(__dirname, docsPath, req.params[0] + '.md'), 'utf8')
-    const html = marked(doc)
-    res.render('documentation_template', { document: html })
-    return true
-  }
-  return false
 }
 
 // Store data from POST body or GET query in session

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "express-writer": "0.0.4",
     "fancy-log": "^2.0.0",
     "govuk-frontend": "^5.5.0",
-    "govuk-markdown": "^0.8.0",
     "gulp": "^5.0.0",
     "gulp-nodemon": "^2.5.0",
     "gulp-sass": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "keypather": "^3.0.0",
     "lunr": "^2.3.9",
     "marked": "^15.0.3",
+    "marked-gfm-heading-id": "^4.1.1",
     "moment": "^2.27.0",
     "nunjucks": "^3.2.3",
     "nunjucks-markdown": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "dotenv": "^16.4.5",
     "express": "^4.17.1",
     "express-session": "^1.17.2",
-    "express-writer": "0.0.4",
     "fancy-log": "^2.0.0",
     "govuk-frontend": "^5.5.0",
     "gulp": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "gulp-sourcemaps": "^3.0.0",
     "inquirer": "^8.2.6",
     "js-yaml": "^4.1.0",
-    "keypather": "^3.0.0",
     "lunr": "^2.3.9",
     "marked": "^15.0.3",
     "marked-gfm-heading-id": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "marked-gfm-heading-id": "^4.1.1",
     "moment": "^2.27.0",
     "nunjucks": "^3.2.3",
-    "nunjucks-markdown": "^2.0.1",
     "pluralize": "^8.0.0",
     "portscanner": "^2.1.1",
     "require-dir": "^1.0.0",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
 // Core dependencies
-const fs = require('fs')
 const path = require('path')
 const url = require('url')
 
@@ -13,11 +12,6 @@ const sessionInCookie = require('client-sessions')
 const sessionInMemory = require('express-session')
 const cookieParser = require('cookie-parser')
 const compression = require('compression')
-
-// Register added
-const { marked } = require('marked')
-const GovukHTMLRenderer = require('govuk-markdown')
-const nunjucksMarkdown = require('nunjucks-markdown')
 
 // Run before other code to make sure variables from .env are available
 dotenv.config()
@@ -106,16 +100,6 @@ utils.addNunjucksFilters(nunjucksAppEnv)
 
 // Add Nunjucks functions (**Register trainee teachers addition**)
 utils.addNunjucksFunctions(nunjucksAppEnv)
-
-// Register added
-marked.setOptions({
-  renderer: new GovukHTMLRenderer(),
-  headerIds: true,
-  headingsStartWith: 'l',
-  smartypants: true
-})
-
-nunjucksMarkdown.register(nunjucksAppEnv, marked)
 // End Register added
 
 // Set views engine


### PR DESCRIPTION
This PR:

- adds `marked-gfm-heading-id` package
- removes `govuk-markdown`, `nunjucks-markdown` packages
- adds markdown styles
- removes unused markdown functions from `utils.js`
- removes markdown functions from `server.js`
- updates the guidance pages' markdown

This PR also removes unused packages: `express-writer` and `keypather`.