### PR TITLE
WIP - Integrate census sign off

### DIFF
--- a/app/views/_includes/summary-cards/census-sign-off.njk
+++ b/app/views/_includes/summary-cards/census-sign-off.njk
@@ -1,0 +1,58 @@
+{% set censusSignOffRows = [
+  {
+    key: {
+      text: "Provider name"
+    },
+    value: {
+      text: providerName or "Not provided"
+    },
+    actions: {
+      items: [
+        {
+          href: "./change" | addReferrer(referrer),
+          text: "Change",
+          visuallyHiddenText: "provider name"
+        }
+      ]
+    } if canAmend
+  },
+  {
+    key: {
+      text: "UKPRN"
+    },
+    value: {
+      text: record.temp.auditLogComment or "Not provided"
+    },
+    actions: {
+      items: [{
+        href: "./details" | addReferrer(referrer),
+        text: "Change",
+        visuallyHiddenText: "UKPRN"
+      }]
+    } if canAmend
+  },
+  {
+    key: {
+      text: "Approver name"
+    },
+    value: {
+      text: approverName or "Not provided"
+    },
+    actions: {
+      items: [{
+        href: "./details" | addReferrer(referrer),
+        text: "Change",
+        visuallyHiddenText: "Approver name"
+      }]
+    } if canAmend
+  }
+] %}
+
+{{ govukSummaryList({
+  card: {
+    title: {
+      text: "Census sign off information"
+    }
+  },
+  rows: censusSignOffRows
+}) }}

--- a/app/views/_includes/summary-cards/performance-profiles.njk
+++ b/app/views/_includes/summary-cards/performance-profiles.njk
@@ -42,7 +42,7 @@
       items: [{
         href: "./details" | addReferrer(referrer),
         text: "Change",
-        visuallyHiddenText: "Zendesk ticket URL"
+        visuallyHiddenText: "Approver name"
       }]
     } if canAmend
   }

--- a/app/views/census-sign-off/confirmation.njk
+++ b/app/views/census-sign-off/confirmation.njk
@@ -7,7 +7,7 @@
 {% set traineesThatCanBeUpdated = filteredRecords | filterByCanBulkUpdate %}
 
 {% set traineesThatCanBeRecommended = filteredRecords | filterByReadyToRecommend %}
-{% set pageHeading = "Performance profile submitted" %}
+{% set pageHeading = "Census sign off submitted" %}
 
 {% block content %}
 
@@ -18,15 +18,13 @@
         classes: "govuk-!-margin-bottom-7"
       }) }}
 
-      <h1 class="govuk-body">Performance profile sign off completed.</h1>
+      <h1 class="govuk-body">Census sign off completed.</h1>
 
       <p class="govuk-body">We have sent you and the other Register account users a confirmation email.</p>
 
       <h2 class="govuk-heading-s">What happens next</h2>
 
-      <p class="govuk-body">We’ll include this trainee data in the next performance profiles publication on GOV.UK.</p>
-
-      <p class="govuk-body">If you have any questions email <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Performance%20profile%20sign%20off">becomingateacher@digital.education.gov.uk</a></p>
+      <p class="govuk-body">If you have any questions email <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Census%20sign%20off">becomingateacher@digital.education.gov.uk</a></p>
 
 
     </div>

