### PR TITLE
Add Lead Partner to Early Years Undergraduate

### DIFF
--- a/app/data/training-route-data.js
+++ b/app/data/training-route-data.js
@@ -597,11 +597,13 @@ const baseRouteData = {
       'courseDetails',
       'personalDetails',
       'diversity',
+      'schools',
       // 'undergraduateQualification',
       'placement',
       'funding'
     ],
     fields: [
+      'leadPartner',
       'studyMode'
     ],
     qualifications: [


### PR DESCRIPTION
## Description

This pull request adds the `leadPartner` field to the early years undergraduate route in the project. The changes include updating the route data to include the `leadPartner` field and ensuring all related components are correctly imported and used.

## Changes

- Updated `app/data/training-route-data.js` to include the `leadPartner` field for Early Years Undergraduate route.