### PR TITLE
Content iterations for discussion

### DIFF
--- a/app/views/bulk-update/add-new/validation-overview.njk
+++ b/app/views/bulk-update/add-new/validation-overview.njk
@@ -7,57 +7,63 @@
 
 {% block content %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
 
-<!--      <div class="govuk-error-summary" data-module="govuk-error-summary">-->
-<!--        <div role="alert">-->
-<!--          <h2 class="govuk-error-summary__title">-->
-<!--            There is a problem-->
-<!--          </h2>-->
-<!--          <div class="govuk-error-summary__body">-->
-<!--            <ul class="govuk-list govuk-error-summary__list">-->
-<!--              <li>-->
-<!--                <a href="#">The CSV template structure has been changed</a>-->
-<!--              </li>-->
-<!--            </ul>-->
-<!--          </div>-->
-<!--        </div>-->
-<!--      </div>-->
+    <!--      <div class="govuk-error-summary" data-module="govuk-error-summary">-->
+    <!--        <div role="alert">-->
+    <!--          <h2 class="govuk-error-summary__title">-->
+    <!--            There is a problem-->
+    <!--          </h2>-->
+    <!--          <div class="govuk-error-summary__body">-->
+    <!--            <ul class="govuk-list govuk-error-summary__list">-->
+    <!--              <li>-->
+    <!--                <a href="#">The CSV template structure has been changed</a>-->
+    <!--              </li>-->
+    <!--            </ul>-->
+    <!--          </div>-->
+    <!--        </div>-->
+    <!--      </div>-->
 
-      <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">{{ data.signedInProviders | andSeparate }}</span>
-        {{ pageHeading }}
-      </h1>
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l">{{ data.signedInProviders | andSeparate }}</span>
+      {{ pageHeading }}
+    </h1>
 
-      <p class="govuk-body">
-        View the status of recently uploaded files containing new trainees.
-      </p>
+    <p class="govuk-body">
+      View the status of recently uploaded files containing new trainees.
+    </p>
 
-      <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
-        Validated
-      </h2>
-      <p class="govuk-body">You can now submit and add trainees to Register.</p>
+    <p class="govuk-body">Failed uploads will be removed after 30 days.</p>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
 
-      <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
-        Succeeded
-      </h2>
-      <p class="govuk-body">This lists all successful new trainee uploads for the current academic year.</p>
-
-      <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
-        Failed
-      </h2>
-      <p class="govuk-body">You need to review errors in the CSV file you uploaded. Failed uploads will be removed after 30 days.</p>
-
-      <table class="govuk-table">
-        <thead class="govuk-table__head">
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col"> Uploaded </th>
           <th class="govuk-table__header" scope="col"> Filename </th>
           <th class="govuk-table__header" scope="col"> Validation status </th>
         </tr>
-        </thead>
-        <tbody class="govuk-table__body">
+      </thead>
+      <tbody class="govuk-table__body">
+
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <a href="validation-in-progress.html">17 January 2025 at 4:24pm</a>
+          </td>
+          <td class="govuk-table__cell">
+            trainees_degree_5.csv
+          </td>
+          <td class="govuk-table__cell">
+            <strong class="govuk-tag govuk-tag--light-blue">
+              In progress
+            </strong>
+          </td>
+        </tr>
+
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
             <a href="fix-errors.html">22 January 2025 at 3:05pm</a>
@@ -71,6 +77,7 @@
             </strong>
           </td>
         </tr>
+
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
             <a href="validation-passed.html">19 January 2025 at 10:27am</a>
@@ -79,32 +86,29 @@
             trainees_5.csv
           </td>
           <td class="govuk-table__cell">
-            <strong class="govuk-tag govuk-tag--green">
-              Succeeded
+            <strong class="govuk-tag govuk-tag--yellow">
+              Ready to submit
             </strong>
           </td>
         </tr>
+
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
-            <a href="validation-in-progress.html">17 January 2025 at 4:24pm</a>
+            <a href="confirm-trainees-registered.html">17 January 2025 at 4:24pm</a>
           </td>
           <td class="govuk-table__cell">
             trainees_degree_5.csv
           </td>
           <td class="govuk-table__cell">
-            <strong class="govuk-tag govuk-tag--blue">
-              In progress
+            <strong class="govuk-tag govuk-tag--green">
+              Trainees registered
             </strong>
           </td>
         </tr>
-        </tbody>
-      </table>
-
-      <p class="govuk-body"><a href="/bulk-update/" class="govuk-link">Cancel reviewing uploads</a></p>
-
-    </div>
+      </tbody>
+    </table>
+    <p class="govuk-body"><a href="/bulk-update/" class="govuk-link">Cancel reviewing uploads</a></p>
   </div>
+</div>
 
 {% endblock %}
-
-


### PR DESCRIPTION
The latest design for discussion within the team. The main changes are as follows:

- Extend the table to full width to better accommodate potentially long file names and the new, longer tags.
- Altered the label names and colours. Split ‘Succeeded’ into ‘Ready to submit’ and 'Trainees registered' as there are now two states that need to be supported.
- Removed most of the introductory content, as the labels should not require specific descriptions. This will necessitate a rethink of content design.