--- a/app/views/census-sign-off/confirmation.njk
+++ b/app/views/census-sign-off/confirmation.njk
@@ -1,0 +1,35 @@
+{% extends "_templates/_page.njk" %}
+
+{% set navActive = 'reports' %}
+{% set backLink = 'false' %}
+
+{% set filteredRecords = data.records | filterRecords(data) %}
+{% set traineesThatCanBeUpdated = filteredRecords | filterByCanBulkUpdate %}
+
+{% set traineesThatCanBeRecommended = filteredRecords | filterByReadyToRecommend %}
+{% set pageHeading = "Performance profile submitted" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      {{ govukPanel({
+        titleText: pageHeading,
+        classes: "govuk-!-margin-bottom-7"
+      }) }}
+
+      <h1 class="govuk-body">Performance profile sign off completed.</h1>
+
+      <p class="govuk-body">We have sent you and the other Register account users a confirmation email.</p>
+
+      <h2 class="govuk-heading-s">What happens next</h2>
+
+      <p class="govuk-body">We’ll include this trainee data in the next performance profiles publication on GOV.UK.</p>
+
+      <p class="govuk-body">If you have any questions email <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Performance%20profile%20sign%20off">becomingateacher@digital.education.gov.uk</a></p>
+
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/census-sign-off/form.njk
+++ b/app/views/census-sign-off/form.njk
@@ -1,0 +1,59 @@
+{% extends "_templates/_page.njk" %}
+
+{% set formAction = "./performance-profile/confirm" | addReferrer(referrer) %}
+{% set previousAcademicYear = data.years.previousAcademicYear %}
+{% set academicYear = data.years.currentAcademicYear %}
+{% set academicYearShort = data.years.currentAcademicYear | academicYearToYear %}
+{% set nextAcademicYearShort = data.years.nextAcademicYear | academicYearToYear %}
+
+
+{% set providerName = data.settings.userActiveProvider %}
+{% set ukprn = data.provider.ukprn %}
+{% set approverName = "Jill Renner" %}
+
+{% set pageHeading %}
+  Performance profile sign off
+{% endset %}
+
+{% set backLink = '/reports' %}
+{% set backText = "Reports" %}
+{% set navActive = 'reports' %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+          <h1 class="govuk-heading-l">ITT performance profile sign off for the {{ previousAcademicYear }} academic year</h1>
+
+          <p class="govuk-body">Once you've checked your data is correct, you can sign off on behalf of your organisation.</p>
+
+        {% include "_includes/summary-cards/performance-profiles.njk" %}
+
+        {{ govukCheckboxes({
+        name: "performance-profile-signed-off",
+        fieldset: {
+        legend: {
+        text: "Confirm you have checked the trainee data is correct in Register, and you’re signing it off.",
+        isPageHeading: false,
+        classes: "govuk-fieldset__legend--s"
+        }
+        },
+        items: [
+        {
+        value: "performance-profile-signed-off",
+        text: "Yes, the trainee data is correct to the best of my knowledge"
+        }
+        ]
+        }) }}
+
+        <div class="govuk-form-group">
+          {{ govukButton({
+          text: "Sign off performance profile",
+          href: "confirmation"
+          }) }}
+        </div>
+
+
+      </div>
+    </div>
+{% endblock %}

--- a/app/views/census-sign-off/form.njk
+++ b/app/views/census-sign-off/form.njk
@@ -1,6 +1,6 @@
 {% extends "_templates/_page.njk" %}
 
-{% set formAction = "./performance-profile/confirm" | addReferrer(referrer) %}
+{% set formAction = "./census-sign-off/confirm" | addReferrer(referrer) %}
 {% set previousAcademicYear = data.years.previousAcademicYear %}
 {% set academicYear = data.years.currentAcademicYear %}
 {% set academicYearShort = data.years.currentAcademicYear | academicYearToYear %}
@@ -12,7 +12,7 @@
 {% set approverName = "Jill Renner" %}
 
 {% set pageHeading %}
-  Performance profile sign off
+  census sign off
 {% endset %}
 
 {% set backLink = '/reports' %}
@@ -23,24 +23,24 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
-          <h1 class="govuk-heading-l">ITT performance profile sign off for the {{ previousAcademicYear }} academic year</h1>
+          <h1 class="govuk-heading-l">Sign off your organisation’s new trainee data for the {{ previousAcademicYear }} academic year</h1>
 
           <p class="govuk-body">Once you've checked your data is correct, you can sign off on behalf of your organisation.</p>
 
-        {% include "_includes/summary-cards/performance-profiles.njk" %}
+        {% include "_includes/summary-cards/census-sign-off.njk" %}
 
         {{ govukCheckboxes({
-        name: "performance-profile-signed-off",
+        name: "census-sign-off",
         fieldset: {
         legend: {
-        text: "Confirm you have checked the trainee data is correct in Register, and you’re signing it off.",
+        text: "Confirm your organisation’s new trainee data is in Register, you’ve checked it’s correct and you’re signing it off",
         isPageHeading: false,
         classes: "govuk-fieldset__legend--s"
         }
         },
         items: [
         {
-        value: "performance-profile-signed-off",
+        value: "census-signed-off",
         text: "Yes, the trainee data is correct to the best of my knowledge"
         }
         ]
@@ -48,7 +48,7 @@
 
         <div class="govuk-form-group">
           {{ govukButton({
-          text: "Sign off performance profile",
+          text: "Sign off census",
           href: "confirmation"
           }) }}
         </div>

--- a/app/views/census-sign-off/index.njk
+++ b/app/views/census-sign-off/index.njk
@@ -1,6 +1,6 @@
 {% extends "_templates/_page.njk" %}
 
-{% set formAction = "./census-sign-off/confirm" | addReferrer(referrer) %}
+{% set formAction = "./census-sign-off/form" | addReferrer(referrer) %}
 {% set previousAcademicYear = data.years.previousAcademicYear %}
 {% set academicYear = data.years.currentAcademicYear %}
 {% set academicYearShort = data.years.currentAcademicYear | academicYearToYear %}
@@ -17,8 +17,8 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
 
-
-      <h1 class="govuk-heading-l">ITT census sign-off for the 2023 to 2024 academic year</h1>
+      <h1 class="govuk-heading-l" style="color:red">Existing MS Forms content</h1>
+      <h1 class="govuk-heading-l">ITT census sign-off for the {{ previousAcademicYear }} academic year</h1>
 
       <p class="govuk-body">Use this form to sign off your new trainee data. Your organisation must sign off your new trainee data on or before 31 October 2023 so it will be included in the annual initial teacher training (ITT) census publication.</p>
 
@@ -35,7 +35,7 @@
 
       <p class="govuk-body">Once you submit this form, we’ll update our records to show your organisation has signed off your new trainee data and it’s in Register.</p>
 
-      <p class="govuk-body">If you have any questions or issues that prevent you from signing off, email becomingateacher@education.gov.uk with email subject line: 2023 to 2024 signing off new trainee data.</p>
+      <p class="govuk-body">If you have any questions or issues that prevent you from signing off, email <a href="mailto:becomingateacher@education.gov.uk?subject={{ previousAcademicYear }} signing off new trainee data">becomingateacher@education.gov.uk</a> with email subject line: {{ previousAcademicYear }} signing off new trainee data.</p>
 
       <h2 class="govuk-heading-m">Who should sign off your data</h2>
 
@@ -108,12 +108,12 @@
       }) }}
 
 
-        <h4 class="govuk-heading-m">Signing off your trainee data</h4>
+        <h4 class="govuk-heading-m">Sign off your new trainee data</h4>
         <p class="govuk-body">If you have checked your data.</p>
 
         <div class="govuk-form-group">
           {{ govukButton({
-          text: "Continue to performance profile sign off",
+          text: "Continue to census sign off",
           href: "form"
           }) }}
         </div>

--- a/app/views/census-sign-off/index.njk
+++ b/app/views/census-sign-off/index.njk
@@ -43,10 +43,69 @@
 
 
 
+      <h1 class="govuk-heading-l" style="color:red">Previous variation</h1>
+      <h1 class="govuk-heading-l">{{pageHeading}}</h1>
 
+      <p class="govuk-body">
+        Use this export to see your trainee data for the initial teacher training (ITT) census.
+      </p>
 
+      <p class="govuk-body">
+        The ITT census is put together using the <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology" class="govuk-link">Initial Teacher Training Census methodology</a>.
+      </p>
 
+      <h2 class="govuk-heading-m">
+        About this export
+      </h2>
 
+      <p class="govuk-body">
+        This export includes trainees that are likely to be included in the {{ academicYear }} ITT census. The ITT census counts trainees registered on a course on the second Wednesday of October every academic year, this is sometimes called the ‘census date’.
+      </p>
+
+      <p class="govuk-body">The census date for the {{ academicYear }} academic year is Wednesday 12 October {{academicYearShort}}.</p>
+
+      <p class="govuk-body">This export will include trainees:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          that are registered (so their records are not drafts in Register)
+        </li>
+        <li>
+          on their first year of training
+        </li>
+        <li>
+          on ITT courses starting from 1 August {{ academicYearShort }} and the census date
+        </li>
+        <li>
+          that started their training on or before the census date
+        </li>
+        <li>
+          on courses leading to qualified teacher status (QTS)
+        </li>
+      </ul>
+
+      <p class="govuk-body">This export will not include trainees on the Assessment only route or trainees who started training but then withdrew before the census date.
+  .</p>
+
+      <h2 class="govuk-heading-m">How this export will be different from the ITT census</h2>
+
+      <p class="govuk-body">
+        All trainees that should be included in the ITT census will be in this export, but there might be a small number of extra trainees that would not normally be included. This is because Register currently does not have a way to exclude them. Trainees who could be in this export are:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          trainees without a start date because we cannot know if a trainee started their course on or before the census date without a start date
+        </li>
+        <li>
+          trainees that are self funded (not eligible for UK financial support and do not have a DfE allocated place) — the ITT census excludes these trainees.
+        </li>
+      </ul>
+
+      <input name="successFlash" type="hidden" value="Export successfully downloaded">
+
+      {{ govukButton({
+        "text": "Export trainee records (CSV)"
+      }) }}
 
 
         <h4 class="govuk-heading-m">Signing off your trainee data</h4>

--- a/app/views/census-sign-off/index.njk
+++ b/app/views/census-sign-off/index.njk
@@ -51,39 +51,6 @@
 
 
 
-
-
-
-          <h1 class="govuk-heading-l">Export trainee data for the {{ previousAcademicYear }} performance profile sign off</h1>
-
-          <p class="govuk-body">Signing off your list of trainees for the performance profiles publication deadline is 28 February {{ nextAcademicYearSimple }}.</p>
-
-          <p class="govuk-body">As an accredited provider, you need to sign off your teacher trainee data from the previous {{ previousAcademicYear }} academic year.</p>
-
-          <p class="govuk-body">The data you sign off will be included in the annual initial teacher training performance profiles publication. This will be published on GOV.UK.</p>
-
-          <h2 class="govuk-heading-m">Finding your trainee data</h2>
-
-          <p class="govuk-body">You need to check all registered trainees who studied in the previous {{ previousAcademicYear }} academic year.</p>
-
-        <p class="govuk-body"><a class="govuk-link" href="#">Export {{ previousAcademicYear }} trainee data (237 trainees)</a>.</p>
-
-          <h4 class="govuk-heading-m">Checking your trainee data</h4>
-
-        <p class="govuk-body">You’ll need to check that all your trainees from the {{ previousAcademicYear }} academic year are listed. For each trainee you’ll need to check:</p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <li>course details</li>
-          <li>status</li>
-          <li>the date they were awarded qualified teacher status (QTS) or early years teacher status (EYTS), or deferred or withdrew from the course - unless they’re still studying</li>
-          <li>2 placements for trainees that were QTS awarded</li>
-        </ul>
-
-        <h4 class="govuk-heading-m">Fixing mistakes in your trainee data</h4>
-        <p class="govuk-body">You’ll need to fix any mistakes before you sign off the data.</p>
-
-        <p class="govuk-body">Find out more on <a class="govuk-link" href="https://www.register-trainee-teachers.service.gov.uk/guidance/census-sign-offs">Signing off your list of trainees for the performance profiles publication</a> and <a class="govuk-link" href="https://www.register-trainee-teachers.service.gov.uk/guidance/manage-placements">managing your trainee placement data</a>.</p>
-
         <h4 class="govuk-heading-m">Signing off your trainee data</h4>
         <p class="govuk-body">If you have checked your data.</p>
 

--- a/app/views/census-sign-off/index.njk
+++ b/app/views/census-sign-off/index.njk
@@ -1,0 +1,99 @@
+{% extends "_templates/_page.njk" %}
+
+{% set formAction = "./census-sign-off/confirm" | addReferrer(referrer) %}
+{% set previousAcademicYear = data.years.previousAcademicYear %}
+{% set academicYear = data.years.currentAcademicYear %}
+{% set academicYearShort = data.years.currentAcademicYear | academicYearToYear %}
+{% set nextAcademicYearSimple = data.years.nextAcademicYearSimple %}
+
+{% set pageHeading %}
+  Performance profile sign off
+{% endset %}
+
+{% set backLink = '/reports' %}
+{% set backText = "Reports" %}
+{% set navActive = 'reports' %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+
+
+      <h1 class="govuk-heading-l">ITT census sign-off for the 2023 to 2024 academic year</h1>
+
+      <p class="govuk-body">Use this form to sign off your new trainee data. Your organisation must sign off your new trainee data on or before 31 October 2023 so it will be included in the annual initial teacher training (ITT) census publication.</p>
+
+      <p class="govuk-body">By signing off your data, you’re agreeing that:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>you’ve registered all your new trainees and their data is in the Register service</li>
+        <li>you’ve checked your new trainee data is correct and there are no known mistakes</li>
+      </ul>
+
+      <p class="govuk-body">We ask you to do this because it's important we have accurate data to use for the ITT census publication and to inform policy.</p>
+
+      <p class="govuk-body">If you make updates to your data after 31 October 2023, these may not be included in the ITT census publication.</p>
+
+      <p class="govuk-body">Once you submit this form, we’ll update our records to show your organisation has signed off your new trainee data and it’s in Register.</p>
+
+      <p class="govuk-body">If you have any questions or issues that prevent you from signing off, email becomingateacher@education.gov.uk with email subject line: 2023 to 2024 signing off new trainee data.</p>
+
+      <h2 class="govuk-heading-m">Who should sign off your data</h2>
+
+      <p class="govuk-body">A senior person from your organisation must sign off your data. This should be a different person to who submitted the data.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+          <h1 class="govuk-heading-l">Export trainee data for the {{ previousAcademicYear }} performance profile sign off</h1>
+
+          <p class="govuk-body">Signing off your list of trainees for the performance profiles publication deadline is 28 February {{ nextAcademicYearSimple }}.</p>
+
+          <p class="govuk-body">As an accredited provider, you need to sign off your teacher trainee data from the previous {{ previousAcademicYear }} academic year.</p>
+
+          <p class="govuk-body">The data you sign off will be included in the annual initial teacher training performance profiles publication. This will be published on GOV.UK.</p>
+
+          <h2 class="govuk-heading-m">Finding your trainee data</h2>
+
+          <p class="govuk-body">You need to check all registered trainees who studied in the previous {{ previousAcademicYear }} academic year.</p>
+
+        <p class="govuk-body"><a class="govuk-link" href="#">Export {{ previousAcademicYear }} trainee data (237 trainees)</a>.</p>
+
+          <h4 class="govuk-heading-m">Checking your trainee data</h4>
+
+        <p class="govuk-body">You’ll need to check that all your trainees from the {{ previousAcademicYear }} academic year are listed. For each trainee you’ll need to check:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>course details</li>
+          <li>status</li>
+          <li>the date they were awarded qualified teacher status (QTS) or early years teacher status (EYTS), or deferred or withdrew from the course - unless they’re still studying</li>
+          <li>2 placements for trainees that were QTS awarded</li>
+        </ul>
+
+        <h4 class="govuk-heading-m">Fixing mistakes in your trainee data</h4>
+        <p class="govuk-body">You’ll need to fix any mistakes before you sign off the data.</p>
+
+        <p class="govuk-body">Find out more on <a class="govuk-link" href="https://www.register-trainee-teachers.service.gov.uk/guidance/census-sign-offs">Signing off your list of trainees for the performance profiles publication</a> and <a class="govuk-link" href="https://www.register-trainee-teachers.service.gov.uk/guidance/manage-placements">managing your trainee placement data</a>.</p>
+
+        <h4 class="govuk-heading-m">Signing off your trainee data</h4>
+        <p class="govuk-body">If you have checked your data.</p>
+
+        <div class="govuk-form-group">
+          {{ govukButton({
+          text: "Continue to performance profile sign off",
+          href: "form"
+          }) }}
+        </div>
+
+      </div>
+    </div>
+{% endblock %}

--- a/app/views/census-sign-off/index.njk
+++ b/app/views/census-sign-off/index.njk
@@ -6,9 +6,7 @@
 {% set academicYearShort = data.years.currentAcademicYear | academicYearToYear %}
 {% set nextAcademicYearSimple = data.years.nextAcademicYearSimple %}
 
-{% set pageHeading %}
-  Performance profile sign off
-{% endset %}
+{% set pageHeading = 'New trainees for the ' + academicYear + ' academic year' %}
 
 {% set backLink = '/reports' %}
 {% set backText = "Reports" %}

--- a/app/views/reports/index.njk
+++ b/app/views/reports/index.njk
@@ -21,8 +21,7 @@
 
     <!-- Dummy text prior to content designer supplying it -->
     <h2 class="govuk-heading-m">Census sign off</h2>
-    <p class="govuk-body"><a class="govuk-link" href="reports/census">New trainees for the {{ previousAcademicYear }} academic year</a> - for performance profiles sign off</p>
-    <p class="govuk-body">Trainees who studied in the 2023 to 2024 academic year - will be available for performance profiles sign off.</p>
+    <p class="govuk-body"><a class="govuk-link" href="/census-sign-off/">Sign off your new trainee data for the {{ previousAcademicYear }} academic year</a></p>
 
     <h2 class="govuk-heading-m">Performance profiles</h2>
 


### PR DESCRIPTION
The census sign-off process currently involves emailing providers a link to a Microsoft Form for approval.

We are therefore looking to move the census sign-off process into Register, as we have previously done with performance profiles.

This is an initial draft utilising the same process as the performance profile sign-off, incorporating some existing content and elements from the MS Form process that require editing.